### PR TITLE
[[ Tutorial ]] Add load action which runs target lesson to completion

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4731,6 +4731,9 @@ on revIDENewMainstack pWidth, pHeight
    
    # Send the 'ideNewStack' message
    revIDEMessageSend "ideNewStack", it
+   
+   # Return the created stack long id
+   return it
 end revIDENewMainstack
 
 on revIDEActionNewMainstack pStackType
@@ -4752,6 +4755,9 @@ on revIDEActionNewMainstack pStackType
          revIDENewMainstack
       end if
    end if
+   
+   # Return the created stack long id
+   return the result
 end revIDEActionNewMainstack
 
 on revIDEActionNewCard
@@ -4767,6 +4773,9 @@ on revIDEActionNewCard
    put the long id of it into tCardID
    put "edited" into gREVStackStatus[the short name of this stack]
    revIDEMessageSend "ideNewCard tCardID"
+   
+   # Return the card id
+   return tCardID
 end revIDEActionNewCard
 
 on revIDEActionDeleteCard
@@ -5085,6 +5094,7 @@ on revIDEImportControl pType, pFileName, pReferenced
    put the long ID of the topstack into tTargetStack
    put the loc of card 1 of the topstack into tCreatedControlLocation
    
+   local tCreatedControlID
    lock screen
    lock messages
    set the defaultStack to tTargetStack
@@ -5092,12 +5102,14 @@ on revIDEImportControl pType, pFileName, pReferenced
       case "image"
          revIDECreateObject "com.livecode.interface.classic.image", tTargetStack, tCreatedControlLocation
          if pReferenced is true then
-            set the filename of the last control to pFileName
+            put the long id of the last control into tCreatedControlID
+            set the filename of tCreatedControlID to pFileName
          else
-            set the text of the last image to URL ("binfile:" & pFileName)
+            put the long id of the last image into tCreatedControlID
+            set the text of tCreatedControlID to URL ("binfile:" & pFileName)
          end if
-         set the borderWidth of the last image to 0
-         select the last control
+         set the borderWidth of tCreatedControlID to 0
+         select tCreatedControlID
          break
       case "audio"
          import AudioClip from file pFileName
@@ -5105,20 +5117,24 @@ on revIDEImportControl pType, pFileName, pReferenced
       case "video"
          if pReferenced is true then
             revIDECreateObject "com.livecode.interface.classic.player", tTargetStack, tCreatedControlLocation
-            set the filename of the last control to pFileName
+            put the result into tCreatedControlID
+            set the filename of tCreatedControlID to pFileName
          else
             import videoclip from file pFileName
+            put the long id of the last videoclip into tCreatedControlID
          end if
          break
       case "text"
          revIDECreateObject "com.livecode.interface.classic.field", tTargetStack, tCreatedControlLocation
-         put URL ("file:" & pFileName) into the last field
-         select the last control
+         put the result into tCreatedControlID
+         put URL ("file:" & pFileName) into tCreatedControlID
+         select tCreatedControlID
          break
    end switch
    
    unlock messages
    unlock screen
+   return tCreatedControlID
 end revIDEImportControl
 
 on revIDEImportSnapshot pScope, pObjectID
@@ -5978,15 +5994,19 @@ on revIDEActionDuplicate
    lock screen
    if the selObj is not empty then
       set the defaultStack to revIDEStackOfObject(line 1 of (the selobj))
-
+      
       # OK-2007-07-31 : Bug 4917. Instead of assuming that the duplicated controls will have the highest layer
       # numbers, we make certain that we select the correct objects by saving a list of each newly created control
       local tCreatedObjects, tID
       put the milliseconds into tID
       repeat for each line tObject in the selObj
          clone tObject
-         put the long id of it & return after tCreatedObjects
-
+         if tCreatedObjects is empty then
+            put the long id of it into tCreatedObjects
+         else
+            put the long id of it & return after tCreatedObjects
+         end if
+         
          if the right of last control > the right of this cd or the bottom of last control > the bottom of this cd then
             set the topLeft of the last control to 10, 10
          end if
