### PR TITLE
Feature dynamic dictionary json

### DIFF
--- a/Documentation/html_viewer/guide.html
+++ b/Documentation/html_viewer/guide.html
@@ -5,7 +5,6 @@
     
     <script src="js/jquery-1.11.1.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
-    <script charset="UTF-8" src="resources/data/guide/built_guide.js"></script>
     <script src="js/marked.js"></script>
     <!--<script src="js/remarkable.min.js"></script>-->
     
@@ -44,13 +43,122 @@
     
     <script src="js/highlight.pack.js"></script> 
     <script>	
+
+   var tUserGuideData;
    
-   $(document).ready(function(e) {
-   		console.log(tUserGuideData.guides);
-   		
-   		var navigation_chooser_html = '';
+	function loadGuide(pGuideName){
+		renderMarkdown(tUserGuideData.guides[pGuideName].data, pGuideName);
+	}
+	
+	function guideExists(pGuideName){
 		$.each(tUserGuideData.guides, function( index, value ) {
-			navigation_chooser_html += '<li role="presentation" class="guide_list_item"><a role="menuitem" tabindex="-1" guide="'+index+'" guide_name="'+value.guide+'">'+value.guide+'</a></li>';
+			if(index == pGuideName) return true;
+		});
+		return false;
+	}
+	
+	function guideFirst(){
+		for (first in tUserGuideData.guides) break;
+		return first;
+	}
+	
+	function createCookie(name, value, days) {
+		var expires;
+
+		if (days) {
+			var date = new Date();
+			date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+			expires = "; expires=" + date.toGMTString();
+		} else {
+			expires = "";
+		}
+		document.cookie = escape(name) + "=" + escape(value) + expires + "; path=/";
+	}
+
+	function readCookie(name) {
+		var nameEQ = escape(name) + "=";
+		var ca = document.cookie.split(';');
+		for (var i = 0; i < ca.length; i++) {
+			var c = ca[i];
+			while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+			if (c.indexOf(nameEQ) === 0) return unescape(c.substring(nameEQ.length, c.length));
+		}
+		return null;
+	}
+
+	function eraseCookie(name) {
+		createCookie(name, "", -1);
+	}
+
+
+	function renderMarkdown(pMarkdown, pGuideIndex){
+		var renderer = new marked.Renderer();
+		var navigation_html = '<ul class="nav bs-docs-sidenav lc_docs_nav">';
+		var current_level = 1;
+	
+		renderer.heading = function (text, level) {
+		  var escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
+	
+			if(level < 3){
+			
+				if(level == current_level){
+					// We are on the same level so just create another li
+					navigation_html += '</li><li><a href="#'+escapedText+'">'+text+'</a>';	
+				} else if(level < current_level){
+					// we've gone up a level so just close of the sub ul and add an li
+					navigation_html += '</li></ul><li><a href="#'+escapedText+'">'+text+'</a>';
+					current_level = level;
+				} else {
+					// we've gone down a level so create a sub ul
+					navigation_html += '<ul class="nav"><li><a href="#'+escapedText+'">'+text+'</a>';
+					current_level = level;
+				}
+			}
+			return '<h' + level + ' id="' + escapedText + '">' +text + '</h' + level + '>';
+		
+		},
+	
+		// Set the core markdown
+		$("#documentation").html(marked(pMarkdown, { renderer: renderer }));
+		$("#guide_name").html(tUserGuideData.guides[pGuideIndex]["display name"]);
+		$("#nav_holder").html(navigation_html + "</ul>");
+		$("#documentation").scrollspy('refresh');
+		$("#documentation img").addClass("img-responsive");
+		
+		$('pre code').each(function(i, block) {
+		//console.log(block);
+		hljs.highlightBlock(block);
+	});	
+	}
+	
+   $(document).ready(function(e) {   		
+   		$('#guide_chooser_list').on("click","a",function(e){
+   			e.preventDefault();
+   			
+   			$("#guide_chooser_list li").removeClass("active");
+   			$(this).parent().addClass("active");
+   		
+   			loadGuide($(this).attr("guide"));
+   			$(this).html(tUserGuideData.guides[$(this).attr("guide")]["display name"]);
+		});
+   		
+    	getDictionaryData();		
+   });
+   
+	function getDictionaryData()
+	{
+		liveCode.fetchData(); 
+	}
+
+	function setData(pJSON)
+	{
+		tUserGuideData = JSON.parse(pJSON);
+		console.log("SET USER GUIDE DATA");
+		   	
+		var navigation_chooser_html = '';
+		   		
+		$.each(tUserGuideData.guides, function( index, value ) {
+			navigation_chooser_html += '<li role="presentation" class="guide_list_item"><a role="menuitem" tabindex="-1" guide="'+index+'" guide_name="'+value.name+'">'+value["display name"]+'</a></li>';
 		});
 		
 		$("#guide_chooser_list").html(navigation_chooser_html);
@@ -65,104 +173,7 @@
    		}	
    		
    		loadGuide(tLastLoadedGuide);
-   		
-   		function loadGuide(pGuideName){
-   			renderMarkdown(tUserGuideData.guides[pGuideName].data, pGuideName);
-   		}
-   		
-   		function guideExists(pGuideName){
-   			$.each(tUserGuideData.guides, function( index, value ) {
-   				if(index == pGuideName) return true;
-   			});
-   			return false;
-   		}
-   		
-   		function guideFirst(){
-   			for (first in tUserGuideData.guides) break;
-   			return first;
-   		}
-   		
-   		function createCookie(name, value, days) {
-			var expires;
-
-			if (days) {
-				var date = new Date();
-				date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-				expires = "; expires=" + date.toGMTString();
-			} else {
-				expires = "";
-			}
-			document.cookie = escape(name) + "=" + escape(value) + expires + "; path=/";
-		}
-
-		function readCookie(name) {
-			var nameEQ = escape(name) + "=";
-			var ca = document.cookie.split(';');
-			for (var i = 0; i < ca.length; i++) {
-				var c = ca[i];
-				while (c.charAt(0) === ' ') c = c.substring(1, c.length);
-				if (c.indexOf(nameEQ) === 0) return unescape(c.substring(nameEQ.length, c.length));
-			}
-			return null;
-		}
-
-		function eraseCookie(name) {
-			createCookie(name, "", -1);
-		}
-   
-
-   		function renderMarkdown(pMarkdown, pGuideIndex){
-			var renderer = new marked.Renderer();
-			var navigation_html = '<ul class="nav bs-docs-sidenav lc_docs_nav">';
-			var current_level = 1;
-		
-			renderer.heading = function (text, level) {
-			  var escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
-		
-				if(level < 3){
-				
-					if(level == current_level){
-						// We are on the same level so just create another li
-						navigation_html += '</li><li><a href="#'+escapedText+'">'+text+'</a>';	
-					} else if(level < current_level){
-						// we've gone up a level so just close of the sub ul and add an li
-						navigation_html += '</li></ul><li><a href="#'+escapedText+'">'+text+'</a>';
-						current_level = level;
-					} else {
-						// we've gone down a level so create a sub ul
-						navigation_html += '<ul class="nav"><li><a href="#'+escapedText+'">'+text+'</a>';
-						current_level = level;
-					}
-				}
-				return '<h' + level + ' id="' + escapedText + '">' +text + '</h' + level + '>';
-			
-			},
-		
-			// Set the core markdown
-			$("#documentation").html(marked(pMarkdown, { renderer: renderer }));
-			$("#guide_name").html(tUserGuideData.guides[pGuideIndex].guide);
-			$("#nav_holder").html(navigation_html + "</ul>");
-			$("#documentation").scrollspy('refresh');
-			$("#documentation img").addClass("img-responsive");
-			
-			$('pre code').each(function(i, block) {
-			//console.log(block);
-    		hljs.highlightBlock(block);
- 		});	
-   		}
-   		
-   		$('#guide_chooser_list').on("click","a",function(e){
-   			e.preventDefault();
-   			
-   			$("#guide_chooser_list li").removeClass("active");
-   			$(this).parent().addClass("active");
-   		
-   			loadGuide($(this).attr("guide"));
-   			$(this).html($(this).attr("guide_name"));
-		});
-   		
-   		
-   });
+	}
     </script>
 </body>
 </html>

