### PR TITLE
[[ Tutorial ]] Tweak tutorial runner to allow interludes with pointer

### DIFF
--- a/Toolset/libraries/revfrontscriptlibrary.livecodescript
+++ b/Toolset/libraries/revfrontscriptlibrary.livecodescript
@@ -877,9 +877,16 @@ on moveStack pLeft, pTop
       send "revUpdatePalette" to this card of stack tPropertyInspector
     end if
   end repeat
-
+  
+  # IDE to notify any objects subscribed to the ideMoveStack Message
+  revIDEMessageSend "ideMoveStack", the owner of the target
+  
   pass moveStack
 end moveStack
+
+on propertyChanged pObject
+	revIDEPropertyChanged pObject
+end propertyChanged
 
 # OK-2008-03-27 : Bug 6229. Added ability to specify a target
 on revCheckStackCollision pStack

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3717,17 +3717,13 @@ on revIDEPropertyCancelAllListeners
    end repeat
 end revIDEPropertyCancelAllListeners
 
-on moveStack
-   revIDEMessageSend "ideMoveStack", the owner of the target
-end moveStack
-
-on propertyChanged pObject
+on revIDEPropertyChanged pObject
    if sLockUpdates is true then
-      exit propertyChanged
+      exit revIDEPropertyChanged
    end if
 
    revIDEMessageSend "idePropertyChanged", pObject
-end propertyChanged
+end revIDEPropertyChanged
 
 on revIDEHideProperty pProperty
 
@@ -4102,22 +4098,30 @@ function revIDEPaletteToStackName pPalette
    return empty
 end revIDEPaletteToStackName
 
-function revIDEAbsoluteRectOfObject pPalette, pObjectTag
-   dispatch function "absoluteRectOfObject" to stack revIDEPaletteToStackName(pPalette) with pObjectTag
+function revIDEAbsoluteRectOfObject pPalette, pObjectData
+   if pPalette is "script editor" then
+      dispatch function "absoluteRectOfObject" to stack revScriptEditor(pObjectData["object"]) with pObjectData["item"]
+   else
+      dispatch function "absoluteRectOfObject" to stack revIDEPaletteToStackName(pPalette) with pObjectData
+   end if
    return the result
 end revIDEAbsoluteRectOfObject
 
 function revIDERelativeRectToAbsolute pRect, pStack
-   put item 1 of pRect + the left of pStack into item 1 of pRect
-   put item 3 of pRect + the left of pStack into item 3 of pRect
+   put item 1 of pRect + the effective left of pStack into item 1 of pRect
+   put item 3 of pRect + the effective left of pStack into item 3 of pRect
    
-   put item 2 of pRect + the top of pStack into item 2 of pRect
-   put item 4 of pRect + the top of pStack into item 4 of pRect
+   put item 2 of pRect + the effective top of pStack into item 2 of pRect
+   put item 4 of pRect + the effective top of pStack into item 4 of pRect
    return pRect
 end revIDERelativeRectToAbsolute
 
 on revIDEHighlightObject pPalette, pObjectData
-   dispatch "highlightObject" to stack revIDEPaletteToStackName(pPalette) with pObjectData
+   if pPalette is "script editor" then
+      dispatch "highlightObject" to stack revScriptEditor(pObjectData["object"]) with pObjectData["item"]
+   else
+      dispatch "highlightObject" to stack revIDEPaletteToStackName(pPalette) with pObjectData
+   end if
 end revIDEHighlightObject
 
 #############

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -731,10 +731,19 @@ end mouseUp
 local sMenuHighlight
 function absoluteRectOfObject pObject
    local tRect
-   put the rect of menu pObject into tRect
-   if the platform is "macos" then
-      put item 1 of tRect + 140 into item 1 of tRect
-      put item 3 of tRect + 140 into item 3 of tRect
+   if there is a button pObject of group "revMenuBar" of me then
+      put the rect of button pObject into tRect
+      if the platform is "macos" then
+         put item 1 of tRect + 140 into item 1 of tRect
+         put item 3 of tRect + 140 into item 3 of tRect
+      end if
+   else 
+      if there is a button pObject of group "menu" of me then
+         put the rect of button pObject of group "menu" of me into tRect
+      else if pObject is "tutorial" then
+         put the rect of group "tutorial" of me into tRect
+      end if
+      put revIDERelativeRectToAbsolute(tRect, me) into tRect
    end if
    return tRect
 end absoluteRectOfObject
