### PR TITLE
[[ Bug 15801 ]] Ensure tools palette opens with all chosen tools and without flicker

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1358,10 +1358,16 @@ end revInternal__InitialiseErrors
 command revInternal__InitialiseTools
   revInternal__Log "Enter", "Tools Initialisation"
   
-  set the topLeft of stack "revTools" to the cToolsTopLeft of stack "revPreferences"
-  palette "revTools"
-  choose pointer tool
+  local tToolsStackName
+  put revIDEPaletteToStackName("Tools") into tToolsStackName
   
+  lock screen
+  send "preOpenStack" to stack tToolsStackName
+  set the topLeft of stack tToolsStackName to the cToolsTopLeft of stack "revPreferences"
+  palette stack tToolsStackName
+  
+  choose pointer tool
+  unlock screen
   --revInternal__ConstrainStack "revTools"  
   
   revInternal__Log "Leave", "Tools Initialisation"

--- a/notes/bugfix-15801.md
+++ b/notes/bugfix-15801.md
@@ -1,0 +1,1 @@
+# The tool palette was empty (except for the run/design choices)


### PR DESCRIPTION
Setting the topLeft of stack "revTools" before paletting it was causing the resizeStack handler of revTools to run, which was regenerating the stack before the default tools visibility settings are set (in the preOpenStack handler)

Switching the order of these (and using various other solutions) seems to cause a flicker. So sending "preOpenStack" under lock screen causes the necessary initialisation to happen without a flicker.
