### PR TITLE
[[ bug 16144 ]] Dictionary title bar showing off screen on opening

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3618,8 +3618,8 @@ on revIDEEnsureOnscreen pStackName
       set the right of stack pStackName to item 3 of tScreenRect
    end if
    
-   if the top of stack pStackName < item 2 of tScreenRect then
-      set the top of stack pStackName to item 2 of tScreenRect
+   if the effective top of stack pStackName < item 2 of tScreenRect then
+      set the top of stack pStackName to (item 2 of tScreenRect + 30)
    else if the bottom of stack pStackName > item 4 of tScreenRect and the height of stack pStackName < tScreenHeight then
       set the bottom of stack pStackName to item 4 of tScreenRect
    end if

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3619,7 +3619,7 @@ on revIDEEnsureOnscreen pStackName
    end if
    
    if the effective top of stack pStackName < item 2 of tScreenRect then
-      set the top of stack pStackName to (item 2 of tScreenRect + 30)
+      set the top of stack pStackName to (item 2 of tScreenRect + abs(the top of stack pStackName - the effective top of stack pStackName))
    else if the bottom of stack pStackName > item 4 of tScreenRect and the height of stack pStackName < tScreenHeight then
       set the bottom of stack pStackName to item 4 of tScreenRect
    end if

--- a/notes/bugfix-16144.md
+++ b/notes/bugfix-16144.md
@@ -1,0 +1,1 @@
+# Title bar of Dictionary can appear off screen on opening


### PR DESCRIPTION
Changed the revIDEEnsureOnScreen handler to check the effective top of the stack.
