### PR TITLE
Feature tutorial load action

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7777,6 +7777,10 @@ on revIDEDismissTransient
 end revIDEDismissTransient
 
 function revIDEFolderListing pFolder, pListFiles
+   if there is not a folder pFolder then
+      return empty
+   end if
+    
    local tDefaultFolder
    put the defaultFolder into tDefaultFolder
    set the defaultFolder to pFolder
@@ -8038,7 +8042,7 @@ end revIDETutorialLessonContent
 Lists the courses that are always present in the order they should display
 */
 function revIDETutorialFixedCourses
-   return "Getting Started,Beginners Course,General Tutorials"
+   return "Welcome,Getting Started,General Tutorials"
 end revIDETutorialFixedCourses
 
 /*
@@ -8085,12 +8089,7 @@ function revIDETutorialInfo pCourse
    local tTutorialList
    put revIDETutorialListTutorials(pCourse) into tTutorialList
    
-   if pCourse is "Beginners Course" then
-      # Create it course is ordered numerically
-      sort tTutorialList ascending numeric
-   else
-      sort tTutorialList
-   end if
+   sort tTutorialList ascending numeric
    
    local tTutorialDataA, tCount, tPercentage
    repeat for each line tTutorial in tTutorialList

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7836,8 +7836,12 @@ function revIDETutorialResourcePath pTutorialInfo
 end revIDETutorialResourcePath
 
 function revIDETutorialUserStackPath pStackTag
-   return (revEnvironmentCustomizationPath() & slash & "Tutorial Data" & slash & sTutorialInfo["course"] & slash & sTutorialInfo["tutorial"] & slash & sTutorialInfo["lesson"] & "-" & pStackTag &".livecode")
+   return revIDETutorialUserStackPathOfLesson(sTutorialInfo["course"],sTutorialInfo["tutorial"],sTutorialInfo["lesson"])
 end revIDETutorialUserStackPath
+
+function revIDETutorialUserStackPathOfLesson pStackTag, pCourse, pTutorial, pLesson
+   return (revEnvironmentCustomizationPath() & slash & "Tutorial Data" & slash & pCourse & slash & pTutorial & slash & pLesson & "-" & pStackTag &".livecode")
+end revIDETutorialUserStackPathOfLesson
 
 on revIDETutorialSave pTaggedObjects, pStepName
    if sTutorialInfo is empty then
@@ -7932,19 +7936,28 @@ on revIDETutorialLoad pCourse, pTutorial, pLesson
    local tStackList, tTags, tStackName
    repeat for each line tStackTag in tLessonDataA["stacks"]
       put the name of stack revIDETutorialUserStackPath(tStackTag) into tStackName
-      go invisible stack revIDETutorialUserStackPath(tStackTag)
-      set the filename of stack tStackName to empty
+      revIDETutorialLoadWithTags tStackName, tTags
       if tStackList is empty then
          put tStackName into tStackList
       else
          put return & tStackName after tStackList
       end if
-      
-      union tTags with __fetchAndRemoveTags(tStackName)
    end repeat
    
    dispatch "revTutorialResume" to stack "revTutorial" with tStackList, tTags, tLessonDataA["step"]
 end revIDETutorialLoad
+
+/*
+Load the stack and update xTags to contain all of the additional tags
+contained in custom properties of the target stack
+*/
+on revIDETutorialLoadWithTags pStackFile, @xTags
+   lock screen
+   go invisible pStackFile
+   set the filename of pStackFile to empty
+   union xTags with __fetchAndRemoveTags(pStackFile)
+   unlock screen
+end revIDETutorialLoadWithTags
 
 /* 
 Returns the preference name corresponding to the given course

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -303,6 +303,18 @@ on revTutorialParseInterlude pTokens, @rData
    return empty
 end revTutorialParseInterlude
 
+on revTutorialParseLoad pTokens, @rData
+   local tData
+   revTutorialParseLine "load stack <token> from lesson <token>", pTokens, tData
+   if the result is not empty then
+      return the result
+   end if
+   put "load" into rData["type"]
+   put tData[1] into rData["tag"]
+   put tData[2] into rData["lesson"]
+   return empty
+end revTutorialParseLoad
+
 on revTutorialParseCapture pTokens, @rData
    local tData
    revTutorialParseLine "capture the next new <token> of <object> as <token>", pTokens, tData
@@ -537,6 +549,9 @@ function revTutorialParseAction pLine, pLineNum
       case "add"
          revTutorialParseAddGuide tTokens, tActionData
          break
+      case "load"
+         revTutorialParseLoad tTokens, tActionData
+         break
       default
          throw "Invalid action on line" && pLineNum & "-" && the result
    end switch
@@ -576,6 +591,9 @@ constant kProgressHeight = 5
 on revTutorialPositionStack pStack, pObject, pToSide, pWidthOverride
    lock screen
    lock messages
+   local tDefaultStack
+   put the defaultStack into tDefaultStack
+   set the defaultstack to "revTutorial"
    if sIsInterlude then
       show button "Got It" of stack "revTutorial"
       put 460 into pWidthOverride
@@ -727,7 +745,7 @@ on revTutorialPositionStack pStack, pObject, pToSide, pWidthOverride
       set the topleft of field "Message" of stack "revTutorial" to kMargin, kMargin
       set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
    end if
-   
+   set the defaultstack to tDefaultStack
    unlock messages
    unlock screen
 end revTutorialPositionStack
@@ -951,6 +969,8 @@ on revTutorialContinue
       lock screen
       // Interlude
       revTutorialExecuteAction sSteps[sStepName]["actions"]["interlude"]
+      // Load any stack needed for this step
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["load"]
       // Text
       revTutorialSetText sStepName
       // Guide
@@ -999,11 +1019,42 @@ on revTutorialExecuteAction pActionData
       case "go"
          revTutorialDoGoToStep pActionData["step"]
          break
+      case "load"
+         revTutorialDoLoad pActionData["tag"], pActionData["lesson"]
+         break
    end switch
 end revTutorialExecuteAction
 
+on revTutorialDoLoad pTag, pLesson
+   # Check to see if the stack from the specified lesson is complete
+   local tTutorialInfo
+   put revIDETutorialInProgress() into tTutorialInfo
+   
+   local tProgressInfoA
+   put revIDETutorialSavedCourseProgress(tTutorialInfo["course"]) into tProgressInfoA
+   
+   local tStackFile
+   if tProgressInfoA[tTutorialInfo["tutorial"]][pLesson]["progress"] is 100 then
+      put revIDETutorialUserStackPathOfLesson(pTag, tTutorialInfo["course"], tTutorialInfo["tutorial"], pLesson) into tStackFile
+      if there is a stack tStackFile then
+         revIDETutorialLoadWithTags the name of stack tStackFile, sTaggedObjects
+         show stack tStackFile
+         exit revTutorialDoLoad
+      end if
+   end if
+   
+   put revIDETutorialResourcePath(tTutorialInfo) & slash & pLesson & "-" & pTag & "-complete.livecode" into tStackFile
+   if there is a file tStackFile then
+      revIDETutorialLoadWithTags the name of stack tStackFile, sTaggedObjects
+      show stack tStackFile
+      exit revTutorialDoLoad
+   end if
+   
+   throw "no stack found"
+end revTutorialDoLoad
+
 on revTutorialSetText pStep
-   revTutorialSetTextOfMessage  sSteps[pStep]["text"], sSteps[pStep]["script"]
+   revTutorialSetTextOfMessage sSteps[pStep]["text"], sSteps[pStep]["script"]
 end revTutorialSetText
 
 on revTutorialSetTextOfMessage pText, pScript


### PR DESCRIPTION
This adds a load action to tutorials -

load stack <tag> from lesson <lesson_name>

Currently it will check user data to see if the user has completed lesson <lesson_name>, and if so it will load that stack.

Otherwise it will look for a stack <lesson_name>-<tag>-complete.livecode (note hyphens) in the tutorial's resources folder and load that.

Loading from a tutorial will collect all the custom properties cTutorialTag from the objects on the loaded stack and build the tagged objects array from them.
