### PR TITLE
dictionary: Tweaks to guides, and heading levels in particular

### DIFF
--- a/Documentation/guides/HTML5 Deployment.md
+++ b/Documentation/guides/HTML5 Deployment.md
@@ -1,15 +1,12 @@
-# HTML5 Deployment
-Copyright © 2015 LiveCode Ltd.
+# Introduction
 
 **Note: This is an experimental release of HTML5 deployment support and is not recommended for production use.**
-
-## Introduction
 
 Almost every Internet-connected device has a web browser.  If your application can run in a browser, your app can be used anywhere and by anyone, without any need to download or install it.
 
 With LiveCode 8's HTML5 deployment capability, you can now run applications written in LiveCode in any web browser that supports JavaScript and HTML5.
 
-### Supported browsers
+## Supported browsers
 
 Only a limited range of browsers are supported for HTML5 deployment in this release of LiveCode.
 
@@ -19,7 +16,7 @@ Only a limited range of browsers are supported for HTML5 deployment in this rele
 
 We hope to broaden the range of supported browsers in the future.
 
-### HTML5 engine features
+## HTML5 engine features
 
 The HTML5 engine in this release of LiveCode has a limited range of features.  You can:
 
@@ -38,9 +35,9 @@ Several important features are not yet supported:
 
 The HTML5 engine is unlikely ever to support externals (including revdb).
 
-## How to deploy an app to HTML5
+# How to deploy an app to HTML5
 
-### Step by step
+## Step by step
 
 Deploying an app to an HTML5 standalone is straightforward:
 
@@ -58,7 +55,7 @@ Deploying an app to an HTML5 standalone is straightforward:
 
 Your application will be packaged up and placed in the selected output folder.
 
-### Contents of the HTML5 standalone
+## Contents of the HTML5 standalone
 
 The HTML5 standalone contains four files:
 
@@ -68,7 +65,7 @@ The HTML5 standalone contains four files:
 
 * A test HTML page.  This can be opened in a browser and will correctly prepare, download and start your HTML5 app in a convenient test environment.
 
-### Testing your HTML5 app with a local web server
+## Testing your HTML5 app with a local web server
 
 Some browsers, such as Google Chrome, do not permit pages to download resources from `file://` URLs.  You won't be able to test your application in these browsers unless you run a local HTTP server.
 
@@ -78,15 +75,15 @@ A quick and easy way to run a simple local HTTP server is to use Python.  Open a
 
 This will let you access your standalone by opening your web browser and visiting <http://localhost:8080>.
 
-## Reporting bugs
+# Reporting bugs
 
 Please report bugs to the [LiveCode Quality Centre](http://quality.runrev.com/).  Make sure to select "HTML5 Standalone" when you're creating your bug report!
 
-## Advanced: Embedding an HTML5 standalone in a web page
+# Advanced: Embedding an HTML5 standalone in a web page
 
 The default HTML5 page provided by the HTML5 standalone builder is designed for testing and debugging purposes.  However, you may want to embed the standalone engine in a more visually appealing page.  To do this, you require three elements: 1) a canvas, 2) a JavaScript `Module` object, and 3) an HTML `<script>` element that downloads the engine.
 
-### The canvas
+## The canvas
 
 The engine renders into a HTML5 `<canvas>` element.  There are three important considerations when creating the canvas:
 
@@ -100,7 +97,7 @@ The absolute minimum canvas element would look something like this:
 
     <canvas style="border: 0px none;" id="canvas" oncontextmenu="event.preventDefault();"></canvas>
 
-### The Module object
+## The Module object
 
 The top-level JavaScript `Module` object contains the parameters that control how the engine runs.  At minimum, you need only specify the `Module.canvas`, which should be your canvas element.
 
@@ -112,7 +109,7 @@ The absolute minimum `Module` object declaration would look something like:
     };
     </script>
 
-### Engine download
+## Engine download
 
 The engine is quite a large JavaScript file, so it's downloaded asynchronously in order to let the rest of the page finish loading and start being displayed.
 