@@ -6012,6 +6032,7 @@ on revIDEActionDuplicate
       revIDEMessageSend "ideSelectedObjectChanged"
    end if
    unlock screen
+   return tCreatedObjects
 end revIDEActionDuplicate
 
 on revIDEDuplicateCard

--- a/Toolset/palettes/tutorial/courses/Welcome/tutorials/1. Newbies/lessons/2. My First App.txt
+++ b/Toolset/palettes/tutorial/courses/Welcome/tutorials/1. Newbies/lessons/2. My First App.txt
@@ -367,6 +367,8 @@ end step
 step "Create Bubble Image"
     We're going to import the bubble image. Click on the file menu, and select Import As Control > Image File...
     Find the blue-bubble.png file in the code resources folder and click open.
+file
+	blue-bubble.png
 action
     capture the next new image of stack "Mainstack" as "Bubble Image"
     highlight menu item "Import As Control" of menu "File"

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -50,6 +50,7 @@ function revTutorialParseData pData
                break
             case "action"
             case "script"
+            case "file"
                // Begin a new subtype
                if tType is not "step" and tType is not "epilogue" then
                   throw "action list not valid in" && tType && " on line" && tLineNum
@@ -76,6 +77,9 @@ function revTutorialParseData pData
                   end if
                else if tSubType is "script" then
                   put tLine & CR after tData
+               else if tSubType is "file" then
+                  # If there is a file for this step, record it
+                  put word 1 to -1 of tLine into tData
                else
                   add 1 to  tActionNum
                   put revTutorialParseAction(tLine, tLineNum) into tData
@@ -328,6 +332,17 @@ on revTutorialParseInterlude pTokens, @rData
    return empty
 end revTutorialParseInterlude
 
+on revTutorialParseLoad pTokens, @rData
+   local tData
+   revTutorialParseLine "load lesson <token>", pTokens, tData
+   if the result is not empty then
+      return the result
+   end if
+   put "load" into rData["type"]
+   put tData[1] into rData["lesson"]
+   return empty
+end revTutorialParseLoad
+
 on revTutorialParseCapture pTokens, @rData
    local tData
    revTutorialParseLine "capture set <objlist> as <token>", pTokens, tData
@@ -570,6 +585,9 @@ function revTutorialParseAction pLine, pLineNum
       case "add"
          revTutorialParseAddGuide tTokens, tActionData
          break
+      case "load"
+         revTutorialParseLoad tTokens, tActionData
+         break
       default
          throw "Invalid action on line" && pLineNum & "-" && the result
    end switch
@@ -609,6 +627,9 @@ constant kProgressHeight = 5
 on revTutorialPositionStack pStack, pObject, pToSide, pWidthOverride
    lock screen
    lock messages
+   local tDefaultStack
+   put the defaultStack into tDefaultStack
+   set the defaultstack to "revTutorial"
    if sIsInterlude then
       show button "Got It" of stack "revTutorial"
       put 460 into pWidthOverride
@@ -760,7 +781,7 @@ on revTutorialPositionStack pStack, pObject, pToSide, pWidthOverride
       set the topleft of field "Message" of stack "revTutorial" to kMargin, kMargin
       set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
    end if
-   
+   set the defaultstack to tDefaultStack
    unlock messages
    unlock screen
 end revTutorialPositionStack
@@ -984,6 +1005,8 @@ on revTutorialContinue
       lock screen
       // Interlude
       revTutorialExecuteAction sSteps[sStepName]["actions"]["interlude"]
+      // Load any stack needed for this step
+      revTutorialExecuteAction sSteps[sStepName]["actions"]["load"]
       // Text
       revTutorialSetText sStepName
       // Create any sets
@@ -1037,11 +1060,23 @@ on revTutorialExecuteAction pActionData
       case "set"
          revTutorialDoCreateSet pActionData["objects"], pActionData["tag"]
          break
+      case "load"
+         revTutorialDoLoad pActionData["lesson"]
+         break
    end switch
 end revTutorialExecuteAction
 
