### PR TITLE
[[ Bug 14572 ]] Don't 'install' packaged extensions when running from dev environment

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -525,12 +525,8 @@ component Documentation
 		file ide:Documentation/html_viewer/resources/data/guide/built_guide.js as resources/data/guide/built_guide.js
 
 component Examples
-	into [[ToolsFolder]]/Examples place
-		file ide:examples/basic-button/main.mlc as basic-button/main.mlc
-		file ide:examples/canvas/main.mlc as canvas/main.mlc
-		file ide:examples/clock/icon.png as clock/icon.png
-		file ide:examples/clock/icon@extra-high.png as clock/icon@extra-high.png
-		file ide:examples/clock/main.mlc as clock/main.mlc
+	into [[ToolsFolder]]/extensions place
+		rfolder macosx:packaged_extensions
 
 component Toolchain.MacOSX
 	into [[ToolsFolder]]/Toolchain place

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -630,23 +630,6 @@ end __extensionModulePaths
 # Returns: List of the packages that are in the directory but not installed
 function __extensionPackagePaths
    local tPaths
-   
-   if not revEnvironmentIsInstalled() then
-      local tPackagesFolder
-      put revEnvironmentBinariesPath() & slash & "packaged_extensions" into tPackagesFolder
-      if there is a folder tPackagesFolder then
-         set the defaultFolder to tPackagesFolder
-         repeat for each line tPackage in the files
-            if not tPackage ends with ".lce" then next repeat
-            if tPaths is empty then
-               put tPackagesFolder & slash & tPackage into tPaths
-            else
-               put return & tPackagesFolder & slash & tPackage after tPaths
-            end if
-         end repeat
-      end if
-   end if
-   
    return tPaths
 end __extensionPackagePaths
 
@@ -772,7 +755,12 @@ function __extensionManifestValueFromFile pExtensionID, pProperty
 end __extensionManifestValueFromFile
 
 private function __extensionFolders
-   return revIDESpecialFolderPath("user extensions") & return & revIDESpecialFolderPath("extensions")
+   local tFolders
+   put revIDESpecialFolderPath("user extensions") & return & revIDESpecialFolderPath("extensions") into tFolders
+   if not revEnvironmentIsInstalled() then
+      put return & revEnvironmentBinariesPath() & slash & "packaged_extensions" after tFolders
+   end if
+   return tFolders
 end __extensionFolders
 
 # Returns a value from the manifest


### PR DESCRIPTION
Just find them in the repo path. This speeds up startup, and prevents copying of packaged extensions to the my livecode folder.
