### PR TITLE
Feature multi tag

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7777,6 +7777,10 @@ on revIDEDismissTransient
 end revIDEDismissTransient
 
 function revIDEFolderListing pFolder, pListFiles
+   if there is not a folder pFolder then
+      return empty
+   end if
+    
    local tDefaultFolder
    put the defaultFolder into tDefaultFolder
    set the defaultFolder to pFolder
@@ -8038,7 +8042,7 @@ end revIDETutorialLessonContent
 Lists the courses that are always present in the order they should display
 */
 function revIDETutorialFixedCourses
-   return "Getting Started,Beginners Course,General Tutorials"
+   return "Welcome,Getting Started,General Tutorials"
 end revIDETutorialFixedCourses
 
 /*
@@ -8085,12 +8089,7 @@ function revIDETutorialInfo pCourse
    local tTutorialList
    put revIDETutorialListTutorials(pCourse) into tTutorialList
    
-   if pCourse is "Beginners Course" then
-      # Create it course is ordered numerically
-      sort tTutorialList ascending numeric
-   else
-      sort tTutorialList
-   end if
+   sort tTutorialList ascending numeric
    
    local tTutorialDataA, tCount, tPercentage
    repeat for each line tTutorial in tTutorialList

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -1086,6 +1086,21 @@ on revTutorialDoInterlude pIsEpilogue
    revTutorialWaitUntilInterludeIsDismissed pIsEpilogue
 end revTutorialDoInterlude
 
+# Tag a set of objects
+on revTutorialDoCreateSet pObjects, pTag
+   local tLongIDList
+   repeat for each element tObject in pObjects
+      local tLongID
+      put sTaggedObjects[tObject["type"]][tObject["tag"]] into tLongID
+      if tLongIDList is empty then
+         put tLongID into tLongIDList
+      else
+         put return & tLongID after tLongIDList
+      end if
+   end repeat
+   put tLongIDList into sTaggedObjects["set"][pTag]
+end revTutorialDoCreateSet
+
 ##############################################################################
 #
 #                     WAIT CONDITION IMPLEMENTATIONS
@@ -1181,7 +1196,7 @@ function revTutorialCheckWaitCondition pActionData
          break
       case "state"
          if pActionData["state"] is "selected" then
-            if revTutorialObjectIsSelected(tObject) then
+            if revTutorialObjectsAreSelected(tObject) then
                return true
             end if
          else if pActionData["state"] is "scripted" then
@@ -1251,7 +1266,7 @@ end revTutorialWaitUntilThereIsAPaletteForObject
 on revTutorialWaitUntilTheToolIs
    // Subscribe to newTool
 end revTutorialWaitUntilTheToolIs
-  
+
 on revTutorialWaitUntilObjectPropertyHasValue pObject
    revIDESubscribe "idePropertyChanged", pObject
 end revTutorialWaitUntilObjectPropertyHasValue
@@ -1771,9 +1786,16 @@ on revTutorialClearHighlights
    put empty into sHighlight
 end revTutorialClearHighlights
 
-function revTutorialObjectIsSelected pLongID
-   return pLongID is among the lines of revIDESelectedObjects()
-end revTutorialObjectIsSelected
+function revTutorialObjectsAreSelected pObjects
+   local tSelected
+   put revIDESelectedObjects() into tSelected
+   repeat for each line tObject in pObjects
+      if tObject is not among the lines of tSelected then
+         return false
+      end if
+   end repeat
+   return true
+end revTutorialObjectsAreSelected
 
 function revTutorialObjectIsTaggedObject pLongID, pType, pTag
    return sTaggedObjects[pType][pTag] is pLongID
@@ -1791,31 +1813,43 @@ function revTutorialToolIs pTool
    return false
 end revTutorialToolIs
 
-function revTutorialObjectPropertyIsValue pLongID, pProperty, pValue
-   if pProperty ends with "color" then
-      return revTutorialColorIs(the pProperty of pLongID, pValue)
-   else if pProperty is "script" then
-      return revTutorialScriptIs(the script of pLongID, pValue)
-   else if pProperty is "name" then
-      return the short name of pLongID is pValue
-   end if
-   
-   if the pProperty of pLongID is pValue then
-      return true
-   end if
-   return false
+function revTutorialObjectPropertyIsValue pObjectIDs, pProperty, pValue
+   repeat for each line tObject in pObjectIDs
+      if pProperty ends with "color" then
+         if revTutorialColorIs(the pProperty of tObject, pValue) is false then
+            return false
+         end if
+      else if pProperty is "script" then
+         if revTutorialScriptIs(the script of tObject, pValue) is false then
+            return false
+         end if
+      else if pProperty is "name" then
+         if the short name of tObject is not pValue then
+            return false
+         end if
+      else 
+         if the pProperty of tObject is not pValue then
+            return false
+         end if
+      end if
+   end repeat
+   return true
 end revTutorialObjectPropertyIsValue
 
-function revTutorialObjectHasPalette pPalette, pObject
+function revTutorialObjectHasPalette pPalette, pObjects
+   local tPaletted
    if pPalette is "property inspector" then
-      return pObject is among the lines of revIDEInspectedObjects()
+      put revIDEInspectedObjects() into tPaletted
+   else if pPalette is "script editor" then
+      put revIDEScriptEditingObjects() into tPaletted
    end if
    
-   if pPalette is "script editor" then
-      return pObject is among the lines of revIDEScriptEditingObjects()
-   end if
-   
-   return false
+   repeat for each line tObject in pObjects
+      if tObject is not among the lines of tPaletted then
+         return false
+      end if
+   end repeat
+   return true
 end revTutorialObjectHasPalette
 
 function revTutorialObjectFitsGuide pObject, pGuide, pTolerance

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -139,6 +139,8 @@ function revTutorialIsObjectType pType
       case "image"
       case "widget"
       case "card"
+         # Add a 'set' type for multi-tagging
+      case "set"
          return true
    end switch
    return false
@@ -250,6 +252,29 @@ on revTutorialParseSubexpression pExpected, pTokens, pStart, @rData
             put tPalette into tData[tTokenCount]
             add 1 to tNextWord
             next repeat
+         case "<objlist>"
+            local tObj, tObjectsA, tResult
+            repeat forever
+               revTutorialParseObject pTokens, tNextToken, tObj
+               put the result into tResult
+               if tResult is not empty then
+                  exit repeat
+               end if
+               get the number of elements in tObjectsA
+               put tObj into tObjectsA[it + 1]
+               if pTokens[tNextToken] is not "," then
+                  exit repeat
+               end if
+               # Skip the comma
+               add 1 to tNextToken
+            end repeat
+            if tObjectsA is empty then
+               return tResult
+            end if
+            add 1 to tTokenCount
+            put tObjectsA into tData[tTokenCount]
+            add 1 to tNextWord
+            break
          default
             break
       end switch
@@ -305,6 +330,14 @@ end revTutorialParseInterlude
 
 on revTutorialParseCapture pTokens, @rData
    local tData
+   revTutorialParseLine "capture set <objlist> as <token>", pTokens, tData
+      if the result is empty then
+      put "set" into rData["type"]
+      put tData[1] into rData["objects"]
+      put tData[2] into rData["tag"]
+      return empty
+   end if
+   
    revTutorialParseLine "capture the next new <token> of <object> as <token>", pTokens, tData
    if the result is empty then
       put "capture" into rData["type"]
@@ -953,6 +986,8 @@ on revTutorialContinue
       revTutorialExecuteAction sSteps[sStepName]["actions"]["interlude"]
       // Text
       revTutorialSetText sStepName
+      // Create any sets
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["set"]
       // Guide
       revTutorialExecuteAction sSteps[sStepName]["actions"]["add guide"]
       // Highlight
@@ -998,6 +1033,9 @@ on revTutorialExecuteAction pActionData
          break
       case "go"
          revTutorialDoGoToStep pActionData["step"]
+         break
+      case "set"
+         revTutorialDoCreateSet pActionData["objects"], pActionData["tag"]
          break
    end switch
 end revTutorialExecuteAction
@@ -1069,6 +1107,8 @@ on revTutorialDoGoToStep pStep
    put 0 into sActionNumber
    revTutorialClearHighlights
    revTutorialClearGuides
+   # For now, set captures are transient
+   delete variable sTaggedObjects["set"]
    disableToolsPalette
    put false into sWaiting
    put false into sIsInterlude
@@ -1798,7 +1838,13 @@ function revTutorialObjectsAreSelected pObjects
 end revTutorialObjectsAreSelected
 
 function revTutorialObjectIsTaggedObject pLongID, pType, pTag
-   return sTaggedObjects[pType][pTag] is pLongID
+   local tObj
+   put sTaggedObjects[pType][pTag] into tObj
+   if pType is "set" then
+      sort tObj
+      sort pLongID
+   end if
+   return tObj is pLongID
 end revTutorialObjectIsTaggedObject
 
 function revTutorialToolIs pTool


### PR DESCRIPTION
This pull request allows the following in tutorial syntax:

```
capture set button "Button 1", button "Button 2", button "Button 3", button "Button 4" as "Buttons"
wait until set "Buttons" is selected
```

I've done it this way rather than allow multiple tagged objects in each action (eg wait until button "Button 1", button "Button 2" is selected) simply because it requires a lot less extra parsing machinery.

The tagged set only lasts for the duration of one step at the moment, because of the way tutorial state is stored (tags as custom props of objects) - although in theory this wouldn't be too hard to add, i'm hoping something better than the tags as custom props model will work out.
