### PR TITLE
[[ Extensions ]] Return empty from __extensionError

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -579,6 +579,7 @@ function __extensionError pExtensionID, pErrorMessage
    __extensionSendProgressUpdate pExtensionID, "Error:" && pErrorMessage, 100
    --put "Error:" && pErrorMessage, 100
    --revIDEUninstallExtension pExtensionID
+   return empty
 end __extensionError
 
 # Send notication that widget has been added/removed


### PR DESCRIPTION
Otherwise 'the result' from a different operation makes its way into the extension properties array.
