### PR TITLE
[[ Dictionary ]] Interpret param descriptions as markdown

### DIFF
--- a/Documentation/html_viewer/css/lcdoc.css
+++ b/Documentation/html_viewer/css/lcdoc.css
@@ -68,6 +68,7 @@
 #lcdoc_body table{ border: 1px solid #cccccc; width:100%; margin-bottom:10px}
 #lcdoc_body table thead{ border-bottom: 2px solid #cccccc;}
 #lcdoc_body table td{ border: 1px solid #cccccc; padding:5px;}
+#lcdoc_body table td p{ margin-bottom:0px;}
 
 #lcdoc_body .lcdoc_glossary_table td{width:37%}
 #lcdoc_body .lcdoc_glossary_table td:first-of-type{width:26%}

--- a/Documentation/html_viewer/viewer.html
+++ b/Documentation/html_viewer/viewer.html
@@ -409,7 +409,7 @@
 									tHTML += '<tr><td class="lcdoc_entry_param">'+value2.name+'</td><td>'+value2.type+'</td><td>'+parameterFormatValue("enum", value2),tEntryObject+'</td></tr>';
 									break;
 								default:
-									tHTML += '<tr><td class="lcdoc_entry_param">'+value2.name+'</td><td>'+replace_link_placeholders_with_links(value2.type,tEntryObject)+'</td><td>'+replace_link_placeholders_with_links(value2.description,tEntryObject)+'</td></tr>';
+									tHTML += '<tr><td class="lcdoc_entry_param">'+value2.name+'</td><td>'+replace_link_placeholders_with_links(value2.type,tEntryObject)+'</td><td>'+marked(replace_link_placeholders_with_links(value2.description,tEntryObject))+'</td></tr>';
 									break;
 							}
 						});


### PR DESCRIPTION
This allows markdown to be used in the description column of the parameter table.

The css tweak is to remove a bottom margin added by marked.js
