### PR TITLE
revdebuggerlibrary: More aggressively filter problematic var names

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -237,16 +237,22 @@ function revDebuggerGlobalNames
 end revDebuggerGlobalNames
 
 # Returns
-#   A list of the globals with valid names. I.e not the ones with (x86) in them on Vista 64bit.
+# A list of the globals with valid names. I.e not the ones with
+# special characters in them.
 function revDebuggerValidGlobalNames
    local tGlobalsRaw
    put the globals into tGlobalsRaw
    
    replace comma with return in tGlobalsRaw
    
-   # For now we just filter out the Vista 64 bit ones. Really we should remove anything that is not a valid Rev identifier
-   # according to lextable.cpp, but that can easily be added in later as this is the only place in the IDE this is done.
-   filter tGlobalsRaw without "*(x86)"
+   # For now we just filter out characters that are known to cause
+   # problems (especially because environment variables can have
+   # arbitrary names). Really we should remove anything that is not a
+   # valid Rev identifier according to lextable.cpp, but that can
+   # easily be added in later as this is the only place in the IDE
+   # this is done.
+   filter tGlobalsRaw without "*(*"
+   filter tGlobalsRaw without "*)*"
    filter tGlobalsRaw without "*/*"
    filter tGlobalsRaw without "*-*"
    


### PR DESCRIPTION
On Linux systems, environment variables are just nul-terminated
strings, and only by convention have the format `name=value`.  This
means that variable names obtained from the environment (i.e. global
`$name` variables) may contain special characters, especially `(` and
`)`.  When environment variable names with special characters are
encountered, it causes subtle debugger breakage which usually
manifests itself as "the message box doesn't work".

@runrevmark originally suggested fixing this problem by filtering out
_all_ variables beginning with `$` at this step.  However, that seemed
like a bit of a blunt instrument, since it may actually be useful to
examine environment variables that might be affecting the behaviour of
the program -- and it's hard to do that in the absence of a `the
environmentVariables` syntax or equivalent (analogous to the
recently-added `the commandArguments` syntax).