--- a/Documentation/html_viewer/viewer.html
+++ b/Documentation/html_viewer/viewer.html
@@ -97,8 +97,7 @@
     <script src="js/bootstrap.min.js"></script>
     <script src="js/marked.js"></script>
     <script src="js/highlight.pack.js"></script>	
-    <script charset="UTF-8" src="resources/data/api/built_api.js"></script>    
-    
+     
     <script>
     
 	var tState = {selected:"",history:[],searched:{},filters:{},filtered_data:{},data:"",selected_api_id:""};
@@ -108,6 +107,7 @@
 	if($.session.get("selected")) tState.selected = $.session.get("selected");
 	else tState.selected = 1;
 
+	var dictionary_data;
 	
 	function dataGet(){
 		//console.log(dictionary_data.docs);
@@ -348,8 +348,8 @@
 	function displayLibraryChooser(){
 		var tHTML = ""
 		$.each(dictionary_data.docs, function(index, libraryData){
-			if(index == tState.selected_api_id) tHTML += '<li role="presentation"><a role="menuitem" tabindex="-1" href="#" library_id="'+index+'" class="active">'+libraryData.library+'</a></li>';
-			else tHTML += '<li role="presentation"><a role="menuitem" tabindex="-1" href="#" library_id="'+index+'">'+libraryData.library+'</a></li>';
+			if(index == tState.selected_api_id) tHTML += '<li role="presentation"><a role="menuitem" tabindex="-1" href="#" library_id="'+index+'" class="active">'+libraryData["display name"]+'</a></li>';
+			else tHTML += '<li role="presentation"><a role="menuitem" tabindex="-1" href="#" library_id="'+index+'">'+libraryData["display name"]+'</a></li>';
 		});
 	
 		$("#lcdoc_library_chooser_list").html(tHTML);
@@ -841,7 +841,7 @@
 	
 	function library_id_to_name(pID){
 		if(dictionary_data.docs.hasOwnProperty(pID)){
-			return dictionary_data.docs[pID].library;
+			return dictionary_data.docs[pID]["display name"];
 		}
 	}
 	
@@ -961,11 +961,23 @@
 		   
 		});
 		
