### PR TITLE
[[ Extension Builder ]] Don't try and load an extension that failed to compile

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -378,6 +378,12 @@ on revIDEDeveloperExtensionTest pPath
       exit revIDEDeveloperExtensionTest
    end if
    
+   # AL-2015-07-15: [[ Bug ]] If the details of the extension doesn't include an ID, then the compile failed
+   if tDetailsA["id"] is empty then
+      __revIDEDeveloperExtensionSendError "Could not compile module" && pPath
+      exit revIDEDeveloperExtensionTest
+   end if
+   
    if there is not a file (pPath & slash & "module.lcm") then
       __revIDEDeveloperExtensionSendError "No compiled module in" && pPath
       exit revIDEDeveloperExtensionTest


### PR DESCRIPTION
Sometimes there is a pre-existing module.lcm file in the target directory - we don't want to load this when the current compile fails.
