### PR TITLE
[[ Developer Extensions ]] Remember selected text editor as a preference

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -525,12 +525,29 @@ on revIDEDeveloperExtensionEditScript pFolder
    local tFile
    put __revIDEDeveloperExtensionFetchModuleInFolder(pFolder) into tFile
    
+   # AL-2015-04-01: [[ Bug 15130 ]] First check to see if there is an existing association
    launch document tFile
-   if the result is "no association" then
+   if the result is not empty then
+      # AL-2015-04-01: [[ Bug 15130 ]] Check to see if the text editor preference is set
+      local tEditor
+      put revIDEGetPreference("LCB_textEditor") into tEditor
+      if tEditor is not empty then
+         launch tFile with tEditor
+      end if
+   end if
+   
+   if the result is "no association" or the result is "request failed" then
       answer file "Select text editor..."
       if it is not empty then
          launch tFile with it
       end if
+   end if
+   
+   if the result is not empty then
+      __revIDEDeveloperExtensionSendError "Could not open" && tFile & ":" && the result
+   else if it is not empty then
+      # AL-2015-04-01: [[ Bug 15130 ]] If the new text editor launch was successful, set the preference
+      revIDESetPreference "LCB_textEditor", it
    end if
 end revIDEDeveloperExtensionEditScript
 


### PR DESCRIPTION
How this works:

1) If there is an existing system association for the lcb file, use that to open it.
2) If there isn't, or the above fails to open the file for some reason then check to see if there is a preference set.
3) If there isn't, or the 'preferred' editor fails to open the file then ask for an application to open with.
4) if 3 is successful, change the 'preferred' editor to the one selected.
5) otherwise log an error.