+		getDictionaryData();
+	});
+
+	function getDictionaryData()
+	{
+		liveCode.fetchData(); 
+	}
+
+	function setData(pJSON)
+	{
+		dictionary_data = JSON.parse(pJSON);
+		console.log("SET API DATA");
 		dataFilter();
 		displayLibraryChooser();
 		console.log("loading entry:" + tState.selected);
 		displayEntry(tState.selected);
-	});
+	}
 	</script>
 </body>
 </html>

--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -307,6 +307,9 @@ local sCrashLogPath
 local sCachePath
 -- This is the path to the user-specified IDE customization folder
 local sCustomizationPath
+-- This is the path to the folder containing per-user dictionary data
+local sUserDocsPath
+
 
 -- This is the path to the folder containing user preferences for the IDE prior to 4.5
 local sOldPreferencesPath
@@ -348,7 +351,7 @@ private command revInternal__SetupLicense
    revInternal__Log "Leave", "License Setup"
 end revInternal__SetupLicense
 
- private command revInternal__SetupPaths
+private command revInternal__SetupPaths
    revInternal__Log "Enter", "Path Setup"
    
    local tHomePath
@@ -378,6 +381,7 @@ end revInternal__SetupLicense
          put the folder & slash & ".runrev/preferences" into sPreferencesPath
          put the folder & slash & ".runrev/cache" into sCachePath
          put the folder & slash & ".runrev/crashlogs" into sCrashLogPath
+         put the folder & slash & ".runrev/docs" into sUserDocsPath
          set the folder to tOldFolder
          
          -- MW-2013-06-13: Adjust the engine path for Linux
