### PR TITLE
[Bug 16304] Make sure screen is not locked when deleting text using visual effects

### DIFF
--- a/Toolset/libraries/revfrontscriptlibrary.livecodescript
+++ b/Toolset/libraries/revfrontscriptlibrary.livecodescript
@@ -853,15 +853,28 @@ end revCheckDelete
 
 on backspaceKey
    lock screen
-   if revCheckDelete() then if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass backspaceKey
-   else pass backSpaceKey to metaCard
+   if revCheckDelete() then 
+      if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then 
+         --PM-2015-10-30: [[ Bug 16304 ]] Balance lock screen
+         unlock screen
+         pass backspaceKey
+      end if
+   else 
+      pass backSpaceKey to metaCard
+   end if
    unlock screen
 end backspaceKey
 
 on deleteKey
    lock screen
-   if revCheckDelete() then if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass deleteKey
-   else pass deleteKey to metaCard
+   if revCheckDelete() then 
+      if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then 
+         unlock screen
+         pass deleteKey
+      end if
+   else 
+      pass deleteKey to metaCard
+   end if
    unlock screen
 end deleteKey
 

--- a/notes/bugfix-16304.md
+++ b/notes/bugfix-16304.md
@@ -1,0 +1,1 @@
+#  Visual effect broken on textChanged


### PR DESCRIPTION
The `backspaceKey` and `deleteKey` handlers in revfrontscriptlibrary had an unbalanced `lock screen` command. This resulted in the screen being locked when deleting text using visual effects, thus the visual effect was not visible. 
