### PR TITLE
[[ fix ]] setting property of stack that didn't exist

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1807,8 +1807,8 @@ on updateForSelectedObjectChanged
    
    --non property palette IDE stacks
    repeat for each line l in gREVStacksList
-      if "revPropertyPalette" is not in l and not the cREVShaded of stack l then 
-         if exists(this cd of stack l) then
+      if exists(stack l) then
+         if "revPropertyPalette" is not in l and not the cREVShaded of stack l then 
             send "revUpdatePalette" to this cd of stack l
          end if
       end if


### PR DESCRIPTION
With gRevDevelopment set to true certain widgets triggered error "unable to find stack l". I moved the check up one level which has solved the problem. The stack causing the error was "revMenuBa" (missing the r). I'm not sure if it's a debugger mystery error or if something is trying to set a property of a typo "revMenuBa". Either way, this fix ensures that the IDE only sends to an object that definitely exists.
