### PR TITLE
[livecode-ide][[Bug 15347]] resizeHandles visible for Reshape of graphic

### DIFF
--- a/Toolset/libraries/revreshapelibrary.livecodescript
+++ b/Toolset/libraries/revreshapelibrary.livecodescript
@@ -198,8 +198,9 @@ on revSetMarkers pRemove
       set the borderColor of l to the accentColor
       set the markerColor of l to black
       set markerDrawn of l to true
-      set the markerPoints of l to the revMarkerPoints of stack "revReshapeLibrary"
-      --set markerPoints of l to -3,-3&cr& 3,-3&cr& 3,3&cr& -3,3&cr& -3,-3
+      set the markerPoints of l to "0,-3" & cr & "2,-2" & cr & "3,0" & cr & \
+               "2,2" & cr & "0,3" & cr & "-2,2" & cr & \
+               "-3,0" & cr & "-2,-2" & cr & "0,-3"
       put l & cr after gREVObjectsList
     end repeat
   end if


### PR DESCRIPTION
markerPoints were not visible because of reference to a customproperty of stack revreshapelibrary that does not exist after it turned into a script only stack. Blocked square markers were replaced by usual round markers