+on revTutorialDoLoad pLesson
+   # Check to see if the stack from the specified lesson is complete
+   local tTutorialInfo
+   put revIDETutorialInProgress() into tTutorialInfo
+   
+   # Simply run the lesson that is to be loaded
+   revTutorialRunTutorial tTutorialInfo["course"], tTutorialInfo["tutorial"], pLesson
+end revTutorialDoLoad
+
 on revTutorialSetText pStep
-   revTutorialSetTextOfMessage  sSteps[pStep]["text"], sSteps[pStep]["script"]
+   revTutorialSetTextOfMessage sSteps[pStep]["text"], sSteps[pStep]["script"]
 end revTutorialSetText
 
 on revTutorialSetTextOfMessage pText, pScript
@@ -1959,3 +1994,162 @@ function revTutorialNumericItemsAreApproximatelyEqual pNumItems, pTolerance, pLe
    end repeat
    return true
 end revTutorialNumericItemsAreApproximatelyEqual
+
+##############################################################################
+#
+#                     AUTORUN
+#
+##############################################################################
+
+local sRunningInfo
+on revTutorialRunTutorial pCourse, pTutorial, pLesson
+   local tTutorialData
+   put revIDETutorialLessonContent(pCourse, pTutorial, pLesson) into tTutorialData
+   
+   local tData
+   put revTutorialParseData(tTutorialData) into tData
+   
+   put pCourse into sRunningInfo["course"]
+   put pTutorial into sRunningInfo["tutorial"]
+   put pLesson into sRunningInfo["lesson"]
+   
+   revTutorialRunSteps tData
+end revTutorialRunTutorial
+
+local sFile
+on revTutorialRunSteps pSteps
+   lock screen
+   local tStep, tStepNum
+   put 0 into tStepNum
+   put pSteps["first step"] into tStep
+   repeat until tStep is empty
+      add 1 to tStepNum
+      put pSteps[tStep]["file"] into sFile
+      revTutorialRunStep pSteps[tStep]["actions"]
+      put pSteps[tStep]["actions"]["go"]["step"] into tStep
+   end repeat
+   unlock screen
+end revTutorialRunSteps
+
+on revTutorialRunStep pStepActions
+   lock screen
+   # Run any load actions
+   revTutorialRunLoad pStepActions["load"]
+   # Execute any set creation actions
+   revTutorialExecuteAction pStepActions["set"]
+   # Run action that satisfies wait condition
+   revTutorialRunAction pStepActions
+   unlock screen
+end revTutorialRunStep
+
+on revTutorialRunLoad pLoadAction
+   # Store currently running lesson in case there are further load actions
+   local tRunningInfo
+   put sRunningInfo into tRunningInfo
+   revTutorialRunTutorial tRunningInfo["course"], tRunningInfo["tutorial"], pLoadAction["lesson"]
+   put tRunningInfo into sRunningInfo
+end revTutorialRunLoad
+
+# We don't actually need to select objects, just keep track of what is supposed to be selected
+local sSelected
+on revTutorialRunAction pActionData
+   lock messages
+   local tWaitData
+   put pActionData["wait"] into tWaitData
+   switch tWaitData["wait condition"]
+      case "there is an object"
+         revTutorialCreateAndCaptureObjects tWaitData, pActionData["capture"], pActionData["highlight"]
+         break
+      case "property"  
+         # Set the property of the objects
+         revTutorialSetPropertyOfObjects sTaggedObjects[tWaitData["object"]["type"]][tWaitData["object"]["tag"]], tWaitData["property"], tWaitData["value"]
+         break
+      case "fits" 
+         # Set the rect of the objects
+         if pActionData["add guide"] is empty then
+            throw "no guide added in wait until object fits action"
+         end if
+         if tWaitData["object"]["type"] is "stack" then
+            put revIDERelativeRectToAbsolute(pActionData["add guide"]["rect"], sTaggedObjects["stack"][tWaitData["object"]["tag"]]) into pActionData["add guide"]["rect"]
+         end if
+         revTutorialSetPropertyOfObjects sTaggedObjects[tWaitData["object"]["type"]][tWaitData["object"]["tag"]], "rect", pActionData["add guide"]["rect"]
+         break
+      case "state"
+         switch tWaitData["state"]
+            case "scripted"
+               # Set the script of the objects
+               revTutorialSetPropertyOfObjects sTaggedObjects[tWaitData["object"]["type"]][tWaitData["object"]["tag"]], "script", tWaitData["script"]
+               break
+            case "selected"
+               put sTaggedObjects[tWaitData["object"]["type"]][tWaitData["object"]["tag"]] into sSelected
+               break
+            default
+               # No other states require action
+               break
+         end switch
+         break
+         # No other waits require action
+      default
+         break
+   end switch
+   unlock messages
+end revTutorialRunAction
+
+on revTutorialCreateAndCaptureObjects pWaitData, pCaptureData, pHighlightData
+   local tCapture, tType
+   # Create the object and tag it
+   repeat with x = 1 to the number of elements in pCaptureData["captures"]
+      put pCaptureData["captures"][x] into tCapture
+      put tCapture["object type"] into tType
+      if tType is "stack" then
+         revIDEActionNewMainstack "default"
+         put the result into sTaggedObjects["stack"][tCapture["tag"]]
+      else if tType is "card" then
+         revIDEActionNewCard
+         put the result into sTaggedObjects["card"][tCapture["tag"]]
+      else
+         if pHighlightData["tool"] is not empty then
+            dispatch function "toolObjectName" to stack "revTools" with pHighlightData["tool"]
+            revIDECreateObject the result, sTaggedObjects["stack"][tCapture["target stack"]["tag"]], "0,0"
+            put the result into sTaggedObjects[tType][tCapture["tag"]]
+         else if pHighlightData["item"] contains "Import" then
+            # Deal with 'import'
+            if sFile is empty then
+               throw "No file specified for import"
+            end if
+            local tImportType
+            switch tType
+               case "image"
+                  put "image" into tImportType
+                  break
+               case "audioClip"
+                  put "audio" into tImportType
+                  break
+               case "videoClip"
+                  put "video" into tImportType
+                  break
+               case "text"
+                  put "field" into tImportType
+                  break
+            end switch
+            revIDEImportControl tImportType, revIDETutorialResourcePath(sRunningInfo) & slash & sFile
+            put the result into sTaggedObjects[tType][tCapture["tag"]]
+         else if pHighlightData["item"] contains "duplicate" then
+            revIDESelectObjects sSelected
+            revIDEActionDuplicate
+            put the result into sTaggedObjects[tType][tCapture["tag"]]
+         else
+            throw "Can't capture target" && tType
+         end if
+      end if
+   end repeat
+   local tObject
+   put sTaggedObjects[pWaitData["object"]["type"]][pWaitData["object"]["tag"]] into tObject
+   if not exists(tObject) then
+      throw "No capture action for object wait" && pWaitData["object"]["type"] && pWaitData["object"]["tag"]
+   end if
+end revTutorialCreateAndCaptureObjects
+
+on revTutorialSetPropertyOfObjects pObjects, pProp, pValue
+   revIDESetPropertyOfObject pObjects, pProp, pValue
+end revTutorialSetPropertyOfObjects


### PR DESCRIPTION
Use  `load lesson <lesson name>` to run <lesson name> so that the tutorial and stack states are the same as they would be at the end of the lesson.

The only additional requirement for this is that now, steps that use the "import as control" menu item must specify the target filename (relative to the resources folder)

Thus the blue bubble step from the original tutorial must be:

```
step "Create Bubble Image"
     We're going to import the bubble image. Click on the file menu, and select Import As Control > Image File...
     Find the blue-bubble.png file in the code resources folder and click open.
file
     blue-bubble.png
action
     capture the next new image of stack "Mainstack" as "Bubble Image"
     highlight menu item "Import As Control" of menu "File"
    wait until there is an image "Bubble Image"
     go to step "Set Bubble Image Area"
end step
```