@@ -745,6 +754,8 @@ on highlightObject pObject
       revMenubarBuildMenus
    else if there is a button pObject of stack "revMenubar" then
       enable button pObject of stack "revMenubar"
+   else if pObject is "tutorial" then
+      // HIghlight tutorial progress group
    end if
    layoutMenu
 end highlightObject

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -893,17 +893,28 @@ command revMenubarBuildMenus
       set the text of button tMenu of group "revMenuBar" of me to revMenubarBuildMenu(tMenu, tContext)
    end repeat
    
-   if sMenuHighlight["File"] is not empty then
-      set the wholematches to false
-      get lineoffset(sMenuHighlight["File"], button "File" of group "revMenuBar" of me)
-      enable line it of button "File" of group "revMenuBar" of me
-   else if sMenuHighlight["Edit"] is not empty then
-      enable button "Edit" of group "revMenuBar" of me
-      set the wholematches to false
-      get lineoffset(sMenuHighlight["Edit"], button "Edit" of group "revMenuBar" of me)
-      enable line it of button "Edit" of group "revMenuBar" of me
+   if sMenuHighlight is not empty then
+      repeat for each item tMenu in revMenubarMenus()
+         disable button tMenu of group "revMenuBar" of me
+      end repeat
+      
+      repeat for each key tMenu in sMenuHighlight
+         enable button tMenu of group "revMenuBar" of me
+         local tMenuText
+         put the text of button tMenu of group "revMenuBar" of me into tMenuText
+         local tLineNumber
+         repeat for each line tLine in tMenuText
+            add 1 to tLineNumber
+            if tLine contains sMenuHighlight[tMenu] then
+               enable line tLineNumber of button tMenu of group "revMenuBar" of me
+            else if tLine begins with tab then
+               next repeat
+            else
+               disable line tLineNumber of button tMenu of group "revMenuBar" of me
+            end if
+         end repeat
+      end repeat
    end if
-   enable button "File" of group "revMenuBar" of me
    unlock menus
 end revMenubarBuildMenus
 

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -2838,3 +2838,21 @@ function buildDebugEntryMessage pObject, pHandler, pParameters
    
    return tCommandString
 end buildDebugEntryMessage
+
+////////////////////////////////////////////////////////////////////////////////
+
+# Used by the tutorial system to interact with elements of the script editor
+function absoluteRectOfObject pObject
+   local tRect
+   if pObject is "Apply" then
+      put the rect of button "Compile" of me into tRect
+   else if there is a button pObject of me then
+      put the rect of button pObject of me into tRect
+   end if
+   put revIDERelativeRectToAbsolute(tRect, me) into tRect
+   return tRect
+end absoluteRectOfObject
+
+on highlightObject pObject
+   
+end highlightObject

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -351,6 +351,14 @@ on revTutorialParseHighlight pTokens, @rData
             put tData[1] into rData["guide"]
          end if
          break
+      case "script"
+         revTutorialParseSubexpression "highlight script editor <token> of <object>", pTokens, tFirstToken, tData
+         if the result is empty then
+            put "script editor" into rData["highlight type"]
+            put tData[1] into rData["item"]
+            put tData[2] into rData["object"]
+         end if
+         break
       default
          revTutorialParseSubexpression "highlight <object>", pTokens, tFirstToken, tData
          if the result is empty then
@@ -1167,6 +1175,9 @@ on revTutorialDoHighlight pActionData
          case "guide"
             revTutorialHighlightGuide pActionData["guide"]
             break
+         case "script editor"
+            revTutorialHighlightScriptEditorItem pActionData["item"], pActionData["object"]
+            break
       end switch
    catch tError
       // Something was specified incorrectly in the tutorial file
