### PR TITLE
[[ Bug 16127 ]] Make Edit Group button stop the group edition mode

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6959,6 +6959,7 @@ on revIDEActionEditGroup
 end revIDEActionEditGroup
 
 on revIDEEditGroup pGroup
+   set the defaultStack to the topStack
    if word 1 of pGroup is "group" then
       if revMenuManagerGroup(pGroup) then
          answer error "Can't edit group that is in use by the Menu Manager.  To edit this group close the Menu Manager."

--- a/notes/bugfix-16127.md
+++ b/notes/bugfix-16127.md
@@ -1,0 +1,1 @@
+# Edit Group button does not "Stop Editing Group"


### PR DESCRIPTION
revIDEEditGroup in revidelibrary was not setting the defaultStack to the topStack,
as it was previously done in 7.