@@ -394,6 +398,7 @@ end revInternal__SetupLicense
          put specialFolderPath("Preferences") & "/RunRev" into sPreferencesPath
          put specialFolderPath("cusr") & "/Library/Application Support/RunRev/Cache" into sCachePath
          put specialFolderPath("cusr") & "/Library/Application Support/RunRev/Crash Logs" into sCrashLogPath
+         put specialFolderPath("cusr") & "/Library/Application Support/RunRev/Docs" into sUserDocsPath
          
          -- MW-2013-06-13: Adjust the engine path for Mac
          put item 1 to -5 of tEnginePath into tEnginePath
@@ -411,6 +416,7 @@ end revInternal__SetupLicense
          -- We put everything else in the 'Local' AppData folder.
          put specialFolderPath(0x001c) & "/RunRev/Cache" into sCachePath
          put specialFolderPath(0x001c) & "/RunRev/Crash Logs" into sCrashLogPath
+         put specialFolderPath(0x001c) & "/RunRev/Docs" into sUserDocsPath
          
          -- MW-2013-06-13: Adjust the engine path for Windows
          put item 1 to -2 of tEnginePath into tEnginePath
@@ -707,6 +713,9 @@ private command revInternal__SetupFolders
    
    revInternal__Log "Message", "Setting up Crash Log Path"
    revInternal__EnsureFolder sCrashLogPath
+   
+   revInternal__Log "Message", "Setting up Docs Path"
+   revInternal__EnsureFolder sUserDocsPath
    
    revInternal__Log "Leave", "Folders Setup"
 end revInternal__SetupFolders
@@ -1721,6 +1730,10 @@ end revEnvironmentUserPreferencesPath
 function revEnvironmentUserCachePath
   return sCachePath
 end revEnvironmentUserCachePath
+
+function revEnvironmentUserDocsPath
+  return sUserDocsPath
+end revEnvironmentUserDocsPath
 
 function revEnvironmentIsUpdateable
   return true

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3193,7 +3193,7 @@ function revIDESpecialFolderPath pKey
          return tPath
          break
       case "documentation cache"
-         put revEnvironmentCustomizationPath() & "/Documentation" into tPath
+         put revEnvironmentUserDocsPath() & slash & "IDE" into tPath
          revIDEEnsurePath(tPath)
          return tPath
          break
@@ -7935,23 +7935,25 @@ private function revIDEGetDocsAPIData
    local tExtensionDocsDataA
    put revIDEExtensionDocsData() into tExtensionDocsDataA
    
-   local tFolder
+   local tFolder, tCachedDataFolder
+   set the itemdelimiter to slash
    repeat for each element tExtensionData in tExtensionDocsDataA
       local tExtensionAPI
       put tExtensionData["folder"] into tFolder
+      put revEnvironmentUserDocsPath() & slash & the last item of tFolder into tCachedDataFolder
       if there is a not file (tFolder & slash & "api.lcdoc")  then next repeat
-      
+      revIDEEnsurePath tCachedDataFolder
       # Check if the .js is out of date
       local tLastModified, tLastGenerated
       put revIDELastModifiedTimeOfFile(tFolder, "api.lcdoc") into tLastModified
-      put revIDELastModifiedTimeOfFile(tFolder, "api.js") into tLastGenerated
+      put revIDELastModifiedTimeOfFile(tCachedDataFolder, "api.js") into tLastGenerated
       if tLastModified < tLastGenerated then
-         put url ("binfile:" & tFolder & slash & "api.js") into tExtensionAPI
+         put url ("binfile:" & tCachedDataFolder & slash & "api.js") into tExtensionAPI
       else
          local tLcdoc
          dispatch function "revDocsFormatDocFileAsJSON" to stack "revDocsParser" with (tFolder & slash & "api.lcdoc"), tExtensionData["title"], tExtensionData["author"]
          put the result into tExtensionAPI
