### PR TITLE
[[ Extension Builder ]] Override preinstalled extensions temporarily when testing

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -392,29 +392,48 @@ end __testStackLoc
 
 private function __testStackScript
    local tScript
-   put "on closeStackRequest;revIDEDeveloperExtensionClearTestStack;exit closeStackRequest;end closeStackRequest;on saveStackRequest;exit saveStackRequest;end saveStackRequest" into tScript
+   put "on closeStackRequest;revIDEDeveloperExtensionClearTestStack true;exit closeStackRequest;end closeStackRequest;on saveStackRequest;exit saveStackRequest;end saveStackRequest" into tScript
    replace ";" with return in tScript
    return tScript
 end __testStackScript
 
+local sToUnload, sToReload
 private on __revIDEDeveloperExtensionLaunchTestStack pPath, pDetailsA
-   local tLoc
+   local tLoc, tReload
    put __testStackLoc() into tLoc
    
+   if sToReload is not empty and pDetailsA["id"] is not sToReload then
+      put true into tReload
+   end if
+   
    if there is a stack "LiveCode Extension Test Window" then
-      revIDEDeveloperExtensionClearTestStack
+      revIDEDeveloperExtensionClearTestStack tReload
+   end if
+   
+   # Must be installed somewhere
+   if pDetailsA["id"] is among the lines of the loadedExtensions then
+      put pDetailsA["id"] into sToReload
+      send "__revIDEDeveloperExtensionUnloadInstalled" to me in 0 millisecs
    end if
    
    revIDEDeveloperExtensionCreateTestStack pPath, tLoc, pDetailsA
 end __revIDEDeveloperExtensionLaunchTestStack
 
-on revIDEDeveloperExtensionClearTestStack
-   send "__revIDEDeveloperExtensionDoClearTestStack" to me in 0 millisecs
+on revIDEDeveloperExtensionClearTestStack pReload
+   send "__revIDEDeveloperExtensionDoClearTestStack pReload" to me in 0 millisecs
 end revIDEDeveloperExtensionClearTestStack
 
 on revIDEDeveloperExtensionCreateTestStack pPath, pLoc, pDetailsA
       send "__revIDEDeveloperExtensionDoCreateTestStack pPath, pLoc, pDetailsA" to me in 0 millisecs
 end revIDEDeveloperExtensionCreateTestStack
+
+on __revIDEDeveloperExtensionUnloadInstalled
+   revIDEExtensionUnloadInstalledByName sToReload
+end __revIDEDeveloperExtensionUnloadInstalled
+
+on __revIDEDeveloperExtensionReloadInstalled
+      revIDEExtensionReloadInstalledByName sToReload
+end __revIDEDeveloperExtensionReloadInstalled
 
 on __revIDEDeveloperExtensionDoCreateTestStack pPath, pLoc, pDetailsA
    if there is a folder (pPath & slash & "resources") then
@@ -443,19 +462,21 @@ on __revIDEDeveloperExtensionDoCreateTestStack pPath, pLoc, pDetailsA
       __revIDEDeveloperExtensionDoClearTestStack
       exit __revIDEDeveloperExtensionDoCreateTestStack
    end if
-   set the cCurExtension of stack "LiveCode Extension Test Window" to (pPath & slash & "module.lcm")
+   put pPath & slash & "module.lcm" into sToUnload
 end __revIDEDeveloperExtensionDoCreateTestStack
 
-on __revIDEDeveloperExtensionDoClearTestStack
+on __revIDEDeveloperExtensionDoClearTestStack pReload
    repeat while there is a widget 1 of stack "LiveCode Extension Test Window" 
       delete widget 1 of stack "LiveCode Extension Test Window"
    end repeat
-   local tExtension
-   put the cCurExtension of stack "LiveCode Extension Test Window" into tExtension
    delete stack "LiveCode Extension Test Window"
-   if tExtension is not empty then
-      unload extension tExtension
+   if sToUnload is not empty then
+      unload extension sToUnload
       __revIDEDeveloperExtensionLog "Unloading..."
+   end if
+   
+   if pReload is true and sToReload is not empty then
+      send "__revIDEDeveloperExtensionReloadInstalled" to me in 0 millisecs
    end if
 end __revIDEDeveloperExtensionDoClearTestStack
 

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -352,7 +352,7 @@ on __extensionInstallMakeLive pExtensionID
    # Copy folder from temp directory into live directory
    revCopyFolder tTempInstallPath,tFinalPath
    
-      # Next step
+   # Next step
    send "__extensionInstallLoad" && pExtensionID to me in 0 milliseconds
 end __extensionInstallMakeLive
 
@@ -947,3 +947,33 @@ private on revIDEExtensionFetchMetadata pManifestPath, @rDataA
    put tDataA into rDataA
    return empty
 end revIDEExtensionFetchMetadata
+
+on revIDEExtensionUnloadInstalledByName pName
+   local tIndex, tPath
+   put __extensionCacheID("name", pName) into tIndex
+   
+   if tIndex is empty then
+      return "No such extension"
+   end if
+   
+   put __extensionPropertyGet(tIndex, "install_path") into tPath
+   unload extension (tPath & slash & "module.lcm")
+end revIDEExtensionUnloadInstalledByName
+
+on revIDEExtensionReloadInstalledByName pName
+   local tIndex, tPath
+   put __extensionCacheID("name", pName) into tIndex
+   
+   if tIndex is empty then
+      return "No such extension"
+   end if
+   
+   put __extensionPropertyGet(tIndex, "install_path") into tPath
+   
+   if there is a folder (tPath & slash & "resources") then
+      load extension (tPath & slash & "module.lcm") with resource path (tPath & slash & "resources")
+   else
+      load extension (tPath & slash & "module.lcm")
+   end if
+   
+end revIDEExtensionReloadInstalledByName


### PR DESCRIPTION
This patch allows installed extensions to be unloaded when the 'test' button is clicked, so that the test can go ahead. The installed extension is then reloaded when it is safe to do so (when the test stack is closed, or when a different extension is tested).

Needs reasonably extensive testing to iron out any issues that this might cause, for example with the property inspector.
