### PR TITLE
[[ Bug 16000 ]] Don't allow lingering revNewButton message after IDE startup

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -689,7 +689,7 @@ end newGroup
 
 
 on newButton
-  send "revNewButton the long id of the target" to me in 50 milliseconds
+  revNewButton the long id of the target
   revUpdateAOControls
   if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass newButton
 end newButton

--- a/notes/bugfix-16000.md
+++ b/notes/bugfix-16000.md
@@ -1,0 +1,1 @@
+# Tools palette is reloaded after being replaced by plugin


### PR DESCRIPTION
Since the revTools stack is script-only and creates buttons, it was triggering the newButton message, which in turn was queuing 'revNewButton' in the pendingmessages.

The long id of the target includes the full path to the IDE tools stack.

Therefore when a plugin (eg PowerTools) tries to replace the tools palette, this lingering message causes the IDE tools palette to be loaded into memory again, causing a naming conflict.
