### PR TITLE
[[ Bug 16176 ]] Make inspector respect language names preference

### DIFF
--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -335,9 +335,6 @@ on inspectorGenerateGroups pGroupList
       local tName
       put the short name of group tElement["label"] of me into tName
       if exists(group tElement["label"] of me) then
-         if tElement["label"] is not tElement["subsection"] then
-            set the rowLabel of group tElement["label"] of me to tElement["label"]
-         end if
          local tPropList, tProperty
          repeat with y = 1 to the number of elements in tElement["proplist"]
             put tElement["proplist"][y] into tProperty
@@ -352,8 +349,21 @@ on inspectorGenerateGroups pGroupList
             end if
          end repeat
          
-         # Set the tooltip for the row
-         set the rowTooltip of group tElement["label"] of me to tPropList
+         # Set the tooltip and label for the row according to 'language names' pref
+         global gRevLanguageNames
+         local tTooltip, tLabel
+         if gRevLanguageNames then
+            put tPropList into tLabel
+            put tElement["label"] into tTooltip
+         else
+            put tPropList into tTooltip
+            put tElement["label"] into tLabel
+         end if
+         
+         set the rowTooltip of group tElement["label"] of me to tTooltip
+         if tElement["label"] is not tElement["subsection"] then
+            set the rowLabel of group tElement["label"] of me to tLabel
+         end if
       end if
       put empty into tPropList
    end repeat

--- a/Toolset/palettes/inspector/behaviors/revinspectorgroupbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectorgroupbehavior.livecodescript
@@ -93,11 +93,13 @@ on propertyDeregistor pProperty
 end propertyDeregistor
 
 # Sets the text for the row label
+constant kLabelHeight = 21
 setprop rowLabel pLabel
    local tTopLeft
    put the topleft of field "rowlabel" of me into tTopLeft
    put pLabel into field "rowlabel" of me
    set the width of field "rowlabel" of me to the formattedwidth of field "rowlabel" of me
+   set the height of field "rowlabel" of me to the number of lines in pLabel * kLabelHeight
    set the topleft of field "rowlabel" of me to tTopLeft
 end rowLabel
 

--- a/notes/bugfix-16176.md
+++ b/notes/bugfix-16176.md
@@ -1,0 +1,1 @@
+# Property Inspector not respecting Preference setting


### PR DESCRIPTION
At the moment we can't make this update 'live' without either a
hack, or changing the binary preferences gui stack - I'd rather not
do the latter until we are sure there will be no changes coming up
from 6.x/7.x

Similarly, the custom property name needs to change as `cLanguageNames`
doesn't really cut it for me as a description of the property. Also
for some reason it is a custom property set on _card_ 1 of stack
"revPreferences" instead of just the stack.

Finally, I don't see any reason for an associated and equally
non-descriptive global `gRevLanguageNames`, except because the custom
property can't be accessed by the normal API as it's set on the card.

In short, there's a lot of ways to improve this when we can.
