### PR TITLE
[[ bug 14634 ]] can't open livecodescript files from file>open menu

### DIFF
--- a/Toolset/libraries/revcommonlibrary.livecodescript
+++ b/Toolset/libraries/revcommonlibrary.livecodescript
@@ -1385,7 +1385,7 @@ end revAnswerFile
 function revAnswerFiles pType, pPrompt
   switch pType
   case "stack"
-    answer files pPrompt with type "LiveCode Stacks|livecode,rev,mc|RSTK,MSTK" or type "All Files|"
+    answer files pPrompt with type "LiveCode Stacks|livecode,rev,mc,livecodescript|RSTK,MSTK" or type "All Files|"
     break
   case "image"
     answer files pPrompt with type "All Picture Files|png,gif,jpg,jpeg,bmp,pct,xbm,xpm,xwd,pbm,ppm,pgm" or type "Portable Network Graphics|png" or type "Joint Photographics Experts Group|jpg,jpeg" or type "Graphics Interchange Format|gif" or type "Windows Bitmap|bmp" or type "Unix Formats|xbm,xpm,xwd,pbm,ppm,pgm" or type "Macintosh PICT - displays on MacOS only|pct" or type "All Files|"


### PR DESCRIPTION
I've update the file chooser to allow the selected of "livecodescript" extension.

A script only is invisible by default so opening a livecodescript file appears to do nothing. I'm not sure if this is the correct behavior but making it visible doesn't seem correct. Only expert users will use script only's at this stage so would be able to edit the script via the message box. If there is a suggestion of a different behavior very happy to discuss and implement a fuller solution that is clearer for newer users.