@@ -1226,6 +1237,19 @@ on revTutorialHighlightInspector pSection, pGroup
    put pGroup into sHighlight["group"]
    revTutorialPositionStackForHighlight
 end revTutorialHighlightInspector
+
+on revTutorialHighlightScriptEditorItem pItem, pObject
+   local tSEData, tObject
+   put sTaggedObjects[pObject["type"]][pObject["tag"]] into tObject
+   put tObject into tSEData["object"]
+   put pItem into tSEData["item"]
+   revIDEHighlightObject "script editor", tSEData
+   revIDESubscribe "ideMoveStack", the name of stack revScriptEditor(tObject)
+   put "script editor" into sHighlight["type"]
+   put pItem into sHighlight["item"]
+   put tObject into sHighlight["object"]
+   revTutorialPositionStackForHighlight
+end revTutorialHighlightScriptEditorItem
 
 local sDisabled
 on revTutorialHighlightMenuItem pMenu, pItem
@@ -1517,6 +1541,8 @@ function revTutorialObjectIsHighlighted pObject
          return pObject is the name of stack revIDEPaletteToStackName("tools")
       case "object"
          return pObject is sHighlight["object"] or pObject is revIDEStackOfObject(sHighlight["object"])
+      case "script editor"
+         return pObject is the name of stack revScriptEditor(sHighlight["object"])
    end switch
    return false
 end revTutorialObjectIsHighlighted
@@ -1541,6 +1567,9 @@ on revTutorialPositionStackForHighlight
          break
       case "object"  
          revTutorialPositionStack "", sHighlight["object"], true
+         break
+      case "script editor"
+         revTutorialPositionStack "script editor", sHighlight, true
          break
    end switch
    unlock screen

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -322,6 +322,13 @@ on revTutorialParseHighlight pTokens, @rData
             put tData[2] into rData["menu"]
          end if
          break
+      case "toolbar"
+         revTutorialParseSubexpression "highlight toolbar <token>", pTokens, tFirstToken, tData
+         if the result is empty then
+            put "toolbar" into rData["highlight type"]
+            put tData[1] into rData["item"]
+         end if
+         break
       case "tool"
          revTutorialParseSubexpression "highlight tool <token>", pTokens, tFirstToken, tData
          if the result is empty then
@@ -521,7 +528,7 @@ end revTutorialParseAction
 #                     STACK APPEARANCE
 #
 ##############################################################################
-local sShowProgress
+local sIsInterlude
 function revTutorialInterludeColor
    return "209,137,50"
 end revTutorialInterludeColor
@@ -543,15 +550,14 @@ constant kMargin = 20
 constant kMessageWidth = 200
 constant kProgressHeight = 5
 
-on revTutorialPositionStack pStack, pObject, pToSide, pIsMenu, pWidthOverride, pIsProperty
+on revTutorialPositionStack pStack, pObject, pToSide, pWidthOverride
    lock screen
    lock messages
-   
-   hide button "Got It" of stack "revTutorial"
-   if sShowProgress is true then
-      show group "Progress" of stack "revTutorial"
+   if sIsInterlude then
+      show button "Got It" of stack "revTutorial"
+      put 460 into pWidthOverride
    else
-      hide group "Progress" of stack "revTutorial"
+      hide button "Got It" of stack "revTutorial"
    end if
    
    local tScreenRect
@@ -587,16 +593,15 @@ on revTutorialPositionStack pStack, pObject, pToSide, pIsMenu, pWidthOverride, p
    set the width of field "Message"of stack "revTutorial" to max(kMessageWidth, pWidthOverride)
    set the height of field "Message" of stack "revTutorial" to 1000
    
