### PR TITLE
[[ Bug 16016 ]] Ensure script editor retains position, including on second monitor

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1255,16 +1255,9 @@ on preOpenStack
    local tTargetStack
    put revIDEStackOfObject(the long id of the target) into tTargetStack
    
-   if revIDEStackIsIDEStack(tTargetStack) then
-      --sanity check inside screen
-      if the bottom of stack tTargetStack > item 4 of the windowBoundingRect
-      then set the bottom of stack tTargetStack to item 4 of the windowBoundingRect
-      if the top of stack tTargetStack < item 2 of the windowBoundingRect
-      then set the top of stack tTargetStack to item 2 of the windowBoundingRect
-      if the right of stack tTargetStack > item 3 of the windowBoundingRect
-      then set the right of stack tTargetStack to item 3 of the windowBoundingRect
-      if the left of stack tTargetStack < item 1 of the windowBoundingRect
-      then set the left of stack tTargetStack to item 1 of the windowBoundingRect
+   if revIDEStackIsIDEStack(tTargetStack) then   
+      # AL-2015-09-15: [[ Bug 15745 ]] Ensure palettes don't get placed off screen
+      revIDEEnsureOnScreen the short name of tTargetStack
    end if
    unlock screen
    

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1478,17 +1478,7 @@ command revEditScriptInNewWindow pObject, pSpecial
    local tTemplateVisibility, tTemplateRect
    put the visible of revScriptEditorTemplate() into tTemplateVisibility
    set the visible of revScriptEditorTemplate() to false
-   
-   # OK-2009-02-05 : This appears to be redundant, but have left it in for now as this command is rather fragile
-   put the rect of revScriptEditorTemplate() into tTemplateRect
-   
-   # OK-2009-02-05 : This appears to be redundant
-   --   local tRect, tPrefname
-   --   put "rect" into tPrefname
-   --   send "revSEGetPreference tPrefname" to revScriptEditorMain()
-   --   put the result into tRect
-   --   put the tPropname of stack "revPreferences" into tRect
-   
+
    local tEditor
    lock messages
    
@@ -1516,9 +1506,7 @@ command revEditScriptInNewWindow pObject, pSpecial
    if tTemplateVisibility then
       set the visible of revScriptEditorTemplate() to true
    end if
-   
-   # OK-2009-02-05 : This appears to be redundant, but have left it in for now as this command is rather fragile
-   set the rect of revScriptEditorTemplate() to tTemplateRect
+
    unlock messages
    
    set the mainstack of tEditor to the short name of revScriptEditorMain()
@@ -1532,10 +1520,7 @@ command revEditScriptInNewWindow pObject, pSpecial
    # OK-2008-07-24 : Note the use of call instead of send here. This is important because
    # it prevents the defaultStack changing when debugging, which can potentially break
    # user code in the debugger which would have run fine otherwise.
-   local tTrueString
-   put "true" into tTrueString
-   
-   call "revSEInitialize tTrueString" to tEditor
+   call "revSEInitialize true" to tEditor
    call "revSEAddTargetObject pObject" to tEditor
    send "revGoScriptEditor tEditor" to me in 0 milliseconds
    
@@ -2245,64 +2230,6 @@ private command _revShowScriptEditorNew pStack
    modeless pStack
    revSEHidePalettes
 end _revShowScriptEditorNew
-
-on revSetScriptEditorRect pScriptEditor
-   # OK-2008-03-11 : Not sure if this is needed anymore, removed for now.
-   exit revSetScriptEditorRect
-   
-   --   local tOpenStacks
-   --   put the openStacks into tOpenStacks
-   --   filter tOpenStacks with "revScriptEditor*"
-   --   delete line lineOffset(pScriptEditor,tOpenStacks) of tOpenStacks
-   
-   --   put empty into tScriptEditorTopLefts
-   --   repeat for each line l in tOpenStacks
-   --      put the topLeft of stack l & cr after tScriptEditorTopLefts
-   --   end repeat
-   --   delete last char of tScriptEditorTopLefts
-   
-   --   --tiling
-   --   put the cScriptEditorRect of stack "revPreferences" into tRect
-   --   put item 1 to 2 of (the cScriptEditorRect of stack "revPreferences") into tTopLeft
-   --   repeat
-   --      if tTopLeft is not among the lines of tScriptEditorTopLefts then exit repeat
-   --      else 
-   --         repeat with i = 1 to 4
-   --            add 23 to item i of tRect
-   --         end repeat
-   --         put item 1 to 2 of tRect into tTopLeft
-   --      end if
-   --   end repeat
-   
-   --   --sanity check
-   --   set the rect of stack pScriptEditor to tRect
-   --   put the windowBoundingRect into tWindowBoundingRect
-   --   put item 3 of tWindowBoundingRect - item 1 of tWindowBoundingRect into tMaxX
-   --   put item 4 of tWindowBoundingRect - item 2 of tWindowBoundingRect into tMaxY
-   
-   --   lock messages
-   --   if the height of stack pScriptEditor > tMaxY
-   --   then set the height of stack pScriptEditor to tMaxY
-   --   if the width of stack pScriptEditor > tMaxX
-   --   then set the width of stack pScriptEditor to tMaxX
-   
-   --   add item 1 of tWindowBoundingRect to tMaxX
-   --   add item 2 of tWindowBoundingRect to tMaxY
-   
-   --   put the right of stack pScriptEditor into tRight
-   --   put the bottom of stack pScriptEditor into tBottom
-   
-   --   if the left of stack pScriptEditor < item 1 of tWindowBoundingRect then set the left of stack pScriptEditor to item 1 of tWindowBoundingRect
-   --   if the right of stack pScriptEditor  > tMaxX then set the right of stack pScriptEditor to tMaxX
-   --   if the top of stack pScriptEditor < item 2 of tWindowBoundingRect then set the top of stack pScriptEditor to item 2 of tWindowBoundingRect
-   --   if the bottom of stack pScriptEditor > tMaxY then set the bottom of stack pScriptEditor to tMaxY
-   
-   --   if the right of stack pScriptEditor is not tRight or the bottom of stack pScriptEditor is not tBottom then
-   --      send "resizeStack" to this cd of stack pScriptEditor
-   --   end if
-   
-   --   unlock messages
-end revSetScriptEditorRect
 
 on revUpdatePaletteStack
    global gREVStacksList

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1607,8 +1607,15 @@ command revGoScriptEditor pEditor
    # For now we work around this here by manually ensuring the editor is not flagged as edited.
    put empty into gREVStackStatus[the short name of pEditor]
    
