### PR TITLE
[[ Menubar ]] Kill menubar flicker

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1416,16 +1416,19 @@ on revIDEMessageSend pMessage, pEffectedTarget
          revIDEUnsubscribeAll tObjectID
          next repeat
       end if
-
-      # If the stack isn't visible on screen, don't send a message
+      
       local tStackID
       set the itemdel to "stack"
       put tObjectID into tStackID
       delete item 1 of tStackID
       if tStackID begins with "tack" then delete char 1 to 4 of tStackID
       put "stack" before tStackID
-      if the mode of tStackID is 0 or the visible of tStackID is false then next repeat
-
+      # If the stack isn't visible on screen, don't send a message
+      # Unless it is the menubar, which should always be able to receive messages
+      if the mode of tStackID is 0 or (tStackID is not the long name of stack revIDEPaletteToStackName("menubar") and the visible of tStackID is false) then 
+         next repeat
+      end if
+      
       # Send the message!
       set the itemdel to ":"
       local tMessage

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -253,8 +253,10 @@ end ideTutorialProgressChanged
 
 on idePreferenceChanged pPreference
    switch pPreference
-      case  "cToolbarText"
+      case "cToolbarText"
       case "cToolbarIcons"
+         lock screen
+         show me
          local tAlterBounding
          if abs(item 2 of the windowBoundingRect - the bottom of me) < 10 then 
             put true into tAlterBounding
@@ -264,6 +266,7 @@ on idePreferenceChanged pPreference
          if tAlterBounding then
             set the windowBoundingRect to item 1 of the windowBoundingRect,the bottom of me + 25, item 3 to 4 of the windowBoundingRect
          end if
+         unlock screen
          break
    end switch
 end idePreferenceChanged
@@ -587,7 +590,6 @@ on updateMenubarPreference
    end repeat 
    
    if the platform is "macos" then
-      show me
       if tShowIcons is false and tShowText is false then
          hide me
       else if tShowIcons is false then


### PR DESCRIPTION
Fixed the menubar flicker by removing a "show me" from the updateMenubarPreference function. This function needs to hide the menubar on mac if preferences dictate that neither toolbar icons nor text should be shown.

Reinstated the 'show me' in the idePreferenceChanged handler, so that it is not called during preOpenStack.

Unfortunately, messages are not sent to hidden stacks, so had to add a workaround to the ide library to send messages to the menubar even if it is hidden.

I'm open to suggestions about a better way to go about that.
