### PR TITLE
[[ Bug 16281 ]] If msg box string looks like a command, try to execute it

### DIFF
--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -550,6 +550,14 @@ command revIDEExecuteScript pScript
    if lSelectedCard is "Single Line" then put empty into field "auto complete" of card lSelectedCard of me
    if pScript is empty then exit revIDEExecuteScript
    
+   # Try executing as a command first
+   if word 1 of pScript is among the lines of the commandNames then
+      revIDEDoMessage pScript
+      if the result is empty then
+         return pScript
+      end if
+   end if
+   
    local tIntelligenceObject
    put the cREVIntelligenceObject of me into tIntelligenceObject
    

--- a/notes/bugfix-16281.md
+++ b/notes/bugfix-16281.md
@@ -1,0 +1,1 @@
+# msg box confuses command "hilite" with property "hilite"


### PR DESCRIPTION
Engine commands should have taken precedence over other interpretations of
the message box string.

We _really_ need to work out using library stacks in the lcs test system
and write tests to ensure the message box does what is expected.
