### PR TITLE
[env-vars] Make revDebuggerValidGlobalNames into a no-op.

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -237,22 +237,12 @@ function revDebuggerGlobalNames
 end revDebuggerGlobalNames
 
 # Returns
-#   A list of the globals with valid names. I.e not the ones with (x86) in them on Vista 64bit.
+#   A list of the globals with valid names.
+#
+# FIXME this function is no longer required; all globals now contain
+# valid names.
 function revDebuggerValidGlobalNames
-   local tGlobalsRaw
-   put the globals into tGlobalsRaw
-   
-   replace comma with return in tGlobalsRaw
-   
-   # For now we just filter out the Vista 64 bit ones. Really we should remove anything that is not a valid Rev identifier
-   # according to lextable.cpp, but that can easily be added in later as this is the only place in the IDE this is done.
-   filter tGlobalsRaw without "*(x86)"
-   filter tGlobalsRaw without "*/*"
-   filter tGlobalsRaw without "*-*"
-   
-   replace return with comma in tGlobalsRaw
-   
-   return tGlobalsRaw
+   return the globals
 end revDebuggerValidGlobalNames
 
 # Parameters


### PR DESCRIPTION
Since runrev/livecode#2716 has been merged, the constraints on naming
of `$<name>` global variables are much tighter.  The filtering that
`revDebuggerValidGlobalNames` does is no longer required.

However, because the function is used elsewhere (in particular, in the
script editor's variables inspector pane), it can't be removed
entirely.