@@ -122,7 +119,7 @@ Quite straightforwardly:
 
 Make sure to replace `<version>` as appropriate.
 
-### Bringing it all together
+## Bringing it all together
 
 Here's the complete skeleton web page for an HTML5 standalone:
 
@@ -138,7 +135,7 @@ Here's the complete skeleton web page for an HTML5 standalone:
     </html>
 
 
-## Advanced: Customizing the Module object
+# Advanced: Customizing the Module object
 
 There are a number of LiveCode-specific `Module` attributes that you can modify to affect how the engine behaves:
 

--- a/Documentation/guides/LiveCode Builder Style Guide.md
+++ b/Documentation/guides/LiveCode Builder Style Guide.md
@@ -1,15 +1,10 @@
-# LiveCode Builder Style Guide
-Copyright 2015 LiveCode Ltd.
-
-[TOC]
-
-## Introduction
+# Introduction
 
 This document describes best practices to be followed when working with
 LiveCode Builder source code.  Please follow it *especially* when writing code
 to be included with the main LiveCode product package.
 
-## Copyright headers
+# Copyright headers
 
 Please include a license header at the top of the `.lcb` file.
 
@@ -17,9 +12,9 @@ For the main LiveCode repository, or for any community extensions, the license
 is the [GNU General Public License v3](http://www.gnu.org/licenses) *without*
 the "any later version" clause.
 
-## Naming
+# Naming
 
-### Module name
+## Module name
 
 The module name uses reverse DNS notation.  For example, a module created by
 the Example Organisation would use module names beginning with `org.example`.
@@ -47,7 +42,7 @@ For the main LiveCode repository, please use module names beginning with
 
 Always write module names in lower case.
 
-### Naming variables and parameters
+## Naming variables and parameters
 
 Give variables and parameters `xCamelCaseNames` with a leading lowercase
 character indicating their scope and availability.
@@ -75,7 +70,7 @@ For `Boolean` variables, please try to use "yes or no" names.  For example:
     variable tIsVisible as Boolean
     variable tHasContents as Boolean
 
-### Naming handlers
+## Naming handlers
 
 Give handlers `TitleCase` names.
 
@@ -85,7 +80,7 @@ In general, please use verbs to name your handlers.  For example,
         -- ...
     end handler
 
-## Documenting the source code
+# Documenting the source code
 
 You should add in-line documentation to `syntax` and `handler` definitions in
 LiveCode Builder source code.  It is particularly important to add in-line
@@ -98,7 +93,7 @@ In-line documentation for a handler or syntax definition is extracted from a
 Please refer to the [Extending LiveCode](Extending LiveCode.md) guide for full
 details of the syntax of in-line documentation comments, including examples.
 
-## Named constants
+# Named constants
 
 Often, it is useful to use constant values in your code.  Please declare named
 constants rather than placing the values in-line.  For example, you may
@@ -115,9 +110,9 @@ want to create three tabs labelled "Things", "Stuff", and "Misc":
 
 In particular, please avoid any "magic numbers" in your code.
 
-## Whitespace
+# Whitespace
 
-### Indentation
+## Indentation
 
 Please indent with tab characters.  Please use one tab character per level of
 indentation.
@@ -145,7 +140,7 @@ For example:
 If it's necessary to mix spaces and tabs for indentation, please use 4 spaces
 per tab.
 
-### Handler declarations, definitions and calls
+## Handler declarations, definitions and calls
 
 In handler type declarations and definitions, don't insert whitespace between
 the handler name and the parameter list.  For example:

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -8111,6 +8111,7 @@ on revIDEGenerateDistributedGuide
    set the itemdelimiter to "."
    repeat for each line tFile in the files
       if tFile begins with "."  then next repeat
+      if tFile ends with "~" then next repeat
       # The name of the guide is just the filename without extension
       put item 1 to -2 of tFile into tGuideName
       get url ("binfile:" & tGuideFolder & slash & tFile)


### PR DESCRIPTION
- Ignore editor backup files when building guides
- Tweak guides to make sure initial contents list is useful