-   if sShowProgress is true then
-      put the formattedHeight of field "Message" of stack "revTutorial" + kMargin * 3 + kProgressHeight into tHeight
-      put max(100,tHeight) into tHeight
-      set the height of field "Message" of stack "revTutorial" to tHeight - kProgressHeight - 2*kMargin
-   else
-      put the formattedHeight of field "Message" of stack "revTutorial" + kMargin * 2 into tHeight
-      put max(100,tHeight) into tHeight
-      set the height of field "Message" of stack "revTutorial" to tHeight - kMargin
-   end if
+   put the formattedHeight of field "Message" of stack "revTutorial" + kMargin * 2 into tHeight
+   put max(100,tHeight) into tHeight
+   set the height of field "Message" of stack "revTutorial" to tHeight - kMargin
+   
    put the formattedWidth of field "Message" of stack "revTutorial" + kMargin * 2 into tWidth
+   
+   if sIsInterlude then
+      put tHeight + the height of button "Got It" of stack "revTutorial" + kMargin into tHeight
+   end if
    
    local tGraphic, tPointer, tGroup, tWindowShape
    set the lineSize of the templateGraphic to 0
@@ -671,90 +676,38 @@ on revTutorialPositionStack pStack, pObject, pToSide, pIsMenu, pWidthOverride, p
    import snapshot from rect (the rect of tGroup) of tGroup
    set the id of the last image to the id of stack "revIcons"
    put the long id of the last image into tWindowShape
-   set the backColor of stack "revTutorial" to revTutorialMessageColor()
+   if sIsInterlude then
+      set the backColor of stack "revTutorial" to revTutorialInterludeColor()
+   else
+      set the backColor of stack "revTutorial" to revTutorialMessageColor()
+   end if
    delete tGroup
    
    set the windowshape of stack "revTutorial" to the id of tWindowShape
    delete tWindowShape
    
-   set the rect of graphic "Trough" of group "Progress" of stack "revTutorial" to 0, 0, tWidth - kMargin * 2, kProgressHeight
-   set the rect of graphic "Bar" of group "Progress" of stack "revTutorial" to 0, 0, revTutorialDoneRatio() * (tWidth - kMargin * 4), kProgressHeight
-   
    if pObject is not empty then
       if pToSide and tPointerLeft then
          set the topleft of field "Message" of stack "revTutorial" to kMargin + 20, kMargin
-         set the topleft of group "Progress" of stack "revTutorial" to kMargin + 20, tHeight - kMargin - kProgressHeight
       else if not pToSide and tPointerTop then
          set the topleft of field "Message" of stack "revTutorial" to kMargin, kMargin + 20
-         set the topleft of group "Progress" of stack "revTutorial" to kMargin, tHeight - kMargin - kProgressHeight + 20
       else
          set the topleft of field "Message" of stack "revTutorial" to kMargin, kMargin
-         set the topleft of group "Progress" of stack "revTutorial" to kMargin, tHeight - kMargin - kProgressHeight
       end if
       set the topleft of stack "revTutorial" to tStackLeft, tStackTop
    else
+      if sIsInterlude then
+         set the topleft of button "Got It" of stack "revTutorial" to tWidth - kMargin - the width of button "Got It" of stack "revTutorial", tHeight - kMargin - the height of button "Got It" of stack "revTutorial"
+      end if
+      
       set the rect of stack "revTutorial" to 0, 0, tWidth, tHeight
       set the topleft of field "Message" of stack "revTutorial" to kMargin, kMargin
-      set the topleft of group "Progress" of stack "revTutorial" to kMargin, tHeight - kMargin - kProgressHeight
       set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
    end if
+   
    unlock messages
    unlock screen
 end revTutorialPositionStack
