### PR TITLE
[[ bug 16071 ]] Menupick in Object menu was calling the wrong functio…

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2526,7 +2526,7 @@ on revMenubarObjectMenuPick pWhich
          revIDEActionBringToFront
          break
       case "Group Selected"
-         revIDEActionGroup
+         revIDEActionGroupObjects
          break
       case "Edit Group"
          revIDEActionEditGroup

--- a/notes/bugfix-16071.md
+++ b/notes/bugfix-16071.md
@@ -1,0 +1,1 @@
+# Group controls not working from menu or shortcuts


### PR DESCRIPTION
…n, changed to call revIDEActionGroupObjects.
