### PR TITLE
[[ Bug 16065 ]] Restore appearance of menubar on windows and linux

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -467,6 +467,7 @@ on generateMenuGroup
    set the threed of the templatebutton to true
    set the showborder of the templatebutton to true
    set the borderwidth of the templatebutton to 2
+   set the showname of the templatebutton to false
    
    if the platform is "Linux" then 
       create button "Divider" in group "revMenuBar"
@@ -554,7 +555,7 @@ on layoutMenu
    set the height of group "revMenuBar" of me to 26
    set the width of group "revMenuBar" of me to the width of me
    set the topleft of group "revMenuBar" of me to 0,0
-   set the rect of button "Divider" of group "revMenuBar" of me to "0,24," & tLeft + 10 & ",25"
+   set the rect of button "Divider" of group "revMenuBar" of me to "0,24," & tLeft + 10 & ",26"
    set the topleft of me to tTopLeft
    unlock messages
    

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -459,10 +459,20 @@ on generateMenuGroup
    if the platform is not "macos" then
       show group "revMenuBar" of me
    end if
+   set the menubar of me to "revMenuBar"
    
-   create graphic "Divider" in group "revMenuBar"
-   set the style of it to "line"
+   reset the templatebutton
+   set the style of the templatebutton to "rectangle"
+   set the height of the templatebutton to 2
+   set the threed of the templatebutton to true
+   set the showborder of the templatebutton to true
+   set the borderwidth of the templatebutton to 2
    
+   if the platform is "Linux" then 
+      create button "Divider" in group "revMenuBar"
+   else
+      create invisible button "Divider" in group "revMenuBar"
+   end if
    reset the templatebutton
    unlock messages
 end generateMenuGroup
@@ -544,7 +554,7 @@ on layoutMenu
    set the height of group "revMenuBar" of me to 26
    set the width of group "revMenuBar" of me to the width of me
    set the topleft of group "revMenuBar" of me to 0,0
-   set the points of graphic "Divider" of group "revMenuBar" of me to "0,24" & return & tLeft + 10 & ",24" & return
+   set the rect of button "Divider" of group "revMenuBar" of me to "0,24," & tLeft + 10 & ",25"
    set the topleft of me to tTopLeft
    unlock messages
    

--- a/notes/bugfix-16065.md
+++ b/notes/bugfix-16065.md
@@ -1,0 +1,1 @@
+# Windows menu bar appearance incorrect 


### PR DESCRIPTION
- Windows menubar appearance is restored by setting the menubar property of the revMenuBar stack.
- Linux menubar appearance is restored by the above and using a button for the divider.
