### PR TITLE
[[ Bug 16176 ]] Fix some issues caused by interaction between PI fixes

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5192,13 +5192,13 @@ on revIDERemoveFromMemory pStackID
    local tSubstacks
    put the subStacks of stack pStackID into tSubstacks
    
-   local tStacks
+   local tStacks 
    put tMainStack & cr & tSubstacks into tStacks
-   answer warning "Really remove the stack file" && tStackPath && "from memory?" & cr & "Any changes made since saving will be lost from the following stacks:" & cr & cr & tStacks with "Cancel" or "OK" as sheet
+   answer warning "Really remove the stack file" && pStackID && "from memory?" & cr & "Any changes made since saving will be lost from the following stacks:" & cr & cr & tStacks with "Cancel" or "OK" as sheet
    if it is "Cancel" then 
       exit revIDERemoveFromMemory
    end if
-   
+   local tStackID
    put the long id of stack tMainStack into tStackID
    
    # OK-2008-08-18: Bug 6932 - Update the script editor here as messages is locked when deleting the stack
@@ -8848,3 +8848,7 @@ function revIDERGBToNamedColor pColor
    
    return sColorsToNamesA[pColor]
 end revIDERGBToNamedColor
+
+on ideCorePropertyInspectorRefreshPropertyLabels
+   revIDEMessageSend "idePreferenceChanged:idePropertyInspector_labels"
+end ideCorePropertyInspectorRefreshPropertyLabels

--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -331,6 +331,7 @@ on inspectorGenerateGroups pGroupList
       set the name of it to tElement["label"]
       show group tElement["label"] of me
       unlock messages
+      set the rowShowLabel of group tElement["label"] of me to true
       
       local tName
       put the short name of group tElement["label"] of me into tName

--- a/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
@@ -216,3 +216,12 @@ end storedValue
 on storeProperty
    dispatch "editorStoreValue" with sPropertyInfo["property_name"], sValue
 end storeProperty
+
+getProp editorLabel
+   global gRevLanguageNames
+   if gRevLanguageNames then
+      return sPropertyInfo["property_name"]
+   else
+      return sPropertyInfo["label"]
+   end if
+end editorLabel

--- a/Toolset/palettes/inspector/behaviors/revinspectorgroupbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectorgroupbehavior.livecodescript
@@ -94,13 +94,16 @@ end propertyDeregistor
 
 # Sets the text for the row label
 constant kLabelHeight = 21
+local sShowLabel
 setprop rowLabel pLabel
-   local tTopLeft
-   put the topleft of field "rowlabel" of me into tTopLeft
    put pLabel into field "rowlabel" of me
-   set the width of field "rowlabel" of me to the formattedwidth of field "rowlabel" of me
-   set the height of field "rowlabel" of me to the number of lines in pLabel * kLabelHeight
-   set the topleft of field "rowlabel" of me to tTopLeft
+   if sShowLabel is true then
+      local tTopLeft
+      put the topleft of field "rowlabel" of me into tTopLeft
+      set the width of field "rowlabel" of me to the formattedwidth of field "rowlabel" of me
+      set the height of field "rowlabel" of me to the number of lines in pLabel * kLabelHeight
+      set the topleft of field "rowlabel" of me to tTopLeft
+   end if
 end rowLabel
 
 getProp rowLabel
@@ -108,15 +111,16 @@ getProp rowLabel
 end rowLabel
 
 setProp rowShowLabel pValue
+   put pValue into sShowLabel
    if pValue then
-      set the width of field "rowlabel" of me to the rowLabelWidth of me
+      show field "rowlabel" of me
    else
-      put empty into field "rowlabel" of me
+      hide field "rowlabel" of me
    end if
 end rowShowLabel
 
 getprop rowLabelWidth
-   if field "rowlabel" of me is not empty then
+   if sShowLabel is true then
       return the formattedwidth of field "rowlabel" of me
    else
       return 0

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.boolean.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.boolean.behavior.livecodescript
@@ -1,7 +1,7 @@
 ﻿script "com.livecode.pi.boolean.behavior"
 on editorInitialize
    set the editorMinWidth of me to 20
-   set the label of button "checkbox" of me to the rowLabel of me
+   set the label of button "checkbox" of me to the editorLabel of me
    set the rowShowLabel of me to false
 end editorInitialize
 

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -3,7 +3,7 @@ local sPropSet
 
 on editorInitialize
    put empty into sPropSet
-   put the rowLabel of me into field "rowlabel" of me
+   put the editorLabel of me into field "rowlabel" of me
    set the rowShowLabel of me to false
    set the label of button "customPropertySet" of group "Set buttons" of me to "customKeys"
    set the editorMinWidth of me to 250

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.datagrid.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.datagrid.behavior.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "com.livecode.pi.datagrid.behavior"
 on editorInitialize
-   put the rowLabel of me into field "rowlabel" of me
+   put the editorLabel of me into field "rowlabel" of me
    set the rowShowLabel of me to false
    set the editorMinWidth of me to 200
    set the editorMaxWidth of me to 0


### PR DESCRIPTION
Namely, the fix for bug 16176 delayed the setting of the rowLabel until after
the property was registered with the editor. This fixes that by assigning the
editor label properly. Also tidied up the showing of the rowLabel, hiding the
field instead of emptying it.
