### PR TITLE
[[ IDE WIdgets ]] Make metadata collection more generic; plumb in userrVisible

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -123,7 +123,7 @@ function revIDEExtensionWidgetPreferredSize pKind
    local tExtensionID
    put __extensionCacheID("name", pKind) into tExtensionID
    
-   return __extensionPropertyGet(tExtensionID, "preferred_size")
+   return __extensionPropertyGet(tExtensionID, "preferredSize")
 end revIDEExtensionWidgetPreferredSize
 
 ##############################
@@ -871,26 +871,17 @@ on __extensionLoad pID, pExtensionDataA
    end if
    
    # Pull key into out of manifest etc into extensions cache
-   __extensionPropertySet tIndex, "install_path", tToLoadA["install_path"]
-   
-   __extensionPropertySet tIndex, "name", tToLoadA["name"] 
-   __extensionPropertySet tIndex, "version", tToLoadA["version"] 
-   __extensionPropertySet tIndex, "title", tToLoadA["title"] 
-   __extensionPropertySet tIndex, "author", tToLoadA["author"] 
-   __extensionPropertySet tIndex, "type", tToLoadA["type"] 
+   repeat for each key tKey in tToLoadA
+      __extensionPropertySet tIndex, tKey, tToLoadA[tKey]
+   end repeat
    __extensionPropertySet tIndex, "type_id", pID  & "." & tToLoadA["version"] 
    __extensionPropertySet tIndex, "status", tStatus
    __extensionPropertySet tIndex, "error", tError
-   __extensionPropertySet tIndex, "builtin", tToLoadA["builtin"]
-   __extensionPropertySet tIndex, "copies", pExtensionDataA["copies"]
-   __extensionPropertySet tIndex, "preferred_size", tToLoadA["preferredSize"] 
    
    put __extensionProperties(pID) into sExtensionProperties[pID]
    
    # Deal with the various icon possibilities
-   if sExtensionProperties[pID]["svg_icon_path"] is not empty then
-      __extensionPropertySet tIndex, "svg_icon_path", sExtensionProperties[pID]["svg_icon_path"]
-   else if there is a file (tToLoadA["install_path"] & "/support/icon.png") then
+   if sExtensionProperties[pID]["svgIconPath"] is empty and there is a file (tToLoadA["install_path"] & "/support/icon.png") then
       __extensionPropertySet tIndex, "icon", tToLoadA["install_path"] & "/support/icon.png"
    end if
    
@@ -1052,20 +1043,17 @@ private on revIDEExtensionFetchMetadata pManifestPath, @rDataA
    end if
    put tTargetAuthor into tDataA["author"]
    
-   local tPreferredSize
+   local tMetadataValue, tMetadataKey
    local tMetadataNodes, tMetadataA, tKeys, tValue
    put revXMLChildNames(tID, "package",return,"metadata",true) into tMetadataNodes
    repeat for each line tMetadata in tMetadataNodes
-      if revXMLAttribute(tID,"package" & "/" & tMetadata,"key") is "preferredSize" then
-         put revXMLNodeContents(tID,"package" & "/" & tMetadata) into tPreferredSize
-         exit repeat
+      put revXMLAttribute(tID,"package" & "/" & tMetadata,"key") into tMetadataKey
+      put revXMLNodeContents(tID,"package" & "/" & tMetadata) into tMetadataValue
+      if tMetadataValue is empty or tMetadataValue begins with "xmlerr" then
+         put empty into tMetadataValue
       end if
+      put tMetadataValue into tDataA[tMetadataKey]
    end repeat
-   if tPreferredSize is empty or tPreferredSize begins with "xmlerr" then
-      put empty into tPreferredSize
-   end if
-   put tPreferredSize into tDataA["preferredSize"]
-   
    local tRequires, tCount
    put 0 into tCount
    put revXMLChildNames(tId,"package",return,"requires",true) into tRequires

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -220,7 +220,7 @@ on generatePalette
    set the itemdel to "."
    create group "images" in group "contents"
    
-   repeat for each line tView in the keys of sViewsData
+   repeat for each key tView in sViewsData
       if the number of elements of sViewsData[tView] is 0 then next repeat
       
       local tOrder
@@ -244,6 +244,11 @@ on generatePalette
       # Create the group to hold the controls
       create group tView in group "contents" 
       repeat for each line tControlTypeID in tOrder
+         # AL-2015-09-07: Don't show objects in tools palette if specified
+         if sViewsData[tView][tControlTypeID]["userVisible"] is false then
+            next repeat
+         end if
+         
          if tControlTypeID is a number then
             
          end if


### PR DESCRIPTION
Widgets can now use metadata to prevent their appearance in the tools palette, using

`metadata userVisible is "false"`
