### PR TITLE
[Tests] Make messagebox TestSetup handler use revised API

### DIFF
--- a/tests/messagebox/messageboxstackbehavior.livecodescript
+++ b/tests/messagebox/messageboxstackbehavior.livecodescript
@@ -18,7 +18,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestSetup
    local tMBoxStackBehavior
-   put IDERepositoryPath() & "/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript" into tMBoxStackBehavior
+   put TestGetIDERepositoryPath() & "/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript" into tMBoxStackBehavior
    start using stack tMBoxStackBehavior
 end TestSetup
 


### PR DESCRIPTION
The test library was changed since commit 6e1f2eff1c99 so that the
path-related helper functions now also start with "Test".
