### PR TITLE
[[ Menubar ]] Tweaks to scriptified menubar

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4857,6 +4857,7 @@ on revIDEImportControl pType, pFileName, pReferenced
    
    lock screen
    lock messages
+   set the defaultStack to tTargetStack
    switch pType
       case "image"
          revIDECreateObject "com.livecode.interface.classic.image", tTargetStack, tCreatedControlLocation
@@ -4869,7 +4870,6 @@ on revIDEImportControl pType, pFileName, pReferenced
          break
       case "audio"
          import AudioClip from file pFileName
-         answer the result && pFileName
          break
       case "video"
          if pReferenced is true then

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -12,13 +12,17 @@ on preOpenStack
    //revMenuBarUpdateRecentPaths
    
    subscribeMessages
-
+   
    setDefaultText
    setMenuProperties
    generateMenu
    updateMenubarPreference
    layoutMenu
    revMenubarBuildMenus
+   
+   # Since the menubar is topleveled on Linux and Windows, set the cantModify to true
+   # to prevent users being able to alter the menubar stack.
+   set the cantModify of me to true
 end preOpenStack
 
 on subscribeMessages


### PR DESCRIPTION
- Set the cantModify so that menubar is not treated as a user stack on non-mac platforms
- Set the defaultStack when importing controls via menubar, as audio and video clips are attached to the defaultStack
