### PR TITLE
[[ bug 14788 ]] Added lock screens in the frontscript for delete action

### DIFF
--- a/Toolset/libraries/revfrontscriptlibrary.livecodescript
+++ b/Toolset/libraries/revfrontscriptlibrary.livecodescript
@@ -738,13 +738,17 @@ function revCheckDelete
 end revCheckDelete
 
 on backspaceKey
-  if revCheckDelete() then if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass backspaceKey
-  else pass backSpaceKey to metaCard
+   lock screen
+   if revCheckDelete() then if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass backspaceKey
+   else pass backSpaceKey to metaCard
+   unlock screen
 end backspaceKey
 
 on deleteKey
-  if revCheckDelete() then if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass deleteKey
-  else pass deleteKey to metaCard
+   lock screen
+   if revCheckDelete() then if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass deleteKey
+   else pass deleteKey to metaCard
+   unlock screen
 end deleteKey
 
 local lSeenErrors, lEmptyFile

--- a/notes/bugfix-14788.md
+++ b/notes/bugfix-14788.md
@@ -1,0 +1,1 @@
+# Deleting lots of selected controls redraws after each delete


### PR DESCRIPTION
Specifically, added lock screens to the following messages in the frontscript:

backspaceKey
deleteKey