-         put tExtensionAPI into url ("binfile:" & tFolder & slash & "api.js") 
+         put tExtensionAPI into url ("binfile:" & tCachedDataFolder & slash & "api.js") 
       end if
       
       if tExtensionAPI is not empty then
@@ -7972,19 +7974,22 @@ private function revIDEGetDocsGuideData
    local tExtensionDocsDataA
    put revIDEExtensionDocsData() into tExtensionDocsDataA
    
-   local tFolder
+   local tFolder, tCachedDataFolder
+   set the itemdelimiter to slash
    repeat for each element tExtensionData in tExtensionDocsDataA
       local tExtensionGuide
       put empty into tExtensionGuide
       put tExtensionData["folder"] into tFolder
+      put revEnvironmentUserDocsPath() & slash & the last item of tFolder into tCachedDataFolder
       if there is a not file (tFolder & slash & "guide.md")  then next repeat
+      revIDEEnsurePath tCachedDataFolder
       
       # Check if the .js is out of date
       local tLastModified, tLastGenerated
       put revIDELastModifiedTimeOfFile(tFolder, "guide.md") into tLastModified
-      put revIDELastModifiedTimeOfFile(tFolder, "guide.js") into tLastGenerated
+      put revIDELastModifiedTimeOfFile(tCachedDataFolder, "guide.js") into tLastGenerated
       if tLastModified < tLastGenerated then
-         put url ("binfile:" & tFolder & slash & "guide.js") into tExtensionGuide
+         put url ("binfile:" & tCachedDataFolder & slash & "guide.js") into tExtensionGuide
       else
          local tGuide
          put url ("binfile:" & tFolder & slash & "guide.md") into tGuide
@@ -7992,11 +7997,12 @@ private function revIDEGetDocsGuideData
          
          if tGuide is not empty then
             put "{" & CR after tExtensionGuide
-            put tab & quote & "guide" & quote & ":" && quote & tFolder & quote & comma & CR after tExtensionGuide
+            put tab & quote & "name" & quote & ":" && quote & tFolder & quote & comma & CR after tExtensionGuide
+            put tab & quote & "display name" & quote & ":" && quote & tFolder & quote & comma & CR after tExtensionGuide
             put quote & "data" & quote & ":" & escape(tGuide, true) & CR after tExtensionGuide
             put "}" after tExtensionGuide
             
-            put textEncode(tExtensionGuide, "utf-8") into url ("binfile:" & tFolder & slash & "guide.js")
+            put textEncode(tExtensionGuide, "utf-8") into url ("binfile:" & tCachedDataFolder & slash & "guide.js")
          end if
       end if
       
@@ -8015,7 +8021,7 @@ on revIDEAddGuideAndRegenerate pGuide
    local tGuidePath
    put revIDESpecialFolderPath("guide") into tGuidePath
    
-   put "var tUserGuideData =" & CR & "{" & CR & tab & quote & "guides" & quote & ":[" into tData
+   put "{" & CR & tab & quote & "guides" & quote & ":[" into tData
    
    put revIDEGetDocsGuideData() after tData
    
@@ -8025,7 +8031,9 @@ on revIDEAddGuideAndRegenerate pGuide
    
    put CR & tab & "]" & CR & "}" after tData
    
-   put tData into URL ("binfile:" & tGuidePath & slash & "built_guide.js")
+   local tDocsCache
+   put revIDESpecialFolderPath("documentation cache") into tDocsCache
+   put tData into URL ("binfile:" & tDocsCache & slash & "built_guide.js")
 end revIDEAddGuideAndRegenerate
 
 on revIDEAddAPIAndRegenerate pAPI
@@ -8035,7 +8043,7 @@ on revIDEAddAPIAndRegenerate pAPI
    local tAPIPath
    put revIDESpecialFolderPath("API") into tAPIPath
    
-   put "var dictionary_data =" & CR & "{" & CR & tab & quote & "docs" & quote & ":[" after tData
+   put "{" & CR & tab & quote & "docs" & quote & ":[" after tData
    
    put revIDEGetDocsAPIData() after tData
    
