### PR TITLE
[[ Bug 16111 ]] RevSaveAs: build the path using the stack's filename,…

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -964,7 +964,8 @@ on revSaveAs pShortName, pSubstackOnly
       end if
    end if
    
-   put revFixPath(pShortName) into tStackName
+   // revFixPath expects to get the actual filename, not the stack's short name
+   put revFixPath(the filename of stack pShortName) into tStackName
    
    // MM-2012-03-09: Added new 5.5 stack file format to drop down.
    local tType

--- a/notes/bugfix-16111.md
+++ b/notes/bugfix-16111.md
@@ -1,0 +1,1 @@
+# Save As dialog always opens in a folder deep in LiveCode's app bundle


### PR DESCRIPTION
… not it's stack name