-
-on revTutorialSetInterludeAppearance pText
-   lock screen
-   
-   show button "Got It" of stack "revTutorial"
-   hide group "Progress" of stack "revTutorial"
-   
-   set the windowShape of stack "revTutorial" to 0
-   lock messages
-   put pText into field "Message" of stack "revTutorial"
-   
-   local tScreenRect
-   put the screenrect into tScreenRect
-   
-   local tWidth, tHeight
-   set the width of field "Message"of stack "revTutorial" to 460
-   set the height of field "Message" of stack "revTutorial" to 1000
-   put the formattedHeight of field "Message" of stack "revTutorial" + kMargin * 2 into tHeight
-   put the formattedWidth of field "Message" of stack "revTutorial" + kMargin * 2 into tWidth
-   
-   put max(100,tHeight) into tHeight
-   set the height of field "Message" of stack "revTutorial" to tHeight - 2 * kMargin
-   
-   put tHeight + the height of button "Got It" of stack "revTutorial" + kMargin into tHeight
-   
-   local tGraphic, tWindowShape
-   set the lineSize of the templateGraphic to 0
-   set the backColor of the templateGraphic to "black"
-   set the opaque of the templateGraphic to true
-   
-   create graphic "Shape"
-   put it into tGraphic
-   set the style of it to "rectangle"
-   set the width of it to tWidth
-   set the height of it to tHeight
-   
-   reset the templateGraphic
-   
-   import snapshot from rect (the rect of tGraphic) of tGraphic
-   set the id of the last image to the id of stack "revIcons"
-   put the long id of the last image into tWindowShape
-   set the backColor of stack "revTutorial" to revTutorialInterludeColor()
-   delete tGraphic
-   
-   set the windowshape of stack "revTutorial" to the id of tWindowShape
-   delete tWindowShape
-   
-   set the rect of stack "revTutorial" to 0, 0, tWidth, tHeight
-   set the topleft of field "Message" of stack "revTutorial" to kMargin, kMargin
-   set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
-   set the topleft of button "Got It" of stack "revTutorial" to tWidth - kMargin - the width of button "Got It" of stack "revTutorial", tHeight - kMargin - the height of button "Got It" of stack "revTutorial"
-   unlock messages
-   unlock screen
-end revTutorialSetInterludeAppearance
 
 ##############################################################################
 #
@@ -767,8 +720,8 @@ local sWaiting
 on revInitialiseTutorial pSteps
    lock screen
    lock messages
-   put false into sShowProgress
    put false into sWaiting
+   put false into sIsInterlude
    put pSteps into sSteps
    
    local tStep, tNumSteps
@@ -806,16 +759,6 @@ on revInitialiseTutorial pSteps
    set the autoHilite of it to false
    set the threeD of it to false
    set the visible of it to false
-   
-   create group "Progress"
-   set the margins of it to 0
-   set the opaque of the templateGraphic to true
-   set the style of the templateGraphic to "rectangle"
-   set the lineSize of the templateGraphic to 0
-   create graphic "Trough" in group "Progress"
-   set the backcolor of it to revTutorialMessageAltColor()
-   create graphic "Bar" in group "Progress"
-   set the backcolor of it to "white"
    
    insert the script of stack "revTutorial" into front
    go invisible stack "revTutorial" as palette
@@ -870,7 +813,8 @@ end revTutorialDoneRatio
 
 on revTutorialPrologue
    if sSteps["prologue"] is not empty then
-      revTutorialDoInterlude sSteps["prologue"]["text"], false
+      revTutorialDoInterlude false
+      revTutorialSetText "prologue"
    else
       send "revTutorialContinue" to stack "revTutorial" in 0 millisecs
    end if
@@ -878,7 +822,8 @@ end revTutorialPrologue
 
 on revTutorialEpilogue
    if sSteps["epilogue"] is not empty then
-      revTutorialDoInterlude sSteps["epilogue"]["text"], true
+      revTutorialDoInterlude true
+      revTutorialSetText "epilogue"
    else
       send "revIDEStopTutorial" to stack "revIDELibrary" in 0 millisecs
    end if
@@ -907,24 +852,23 @@ on revTutorialContinue
             next repeat
          end if
       end if
+      // Do text, highlight and guide actions under lock screen, to remove 'flicker'
       lock screen
