### PR TITLE
[[ Bug 10722 ]] Port forward fix for bug 10722

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -1301,14 +1301,6 @@ function seMatchingDefinitions pText, pObject, pHandler
          next repeat
       end if
       
-      # If gREVDevelopment is not true, filter out IDE handlers
-      global gREVDevelopment
-      if not gREVDevelopment then
-         if revOkTarget(tObject) then
-            next repeat
-         end if
-      end if
-      
       put "handler," into tResult
       
       local tIsPrivate, tType


### PR DESCRIPTION
Previously when right-clicking a handler name to get a contextual menu in the script editor, "Go to definition" was disabled with gRevDevelopment not true. Removing this code makes "Go to definition" enabled all the time.
