### PR TITLE
[[ Docs ]] Docs parser not necessarily in the message path at point of rebuilding

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7990,7 +7990,8 @@ private function revIDEGetDocsAPIData
       if tLastModified > tLastGenerated then
          # Generate the docs text in lcdoc format 
          local tDoc
-         put revDocsGenerateDocsFileFromModularFile(tFolder & slash & tSource) into tDoc
+         dispatch function "revDocsGenerateDocsFileFromModularFile" to stack "revDocsParser" with tFolder & slash & tSource
+         put the result into tDoc
          
          # Output the lcdoc file
          put textEncode(tDoc, "utf-8") into url ("binfile:" & tFolder & slash & "api.lcdoc")


### PR DESCRIPTION
Found it!

(https://github.com/runrev/livecode-ide/pull/438)
