### PR TITLE
[[Bugfix 15229]] - Message box stealing focus on open

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3294,6 +3294,12 @@ command revIDEOpenPalette pPaletteName
       case "extension manager"
          modeless stack "revIDEExtensionManager"
          break
+      case "message box"
+         palette stack "Message Box"
+         break
+      case "search engine"
+         go stack "revSearchEngine"
+         break
    end switch
 end revIDEOpenPalette
 

--- a/Toolset/libraries/revidelibrary.livecodescript
+++ b/Toolset/libraries/revidelibrary.livecodescript
@@ -273,13 +273,18 @@ function revIDESideWindows
 end revIDESideWindows
 
 command revIDEShowSearchEngine
-   go stack "revSearchEngine"
+   revIDEOpenPalette "search engine"
 end revIDEShowSearchEngine
 
 # OK-2008-06-24: Bug 6575 - Message box command + m shortcut not working in script editor
 # Description
 #   Launches and shows the message box, the same as the Tools -> Message box menu item
 command revIDEShowMessageBox
+   # BB-2015-05-21 - This handler should ultimately be deleted. Calling into new IDE library
+   # to open the message box.
+   revIDEOpenPalette "message box"
+   exit revIDEShowMessageBox
+   
    set the cUserOpen of stack "Message Box" to true
    if the mode of stack "Message Box" is 0 then
       set the visible of stack "Message Box" to true

--- a/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
@@ -280,9 +280,7 @@ on generateFrame
    
    if tHeaderNavCount is not 0 or tHeaderActionCount is not 0 or tHeaderPreferenceCount is not 0 then
       if there is not a widget "header_background" of group "background" of me then 
-         start editing group "background" of me
-         create widget "header_background" as "com.livecode.widget.paletteActions"
-         stop editing
+         create widget "header_background" as "com.livecode.widget.paletteActions" in group "background" of me
       end if
       set the isHeader of widget "header_background" of group "background" of me to true
       set the navData of widget "header_background" of group "background" of me to tHeaderNavDataA
@@ -301,9 +299,7 @@ on generateFrame
    
    if tFooterActionCount is not 0 then
       if there is not a widget "footer_background" of group "background" of me then 
-         start editing group "background" of me
-         create widget "footer_background" as "com.livecode.widget.paletteActions"
-         stop editing
+         create widget "footer_background" as "com.livecode.widget.paletteActions" in group "background" of me
       end if
       set the isHeader of widget "footer_background" of group "background" of me to false
       set the actionData of widget "footer_background" of group "background" of me to tFooterActionDataA


### PR DESCRIPTION
Caused by the palette behaviour. The reason for this was the use of "start editing group". It was not possible to "create widget as xxx in group yyy". Ali has added this so IDE will break unless Ali's update is merged in.