-   set the visible of pEditor to true
+   lock screen
    toplevel pEditor
+   
+   # AL-2015-10-01: [[ Bug 16016 ]] Ensure the palette rect is set after the go command
+   #  as otherwise the engine closes and reopens the stack, resulting in it being bound 
+   #  to the windowBoundingRect (due to some very specific properties of the script editor)
+   revIDEPositionPalette the short name of pEditor
+   set the visible of pEditor to true
+   unlock screen 
    
    # OK-2008-08-18 : Bug 6935 - The script editor should be un-iconified here.
    if the iconic of pEditor then

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3651,6 +3651,10 @@ on revIDEPositionPalette pStackName
             set the rect of stack pStackName to tRect
             break
          default 
+            if pStackName begins with revIDEScriptEditorPrefix() then
+               set the rect of stack pStackName to tRect
+               break
+            end if
             # If we don't restore the position for this palette then position the stack in the default location
             revIDEPositionPaletteDefault pStackName
             break

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3613,14 +3613,14 @@ on revIDEEnsureOnscreen pStackName
    put item 4 of tScreenRect - item 2 of tScreenRect into tScreenHeight
    put item 3 of tScreenRect - item 1 of tScreenRect into tScreenWidth
    
-   if the left of stack pStackName < 0 then
-      set the left of stack pStackName to 0
+   if the left of stack pStackName < item 1 of tScreenRect then
+      set the left of stack pStackName to item 1 of tScreenRect
    else if the right of stack pStackName > item 3 of tScreenRect and the width of stack pStackName < tScreenWidth then
       set the right of stack pStackName to item 3 of tScreenRect
    end if
    
-   if the top of stack pStackName < 0 then
-      set the top of stack pStackName to 0
+   if the top of stack pStackName < item 2 of tScreenRect then
+      set the top of stack pStackName to item 2 of tScreenRect
    else if the bottom of stack pStackName > item 4 of tScreenRect and the height of stack pStackName < tScreenHeight then
       set the bottom of stack pStackName to item 4 of tScreenRect
    end if

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2856,7 +2856,6 @@ on revIDEEditScriptOfObject pObject
    local tExistingEditor
    put revScriptEditor(tObject) into tExistingEditor
    if tExistingEditor is not empty then
-      revGoScriptEditor the long id of stack tExistingEditor
       send "revSESetCurrentObject tObject" to stack tExistingEditor
       exit revIDEEditScriptOfObject
    end if

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -2454,14 +2454,14 @@ end binaryEquals
 #   then sends a "resize" message to each object to allow the object to resize its controls
 #   appropriately to its new size.
 on resizeStack
+   revIDEStorePaletteRect the short name of me
    actionResizeStack
-   sePrefSet "rect", the rect of me
 end resizeStack
 
 # Description
 #    Sent when the script editor is moved. Saves the new size in the preferences.
 on moveStack
-   sePrefSet "rect", the rect of me
+   revIDEStorePaletteRect the short name of me
 end moveStack
 
 # Description
@@ -2566,7 +2566,6 @@ command revSEInitialize pDontCheckTarget
       set the backgroundColor of me to "236,236,236"
    end if
    
-   set the rect of me to sePrefGet("rect")
    actionResizeStack true
 end revSEInitialize
   

--- a/notes/bugfix-16016.md
+++ b/notes/bugfix-16016.md
@@ -1,0 +1,1 @@
+# Script editor doesn't remember where it was placed


### PR DESCRIPTION
- Cleanup various bits of unused code
- Use new IDE handlers for rect storage
- Set script editor rect _after_ go command
- Ensure all rect-constraining functions take current screen into account
