### PR TITLE
[[ Docs Integration ]] A number of changes related to integrating docs.

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1012,9 +1012,8 @@ command revInternal__InitialiseLibraries
    end try 	 	
    	    	 	
    try 	 	
-      insert script of stack "revidedocumentationlibrary" into back 	 	
-      revInternal__LoadLibrary "revIDELibrary.8"	
-      	 		 	
+      revInternal__LoadLibrary "revidedocumentationlibrary"	
+      revInternal__LoadLibrary "revIDELibrary.8"	 
       insert script of stack "revidemessagehandler" into front 	 	
    catch tError 	 	
       answer "Error loading main IDE" & return & tError 	 	

--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -109,6 +109,7 @@ on openStack
    revInternal__Log "Leave", "Open Stack"
 end openStack
 
+local sSplashStartTime
 on revInternal__openStack
    revInternal__Log "Enter", "revInternal__openStack"
    
@@ -328,8 +329,6 @@ local sOldSupportPath
 local sBinariesPath
 -- MW-2013-06-10: [[ CloneAndRun ]] This is the path containing the root of the git repository.
 local sRepositoryPath
-
-local sSplashStartTime
 
 //EJB
 local sOverrideRuntimePath, sTestEnvironment

--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -30,13 +30,6 @@ private on __revIDEDeveloperCompilationError pError, pFile
    revIDEMessageSend "ideExtensionLog", "Error:" && pError
 end __revIDEDeveloperCompilationError
 
-private function __revIDEDeveloperLastModifiedTimeOfFile pFolder, pFile
-   local tDetailedFiles
-   set the defaultFolder to pFolder
-   put the detailed files into tDetailedFiles
-   return item 5 of line lineOffset(pFile, tDetailedFiles) of tDetailedFiles
-end __revIDEDeveloperLastModifiedTimeOfFile
-
 private function __revIDEDeveloperExtensionShouldRecompile pFolder, pFile
    # To avoid excessive recompilation, test to see if the compiled module exists and is up to date.
    
@@ -47,8 +40,8 @@ private function __revIDEDeveloperExtensionShouldRecompile pFolder, pFile
    
    # Check timestamps to see if compiled module is out of date.
    local tLastCompiled, tLastModified
-   put __revIDEDeveloperLastModifiedTimeOfFile(pFolder, "module.lcm") into tLastCompiled
-   put __revIDEDeveloperLastModifiedTimeOfFile(pFolder, pFile) into tLastModified
+   put revIDELastModifiedTimeOfFile(pFolder, "module.lcm") into tLastCompiled
+   put revIDELastModifiedTimeOfFile(pFolder, pFile) into tLastModified
    
    return (tLastCompiled is empty or tLastModified > tLastCompiled)
 end __revIDEDeveloperExtensionShouldRecompile
@@ -183,8 +176,8 @@ private function __revIDEDeveloperExtensionFetchFolderDetails pFolder, pFile
    
    # Check timestamps to see if API  is out of date.
    local tLastGenerated, tLastModified
-   put __revIDEDeveloperLastModifiedTimeOfFile(pFolder, "api.lcdoc") into tLastGenerated
-   put __revIDEDeveloperLastModifiedTimeOfFile(pFolder, pFile) into tLastModified
+   put revIDELastModifiedTimeOfFile(pFolder, "api.lcdoc") into tLastGenerated
+   put revIDELastModifiedTimeOfFile(pFolder, pFile) into tLastModified
    local tAPI
    if tLastGenerated is empty or tLastModified > tLastGenerated then
       put revDocsGenerateDocsFileFromModularFile(pFolder & slash & pFile) into tAPI 

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -95,8 +95,17 @@ command generateDistributedGuide
 end generateDistributedGuide
 
 command generateDistributedAPI
-   local tList
-   put "LiveCode Script,/Users/alilloyd/Documents/GitHub/livecode-docs,dictionary" into tList
+   if revEnvironmentIsInstalled() then
+      exit generateDistributedAPI
+   end if
+   
+   local tList, tDictionaryFolder
+   put revEnvironmentRepositoryPath() & "/../livecode-docs" into tDictionaryFolder
+   
+   if there is not a folder tDictionaryFolder then
+      answer "No dictionary data found at" && tDictionaryFolder
+   end if
+   put "LiveCode Script," & tDictionaryFolder & ",dictionary" into tList
    
    local tLibrariesA, tCount
    put 1 into tCount

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -197,35 +197,37 @@ end revDocsGenerateDocsFilesFromBuiltIn
 #
 ##################################################
 
-private function revDocsGetAPIData
+function revDocsGetAPIData
    local tData
    
    local tAPIPath
    put revIDESpecialFolderPath("API") into tAPIPath
    put url ("binfile:" & tAPIPath & slash & "distributed_API.js") into tData
    
