### PR TITLE
[[ Bug 14759 ]] Tool Palette: clicking "+" in header does nothing

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1353,7 +1353,6 @@ on revIDEMessageSend pMessage, pEffectedTarget
             dispatch "idePreferenceChanged" to tObjectID with item 2 of pMessage
             break
          case "ideFindMoreWidgets"
-            answer tObjectID
             dispatch pMessage to tObjectID with pEffectedTarget
             break
          case "ideNewStack"
@@ -2335,7 +2334,10 @@ on revIDEDownloadFinished pURL
 end revIDEDownloadFinished
 
 on revIDEFindMoreWidgets
+   lock screen
+   revIDEOpenPalette "extension manager"
    revIDEMessageSend "ideFindMoreWidgets"
+   unlock screen
 end revIDEFindMoreWidgets
 
 on revIDECreateObject pObjectTypeID, pTarget, pLoc  

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -109,7 +109,7 @@ on ideToolChanged
          end if
       end if
    end repeat
-end ideToolChanged
+end ideToolChanged 
 
 on framePreferenceSelected pPreference, pValue
    switch pPreference

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -120,9 +120,12 @@ on framePreferenceSelected pPreference, pValue
       case "revTools_show"
          local tCurrentPreferenceValue, tPreferencePosition
          put revIDEGetPreference("revTools_show") into tCurrentPreferenceValue
-         put itemoffset(pValue, tCurrentPreferenceValue) into tPreferencePosition
-         if tPreferencePosition > 0 and item tPreferencePosition of tCurrentPreferenceValue is pValue then
-            delete item tPreferencePosition of tCurrentPreferenceValue
+         if pValue is among the items of tCurrentPreferenceValue then
+            repeat with x = the number of items of tCurrentPreferenceValue down to 1
+               if item x of tCurrentPreferenceValue is pValue then
+                  delete item x of tCurrentPreferenceValue
+               end if
+            end repeat
          else
             put "," & pValue after tCurrentPreferenceValue
          end if


### PR DESCRIPTION
revIDELibrary was sending the appropriate message to get the "extension manager" to move to the "get more extensions" tab. However, this only worked when the extension manager stack was open. So adding a call to revIDEOpenPalette ensures that the stack is open and able to receive the messages. 

I was able to test in part. The extension manager opens but because CEF doesn't build I'm not able to see if it works right through to completion.
