### PR TITLE
[[ Bug 15804 ]] Add missing break to fix Reshape Graphic option from Object menu

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2453,6 +2453,7 @@ on revMenubarObjectMenuPick pWhich
    switch item 1 of pWhich
       case "Reshape Graphic"
          revIDEToggleReshapeGraphic
+         break
       case "New card"
          revIDEActionNewCard
          break


### PR DESCRIPTION
Bug 15804 - FIX: selecting "Reshape Graphic" from Object menu causes a new card to be added

missing "break" causes new card to be created.

Bernd Niggemann