-      if sSteps[sStepName]["actions"]["interlude"] is empty then
-         // Do text, highlight and guide actions under lock screen, to remove 'flicker'
-         // Text
-         revTutorialSetText sStepName
-         // Guide
-         revTutorialExecuteAction sSteps[sStepName]["actions"]["add guide"]
-         // Highlight
-         revTutorialExecuteAction sSteps[sStepName]["actions"]["highlight"]
-         unlock screen
-         show stack "revTutorial"
-         revTutorialExecuteAction sSteps[sStepName]["actions"]["capture"]
-         revTutorialExecuteAction sSteps[sStepName]["actions"]["wait"]
-      else
-         revTutorialExecuteAction sSteps[sStepName]["actions"]["interlude"]
-         unlock screen
-         show stack "revTutorial"
-      end if
+      // Interlude
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["interlude"]
+      // Text
+      revTutorialSetText sStepName
+      // Guide
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["add guide"]
+      // Highlight
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["highlight"]
+      unlock screen
+      show stack "revTutorial"
+      // Capture
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["capture"]
+      // Wait
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["wait"]
+      
       if sWaiting then
          exit repeat
       end if
@@ -944,7 +888,7 @@ on revTutorialExecuteAction pActionData
          revTutorialDoCapture pActionData["object type"], pActionData["tag"]
          break
       case "interlude"
-         revTutorialDoInterlude pActionData["text"], false
+         revTutorialDoInterlude false
          break
       case "add guide"
          revTutorialDoAddGuide pActionData["guide"], pActionData["rect"], pActionData["object"]["type"], pActionData["object"]["tag"]
@@ -972,7 +916,7 @@ on revTutorialSetTextOfMessage pText, pScript
       put the formattedWidth of field "Message" of stack "revTutorial" into tWidthOverride
    end if
    put pText before field "Message" of stack "revTutorial"
-   revTutorialPositionStack "", "", true, false, tWidthOverride
+   revTutorialPositionStack "", "", true, tWidthOverride, false
 end revTutorialSetTextOfMessage
 
 function revTutorialScriptRetry pCurrent
@@ -998,6 +942,7 @@ on revTutorialDoGoToStep pStep
    revTutorialClearGuides
    disableToolsPalette
    put false into sWaiting
+   put false into sIsInterlude
 end revTutorialDoGoToStep
 
 local sCaptureData, sTaggedObjects
@@ -1006,8 +951,8 @@ on revTutorialDoCapture pType, pTag
    put pTag into sCaptureData[pType]
 end revTutorialDoCapture
 
-on revTutorialDoInterlude pText, pIsEpilogue
-   revTutorialSetInterludeAppearance pText
+on revTutorialDoInterlude pIsEpilogue
+   put true into sIsInterlude
    revTutorialWaitUntilInterludeIsDismissed pIsEpilogue
 end revTutorialDoInterlude
 
@@ -1210,6 +1155,9 @@ on revTutorialDoHighlight pActionData
          case "menu"
             revTutorialHighlightMenuItem pActionData["menu"], pActionData["item"]
             break
+         case "toolbar"
+            revTutorialHighlightToolbarItem pActionData["item"]
+            break
          case "property"
             revTutorialHighlightInspector pActionData["section"], pActionData["property"]
             break
@@ -1289,6 +1237,14 @@ on revTutorialHighlightMenuItem pMenu, pItem
    put pMenu into sHighlight["menu"]
    revTutorialPositionStackForHighlight
 end revTutorialHighlightMenuItem
+
+on revTutorialHighlightToolbarItem pItem
+   revIDEHighlightObject "menubar", pItem
+   revIDESubscribe "ideMoveStack", the name of stack revIDEPaletteToStackName("menubar")
+   put "toolbar" into sHighlight["type"]
+   put pItem into sHighlight["item"]
+   revTutorialPositionStackForHighlight
+end revTutorialHighlightToolbarItem
 
 on disableToolsPalette
    dispatch "disableTools" to stack "revTools"
@@ -1572,10 +1528,13 @@ on revTutorialPositionStackForHighlight
          revTutorialPositionStack "", sGuides[sHighlight["guide"]], true
          break
       case "property"
-         revTutorialPositionStack "inspector", sHighlight["group"], true, false, "", true
+         revTutorialPositionStack "inspector", sHighlight["group"], true
          break
       case "menu"
