### PR TITLE
[[ Misc ]] Ignore environment_log.txt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ xcuserdata/
 #################
 _build/
 _cache/
+environment_log.txt


### PR DESCRIPTION
This makes it slightly easier to run the IDE from the working tree
on Linux.