-   local tExtensionAPI
-   # Go through the extensions folder and add all the APIs to the JSON
-   local tExtensionsFolder
-   repeat for each item tItem in "extensions,user extensions"
-      put revIDESpecialFolderPath(tItem) into tExtensionsFolder
-      set the defaultfolder to tExtensionsFolder
-      repeat for each line tFolder in the folders
-         if tFolder is ".." then next repeat
-         
-         if there is a file (tFolder & "api.js") then
-            put url ("binfile:" & tExtensionsFolder & slash & tFolder & slash & "api.js") into tExtensionAPI
-         else if there is a file (tFolder & "api.lcdoc") then
-            local tLcdoc
-            put revDocsFormatDocFileAsJSON(tExtensionsFolder & slash & tFolder & slash & "api.lcdoc") into tExtensionAPI
-            put tExtensionAPI into url ("binfile:" & tExtensionsFolder & slash & tFolder & slash & "api.js") 
-         end if
-         
-         if tExtensionAPI is not empty then
-            put comma & tExtensionAPI after tData
-         end if
-         
-      end repeat
+   local tExtensionDocsDataA
+   put revIDEExtensionDocsData() into tExtensionDocsDataA
+   
+   local tFolder
+   repeat for each element tExtensionData in tExtensionDocsDataA
+      local tExtensionAPI
+      put tExtensionData["folder"] into tFolder
+      if there is a not file (tFolder & slash & "api.lcdoc")  then next repeat
+      
+      # Check if the .js is out of date
+      local tLastModified, tLastGenerated
+      put revIDELastModifiedTimeOfFile(tFolder, "api.lcdoc") into tLastModified
+      put revIDELastModifiedTimeOfFile(tFolder, "api.js") into tLastGenerated
+      if tLastModified < tLastGenerated then
+         put url ("binfile:" & tFolder & slash & "api.js") into tExtensionAPI
+      else
+         local tLcdoc
+         put revDocsFormatDocFileAsJSON(tFolder & slash & "api.lcdoc", tExtensionData["name"], tExtensionData["author"]) into tExtensionAPI
+         put tExtensionAPI into url ("binfile:" & tFolder & slash & "api.js") 
+      end if
+      
+      if tExtensionAPI is not empty then
+         put comma & tExtensionAPI after tData
+      end if
    end repeat
    
    return tData
@@ -238,37 +240,39 @@ private function revDocsGetGuideData
    put revIDESpecialFolderPath("guide") into tGuidePath
    put url ("binfile:" & tGuidePath & slash & "distributed_guide.js") into tData
    
-   # Go through the extensions folder and add all the guides to the JSON
-   local tExtensionsFolder
-   repeat for each item tItem in "extensions,user extensions"
+   local tExtensionDocsDataA
+   put revIDEExtensionDocsData() into tExtensionDocsDataA
+   
+   local tFolder
+   repeat for each element tExtensionData in tExtensionDocsDataA
+      local tExtensionGuide
+      put tExtensionData["folder"] into tFolder
+      if there is a not file (tFolder & slash & "guide.md")  then next repeat
       
-      put revIDESpecialFolderPath(tItem) into tExtensionsFolder
-      set the defaultfolder to tExtensionsFolder
-      repeat for each line tFolder in the folders
-         if tFolder is ".." then next repeat
+      # Check if the .js is out of date
+      local tLastModified, tLastGenerated
+      put revIDELastModifiedTimeOfFile(tFolder, "guide.md") into tLastModified
+      put revIDELastModifiedTimeOfFile(tFolder, "guide.js") into tLastGenerated
+      if tLastModified < tLastGenerated then
+         put url ("binfile:" & tFolder & slash & "guide.js") into tExtensionGuide
+      else
+         local tGuide
+         put url ("binfile:" & tFolder & slash & "guide.md") into tGuide
+         put textDecode(tGuide, "utf-8") into tGuide
          
-         local tExtensionGuide
-         if there is a file (tFolder & "guide.js") then
-            put url ("binfile:" & tExtensionsFolder & slash & tFolder & slash & "guide.js") into tExtensionGuide
-         else if there is a file (tFolder & slash & "guide.md") then
-            local tGuide
-            put url ("binfile:" & tFolder & slash & "guide.md") into tGuide
-            put textDecode(tGuide, "utf-8") into tGuide
-            
-            put "{" & CR after tExtensionGuide
-            put tab & quote & "guide" & quote & ":" && quote & tFolder & quote & comma & CR after tExtensionGuide
-            put quote & "data" & quote & ":" & escape(tGuide, true) & CR after tExtensionGuide
-            put "}" after tExtensionGuide
-            
-            put textEncode(tExtensionGuide, "utf-8") into url ("binfile:" & tExtensionsFolder & slash & tFolder & slash & "guide.js")
-         end if
+         put "{" & CR after tExtensionGuide
+         put tab & quote & "guide" & quote & ":" && quote & tFolder & quote & comma & CR after tExtensionGuide
+         put quote & "data" & quote & ":" & escape(tGuide, true) & CR after tExtensionGuide
+         put "}" after tExtensionGuide
          
