### PR TITLE
[[ Bug 14770 ]] Layer property definition has phantom space

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
@@ -77,7 +77,7 @@ ink	Ink	Colors	com.livecode.pi.enum	true	false		srcCopy	blendClear,blendSrc,blen
 innerGlow	Inner Glow	Effects	com.livecode.pi.graphicEffect	true	false			
 innerShadow	Inner Shadow	Effects	com.livecode.pi.graphicEffect	true	false			
 label	Label	Basic	com.livecode.pi.string	true	false			
-layer 	Layer	Position	com.livecode.pi.number	true	false			
+layer	Layer	Position	com.livecode.pi.number	true	false		no_default
 layerMode	Layer Mode	Basic	com.livecode.pi.enum	true	false		Static	Static,Dynamic,Scrolling
 left	Left	Position	com.livecode.pi.number	true	false		no_default	
 lineInc	Scroll distance on arrow click	Basic	com.livecode.pi.number	true	false		512	


### PR DESCRIPTION
[[ Bug 14660 ]] Layer property should have default 'no_default'
