### PR TITLE
[[ Bug 15854 ]] Set the defaultStack before executing the "stop editing" command

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6919,6 +6919,8 @@ on revIDEEditGroup pGroup
 end revIDEEditGroup
 
 on revIDEStopEditingGroup
+   # TS-2015-09-02: [[ Bug 15854 ]] Set the defaultStack before executing the "stop editing" command.
+   set the defaultStack to the topStack
    stop editing
 end revIDEStopEditingGroup
 

--- a/notes/bugfix-15854.md
+++ b/notes/bugfix-15854.md
@@ -1,0 +1,1 @@
+# Stop Editing Group menu item doesn't work in LC8


### PR DESCRIPTION
Bug report submitted:  http://quality.runrev.com/show_bug.cgi?id=15854