-         if tExtensionGuide is not empty then
-            put comma & tExtensionGuide after tData
-         end if
-         
-      end repeat
+         put textEncode(tExtensionGuide, "utf-8") into url ("binfile:" & tFolder & slash & "guide.js")
+      end if
+      
+      if tExtensionGuide is not empty then
+         put comma & tExtensionGuide after tData
+      end if
    end repeat
+   
    return tData
 end revDocsGetGuideData
 

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -1308,7 +1308,7 @@ end revDocsParseDocFileToLibraryArray
 function revDocsParseDocTextToLibraryArray pText, pLibraryName, pAuthor
    local tLibraryA
    put revDocsParseDocText(pText) into tLibraryA
-   if tLibraryA["name"] is empty then
+   if pLibraryName is not empty then
       put pLibraryName into tLibraryA["name"]
    end if
    put pAuthor into tLibraryA["author"]

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -73,7 +73,6 @@ command revDocsLaunchPreview pJSON
 end revDocsLaunchPreview
 
 command generateDistributedDocs
-   start using stack "revidelibrary"
    generateDistributedGuide
    generateDistributedAPI
 end generateDistributedDocs

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -766,6 +766,15 @@ end __extensionManifestValueFromFile
 on extensionUpdateDataReceived
 end extensionUpdateDataReceived
 
-
+function revIDEExtensionDocsData
+   local tDataA, tCount
+   repeat for each key tExtensionID in sExtensions
+      add 1 to tCount
+      put __extensionPropertyGet(tExtensionID, "install_path") into tDataA[tCount]["folder"]
+      put __extensionPropertyGet(tExtensionID, "title") into tDataA[tCount]["name"]
+      put __extensionPropertyGet(tExtensionID, "author") into tDataA[tCount]["author"]
+   end repeat
+   return tDataA
+end revIDEExtensionDocsData
 
 

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -604,7 +604,7 @@ function __extensionModulePaths
    
    local tExtensionModulePaths
    set the itemdel to "."
-   repeat for each line tExtensionFolder in __extensionFolders()
+   repeat for each line tExtensionFolder in revIDEExtensionFolders()
       set the defaultfolder to tExtensionFolder
       repeat for each line tFolder in the folders
          if tFolder begins with "." then next repeat
@@ -753,15 +753,6 @@ function __extensionManifestValueFromFile pExtensionID, pProperty
       return tValue
    end if
 end __extensionManifestValueFromFile
-
-private function __extensionFolders
-   local tFolders
-   put revIDESpecialFolderPath("user extensions") & return & revIDESpecialFolderPath("extensions") into tFolders
-   if not revEnvironmentIsInstalled() then
-      put return & revEnvironmentBinariesPath() & slash & "packaged_extensions" after tFolders
-   end if
-   return tFolders
-end __extensionFolders
 
 # Returns a value from the manifest
 //private on __extensionManifestValue pExtensionID, pManifestKey

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3595,3 +3595,19 @@ on logChanged pLog
    revIDEMessageSend "ideExtensionLog", pLog
 end logChanged
 
+function revIDELastModifiedTimeOfFile pFolder, pFile
+   local tDetailedFiles
+   set the defaultFolder to pFolder
+   put the detailed files into tDetailedFiles
+   return item 5 of line lineOffset(pFile, tDetailedFiles) of tDetailedFiles
+end revIDELastModifiedTimeOfFile
+
+function revIDEExtensionFolders
+   local tFolders
+   put revIDESpecialFolderPath("user extensions") & return & revIDESpecialFolderPath("extensions") into tFolders
+   if not revEnvironmentIsInstalled() then
+      put return & revEnvironmentBinariesPath() & slash & "packaged_extensions" after tFolders
+   end if
+   return tFolders
+end revIDEExtensionFolders
+


### PR DESCRIPTION
- Fixing to the home stack to make it compile in strict mode
- Using the correct mechanism to load the docs library
- Relocating useful functions (revIDELastModifiedTimeOfFile and revIDEExtensionFolders) to the IDE library
- Tweaking the LC Script generation code so that (theoretically) anyone can build the docs provided they have checked out the livecode-docs repo
- Reworking the API and guide data generation so that it a) only regenerates api json if the api.js file is out of date, and b) uses the extension library to provide relevant data
- Tweaking the docs library to use the passed in data for dictionary display, rather than using a default (eg use widget display name instead of type id)