-         revTutorialPositionStack "menubar", sHighlight["menu"], false, true
+         revTutorialPositionStack "menubar", sHighlight["menu"], false
+         break
+      case "toolbar"
+         revTutorialPositionStack "menubar", sHighlight["item"], false
          break
       case "tool"
          revTutorialPositionStack "tools", sHighlight["tool"], true

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -1056,12 +1056,12 @@ function revTutorialCheckWaitCondition pActionData
             end if
          else if pActionData["state"] is "scripted" then
             # If the script hasn't changed then don't do anything.
-            if sWait["current script"] is empty or revTutorialScriptIs(the script of tObject, sWait["current script"]) then
+            if revTutorialScriptIs(the script of tObject, sWait["current script"]) then
                break
             end if
             if revTutorialObjectPropertyIsValue(tObject, "script", pActionData["script"]) then
                return true
-            else
+            else if sWait["current script"] is not empty then
                add 1 to sWait["incorrect attempts"]
                put the script of tObject into sWait["current script"]
                # Show the current script and the target script in the tip stack

--- a/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
+++ b/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
@@ -213,6 +213,7 @@ step "Set Send Button Script"
 	The mouseUp message is sent to a button when the user clicks on it. We are going to make a dialog
 	box pop up when the user clicks on the 'Send' button, by using LiveCode's 'answer' command in response 
 	to the mouseUp message.
+	
     Set the script of the button to the following, and click the Apply button (in the top left corner of the script editor):
 script
     on mouseUp

--- a/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
+++ b/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
@@ -206,14 +206,28 @@ step "Script Editor Interlude"
 	This is achieved by adding blocks of script which tell LiveCode what to do when a given user action has occurred.
 action
 	interlude
-    go to step "Set Send Button Script"
+	go to step "Apply Button Interlude"	
 end step	
 
-step "Set Send Button Script"
+step "Apply Button Interlude"
+	The script entered into the script editor does not become live until you click on the Apply button.
+	When this is clicked, you will get feedback about whether the script you have written is correct.
+action
+	highlight script editor "Apply" of button "Send Button"
+	interlude
+	go to step "Send Button Script"	
+end step
+
+step "Send Button Script"
 	The mouseUp message is sent to a button when the user clicks on it. We are going to make a dialog
 	box pop up when the user clicks on the 'Send' button, by using LiveCode's 'answer' command in response 
 	to the mouseUp message.
-	
+action
+	interlude
+	go to step "Set Send Button Script"	
+end step
+
+step "Set Send Button Script"
     Set the script of the button to the following, and click the Apply button (in the top left corner of the script editor):
 script
     on mouseUp

--- a/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
+++ b/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
@@ -21,7 +21,7 @@ step "Create Mainstack"
 	Click on the File menu, and select New Stack > Default Size
 action
     -- Give the user a visual hint of where they should be clicking
-    highlight menu item "New Mainstack" of menu "File"
+    highlight menu item "New Stack" of menu "File"
     -- The tutorial scripts only act on 'captured' object - this will cause the next created stack
     -- to be internally tagged as 'Mainstack' so it can be referenced in the rest of the tutorial
     capture the next new stack as "Mainstack"

--- a/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
+++ b/Toolset/palettes/tutorial/tutorials/My First App/My First App.txt
@@ -8,6 +8,15 @@ prologue
 	tools palette.
 end prologue
 
+step "Tutorials Intro"
+	You can keep track of how much of the tutorial you have completed with this progress bar, and 
+	exit the tutorial at any time by clicking on the x button.
+action
+	highlight toolbar "tutorial"
+	interlude
+	go to step "Create Mainstack"
+end step
+
 step "Create Mainstack"
 	Click on the File menu, and select New Stack > Default Size
 action


### PR DESCRIPTION
- Refactor tutorial window shape and positioning code so to maximize re-use between interludes and instructions
- Enable interludes to use the highlight mechanism, in case the information relates to a specific IDE element
- Add interlude to the beginning of the 'My First App' tutorial to show the progress bar and exit tutorial button on the toolbar