@@ -8044,7 +8052,10 @@ on revIDEAddAPIAndRegenerate pAPI
    end if
    
    put CR & tab & "]" & CR & "}" after tData
-   put tData into URL ("binfile:" & tAPIPath & slash & "built_api.js")
+   
+   local tDocsCache
+   put revIDESpecialFolderPath("documentation cache") into tDocsCache
+   put tData into URL ("binfile:" & tDocsCache & slash & "built_api.js")
 end revIDEAddAPIAndRegenerate
 
 on revIDERegenerateBuiltAPIs

--- a/Toolset/palettes/dictionary/revdictionary.livecodescript
+++ b/Toolset/palettes/dictionary/revdictionary.livecodescript
@@ -2,20 +2,21 @@
 local sBrowserID, sTab
 
 on preOpenStack
-   local tURL
-   put "file:" & revIDESpecialFolderPath("documentation") & slash & "html_viewer/viewer.html" into tURL
-   
-   put revBrowserOpenCEF(the windowId of this stack, tUrl) into sBrowserID
-   
+   put revBrowserOpenCEF(the windowId of this stack) into sBrowserID
+   revBrowserAddJavaScriptHandler sBrowserID, "fetchData"
    dispatch "setAsBehavior" to stack revIDEFrameBehavior() with the long id of me
 end preOpenStack
 
 on openStack
+   lock screen
    addFrameItem "show_apis","header", "navigation", "API", "f1b3", "f1b3","showAPIs", the long id of me
    addFrameItem "show_guides","header", "navigation", "Guide", "f1b3", "f1b3","showGuides", the long id of me
    
    set the navigationDisplayStyle of me to "names"
    resizeStack
+   hiliteFrameItem "api"
+   showAPIs
+   unlock screen
 end openStack
 
 on resizeStack
@@ -23,13 +24,13 @@ on resizeStack
 end resizeStack
 
 on showAPIs
-   setUrl "file:" & revIDESpecialFolderPath("documentation") & slash & "html_viewer" & slash & "viewer.html"
    put "api" into sTab
+   setUrl "file:" & revIDESpecialFolderPath("documentation") & slash & "html_viewer" & slash & "viewer.html"
 end showAPIs
 
 on showGuides
-   setUrl "file:" & revIDESpecialFolderPath("documentation") & slash & "html_viewer" & slash & "guide.html"
    put "guide" into sTab
+   setUrl "file:" & revIDESpecialFolderPath("documentation") & slash & "html_viewer" & slash & "guide.html"
 end showGuides
 
 on showPreview
@@ -67,5 +68,16 @@ on closeStack
 end closeStack
 
 on browserNavigateComplete
-
+   revBrowserAddJavaScriptHandler sBrowserID, "fetchData"
 end browserNavigateComplete
+
+on fetchData
+   send "setData" to me in 0 millisecs
+end fetchData
+
+on setData
+   local tJSONDataPath
+   put revIDESpecialFolderPath("documentation cache") & slash & "built_" & sTab & ".js" into tJSONDataPath
+   get revBrowserCallScript(sBrowserID, "setData", textDecode(url("binfile:" & tJSONDataPath), "utf-8"))
+   revBrowserRemoveJavaScriptHandler sBrowserID, "fetchData"
+end setData


### PR DESCRIPTION
Build dictionary data in per-user application data folder. This allows the on-the-fly creation of the dictionary data, so that all and only installed widget APIs appear in the docs. 

Currently there are issues with getting the data to appear consistently, due to the timing of the registration of the liveCode object in the current JavaScript context.

The following _sometimes_ works:

```
on browserNavigateComplete
  revBrowserAddJavaScriptHandler sBrowserID, "fetchData"
end browserNavigateComplete
```

but not nearly often enough. When it fails, the dictionary appears broken and 

```
[0722/142754:INFO:CONSOLE(150)] "Uncaught ReferenceError: liveCode is not defined", source: file:///Users/alilloyd/Documents/GitHub/refactor/ide/Documentation/html_viewer/guide.html (150)
```

appears in the logs. Obviously we need this to work every time if this approach is to be used.
