### PR TITLE
revRuggedID fails on creating new stack

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -2172,11 +2172,16 @@ function revRuggedId pObject
    # MW-2008-09-08: [[ Bug 7142 ]] If the hcAddressing of the stack is true, then the long id
    #    is in a different form than this expects. Thus we temporarily fetch it while hcAddressing
    #    is false.
-   if the hcAddressing of tStack then
-      set the hcAddressing of tStack to false
-      put the long id of pObject into tObject
-      set the hcAddressing of tStack to true
-   end if
+   # MDW-2015-08-21: [[ bugfix_revRuggedId ]] tStack is empty when creating a new stack
+   try
+	  if the hcAddressing of tStack then
+		 set the hcAddressing of tStack to false
+		 put the long id of pObject into tObject
+		 set the hcAddressing of tStack to true
+	  end if
+   catch e
+      -- ignore the error and carry on
+   end try
    
    local tType
    put word 1 of tObject into tType

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -2132,6 +2132,10 @@ function revRuggedId pObject
       put the long id of pObject into tObject
    else
       put pObject into tObject
+      # MDW-2015-08-21: [[ bugfix_revRuggedId ]] pObject is empty when creating a new object
+      if tObject is empty then
+         put the long id of the target into tObject
+      end if
    end if
    
    # Find out what the name of the stack owning the object is. We are only interested in the 

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -2176,16 +2176,11 @@ function revRuggedId pObject
    # MW-2008-09-08: [[ Bug 7142 ]] If the hcAddressing of the stack is true, then the long id
    #    is in a different form than this expects. Thus we temporarily fetch it while hcAddressing
    #    is false.
-   # MDW-2015-08-21: [[ bugfix_revRuggedId ]] tStack is empty when creating a new stack
-   try
-	  if the hcAddressing of tStack then
-		 set the hcAddressing of tStack to false
-		 put the long id of pObject into tObject
-		 set the hcAddressing of tStack to true
-	  end if
-   catch e
-      -- ignore the error and carry on
-   end try
+	if the hcAddressing of tStack then
+		set the hcAddressing of tStack to false
+		put the long id of pObject into tObject
+		set the hcAddressing of tStack to true
+	end if
    
    local tType
    put word 1 of tObject into tType


### PR DESCRIPTION
revRuggedID in the IDE backscript library was throwing errors and getting into a tight loop when creating a new stack (enable gRevDevelopment and turn on the Message Watcher to expose and track the error). I placed the hcaddressing check in a try/catch construct to bypass the error. Note: the error is in the 6.x branch as well, but isn't nearly as destructive there.
