### PR TITLE
[[ PI ]] Fix bugs when multiple objects are selected

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -107,16 +107,28 @@ function revIDEExtensionProperties pTypeID
    return sExtensionProperties[pTypeID]
 end revIDEExtensionProperties
 
-function revIDEExtensionPropertiesInfo pTypeId
-   local tPropsA, tPropInfoA
+function revIDEExtensionPropertiesInfo pTypeId, pOrganise
+   local tPropsA, tExtensionPropsInfoA
    put revIDEExtensionProperties(pTypeId) into tPropsA
    
-   repeat for each key tProp in tPropsA
-      put tPropsA[tProp] into tPropInfoA[tPropsA[tProp]["section"]]["grouplist"][tPropsA[tProp]["label"]]["proplist"][tProp]
-      put tPropsA[tProp]["widget_prop"] into tPropInfoA[tPropsA[tProp]["section"]]["grouplist"][tPropsA[tProp]["label"]]["widget_prop"]
-      put tPropsA[tProp]["order"] into tPropInfoA[tPropsA[tProp]["section"]]["grouplist"][tPropsA[tProp]["label"]]["order"]
-   end repeat
-   return tPropInfoA
+   if pOrganise then
+      # If pOrganise is true, organise the property info into the structure that the property 
+      #  inspector expects, namely [<section>]["grouplist"][<group>]["proplist"][<prop>]
+      repeat for each key tProp in tPropsA
+         local tSection, tGroup, tOrder, tPropInfoA
+         put tPropsA[tProp] into tPropInfoA
+         put tPropsA[tProp]["order"] into tOrder
+         put tPropsA[tProp]["label"] into tGroup
+         put tPropsA[tProp]["section"] into tSection
+         put tPropInfoA into tExtensionPropsInfoA[tSection]["grouplist"][tGroup]["proplist"][tProp]
+         
+         put true into tExtensionPropsInfoA[tSection]["grouplist"][tGroup]["widget_prop"]
+         put tOrder into tExtensionPropsInfoA[tSection]["grouplist"][tGroup]["order"]
+      end repeat
+   else
+      put tPropsA into tExtensionPropsInfoA
+   end if
+   return tExtensionPropsInfoA
 end revIDEExtensionPropertiesInfo
 
 function revIDEExtensionProperty pKind, pProperty

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -616,60 +616,48 @@ private function __orderPropArray pPropsA, pSections
    return tOrderedPropsA
 end __orderPropArray
 
-private function __objectPropertiesShared pObjectTypeList, pOptionalSection
+private function __objectPropertiesInfo pObjectType, pOrganiseInSections, pOptionalSection
+   local tPropertiesArray, tClassicObjectType
+   if not (pObjectType begins with "com.livecode.interface.classic") then
+      # This is not a classic object, so fetch the 'extension' properties.
+      put revIDEExtensionPropertiesInfo(pObjectType, pOrganiseInSections) into tPropertiesArray
+      # Currently this must be a widget, so get the universal widget property info 
+      # that has been parsed from the definitions file
+      put "com.livecode.interface.classic.widget" into tClassicObjectType
+   else
+      put pObjectType into tClassicObjectType
+   end if
+   
+   if pOrganiseInSections then
+      # Add the object properties for this object type
+      union tPropertiesArray with sClassicObjectPropertiesInfo[tClassicObjectType] recursively
+      # Restrict to group, if present
+      if pOptionalSection is not empty then
+         local tSectionProps
+         put tPropertiesArray[pOptionalSection] into tSectionProps[pOptionalSection]
+         put tSectionProps into tPropertiesArray
+      end if
+   else
+      union tPropertiesArray with sClassicObjectProperties[tClassicObjectType] recursively
+   end if
+   return tPropertiesArray
+end __objectPropertiesInfo
+
+private function __objectPropertiesShared pObjectTypeList, pOrganiseInSections, pOptionalSection
    local tPropertiesArray,tPropertiesArray2, tPropertiesArray3,x, tSectionProps, tAllControls
-   put 1 into x
    put true into tAllControls
-   set the itemdelimiter to "."
+
    repeat for each line tObjectType in pObjectTypeList
+      set the itemdelimiter to "."
       get item -1 of tObjectType
       if it is "Card" or it is "Stack" then
          put false into tAllControls  
       end if
-      
-      if tObjectType begins with "com.livecode.interface.classic" then
-         # Classic control
-         if x is 1 then
-            put sClassicObjectPropertiesInfo[tObjectType] into tPropertiesArray
-            # Restrict to group, if present
-            if pOptionalSection is not empty then
-               if tPropertiesArray[pOptionalSection] is not empty then
-                  put tPropertiesArray[pOptionalSection] into tSectionProps[pOptionalSection]
-                  put tSectionProps into tPropertiesArray
-               else
-                  put empty into tPropertiesArray
-               end if
-            end if
-            
-         else
-            put sClassicObjectPropertiesInfo[tObjectType] into tPropertiesArray2
-            
-            intersect tPropertiesArray with tPropertiesArray2 recursively
-         end if
+      if tPropertiesArray is empty then
+         put __objectPropertiesInfo(tObjectType, pOrganiseInSections, pOptionalSection) into tPropertiesArray
       else
-         # Widget
-         if x is 1 then
-            put revIDEExtensionPropertiesInfo(tObjectType) into tPropertiesArray
-            put sClassicObjectPropertiesInfo["com.livecode.interface.classic.widget"] into tPropertiesArray2
-            
-            union tPropertiesArray with tPropertiesArray2 recursively
-            
-            # Restrict to group, if present
-               if tPropertiesArray[pOptionalSection] is not empty then
-                  put tPropertiesArray[pOptionalSection] into tSectionProps[pOptionalSection]
-                  put tSectionProps into tPropertiesArray
-               else
-                  put empty into tPropertiesArray
-               end if
-         else
-            put revIDEExtensionPropertiesInfo(tObjectType) into tPropertiesArray2
-            put sClassicObjectPropertiesInfo["com.livecode.interface.classic.widget"] into tPropertiesArray3
-            union tPropertiesArray2 with tPropertiesArray3 recursively
-            
-            intersect tPropertiesArray with tPropertiesArray2 recursively
-         end if
+         intersect tPropertiesArray with __objectPropertiesInfo(tObjectType, pOrganiseInSections, pOptionalSection) recursively
       end if
-      add 1 to x
    end repeat
    
    if tAllControls then
@@ -1216,7 +1204,7 @@ function __readStructureOfContainer @pData
    return tControlsProcessedInContainer
 end __readStructureOfContainer
 
-function __readGroupedPropertiesOfControl pGroupsA, @pDataA
+on __readGroupedPropertiesOfControl pGroupsA, @pDataA
    local tPropMappingA, tProp
    repeat for each key tGroup in pGroupsA
       repeat for each key tProp in pGroupsA[tGroup]["proplist"]
@@ -1825,7 +1813,7 @@ function revIDEGetPropertiesOfObjects pObjects
 
    # Get this list of all the properties to read for the given type list
    local tSharedProperties
-   put __objectPropertiesShared(tObjectTypeList) into tSharedProperties
+   put __objectPropertiesShared(tObjectTypeList, true) into tSharedProperties
 
    # Generate a list of the properties we want to retreive
    local tPropertyValues
@@ -4374,7 +4362,7 @@ function __revIDEPropertiesInfoOfSection pObjectList, pSection
 
    # Return this list of all the properties to read for the given type list
    local tProperties
-   put __objectPropertiesShared(tObjectTypeList, pSection) into tProperties
+   put __objectPropertiesShared(tObjectTypeList, true, pSection) into tProperties
    
    # Include multiple object properties if required
    if the number of lines in pObjectList > 1 then
@@ -4536,7 +4524,7 @@ private function __revIDEPropertiesOfObjectsInSection pObjectList, pSectionInfoA
    # Generate a list of the properties we want to retreive
    local tPropertyValuesA
    repeat for each line tObject in pObjectList
-      dispatch function "__readGroupedPropertiesOfControl" to tObject with pSectionInfoA, tPropertyValuesA
+      dispatch "__readGroupedPropertiesOfControl" to tObject with pSectionInfoA, tPropertyValuesA
    end repeat
    return tPropertyValuesA
 end __revIDEPropertiesOfObjectsInSection

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1234,9 +1234,11 @@ on __readGroupedPropertiesOfControl pGroupsA, @pDataA
          put tDataA["effective" && tKey] into tValue
          put true into tEffective
       end if
-      put pGroupsA[tGroup]["proplist"][tKey] into pDataA[tGroup][tKey]
-      put tValue into pDataA[tGroup][tKey]["value"]
-      put tEffective into pDataA[tGroup][tKey]["effective"]
+      if pDataA[tGroup][tKey] is empty then
+         put pGroupsA[tGroup]["proplist"][tKey] into pDataA[tGroup][tKey]
+      end if
+      put tValue into pDataA[tGroup][tKey]["value"][the long id of the target]
+      put tEffective into pDataA[tGroup][tKey]["effective"][the long id of the target]
    end repeat
 end __readGroupedPropertiesOfControl
 

--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -381,7 +381,10 @@ private on inspectorNavigationGenerate
    clearFrameNavigationData
    
    # Add all the navigation elements
-   repeat for each element tSection in sDataA
+   repeat with x = 1 to the number of elements in sDataA
+      local tSection
+      put sDataA[x] into tSection
+      
       local tIcon
       dispatch function "inspectorSectionIcon" to me with tSection["label"]
       put the result into tIcon

--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -433,8 +433,10 @@ on inspectorSectionChanged pSection
 end inspectorSectionChanged
 
 on updateFocusedEditor
-   if the short name of revIDEStackOfObject(the focusedObject) is the short name of me then
-      dispatch "valueChanged" to the focusedObject
+   if revIDEStackOfObject(the focusedObject) is the long name of me then
+      # Ensure that if the text of a field was changed, the value is set when changing sections
+      # Using focus on nothing makes sure the correct message is sent (closeField / exitField)
+      focus on nothing
    end if
 end updateFocusedEditor
 

--- a/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
@@ -134,8 +134,9 @@ on clearFrameData
 end clearFrameData
 
 on clearFrameNavigationData
-   local tNewDataA, tCount
-   repeat for each element tElement in sData
+   local tNewDataA, tCount, tElement
+   repeat with x = 1 to the number of elements in sData
+      put sData[x] into tElement
       if tElement["type"] is "navigation" then
          next repeat
       end if
@@ -259,7 +260,9 @@ on generateFrame
    
    local tPreferenceMenuA, tDataA, tSelected
    # Gather the data to set on the widget(s)
-   repeat for each element tNavItem in sData
+   repeat with x = 1 to the number of elements in sData
+      local tNavItem
+      put sData[x] into tNavItem
       if tNavItem["hidden"] is true then
          next repeat
       end if

--- a/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
@@ -233,3 +233,12 @@ getProp editorLabel
       return sPropertyInfo["label"]
    end if
 end editorLabel
+
+local sConflicted
+setProp editorConflicted pValue
+   put pValue into sConflicted
+end editorConflicted
+   
+getprop editorConflicted
+   return sConflicted
+end editorConflicted

--- a/Toolset/palettes/inspector/behaviors/revinspectorgroupbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectorgroupbehavior.livecodescript
@@ -73,8 +73,27 @@ setProp rowData pData
    lock screen
    repeat for each key tProperty in pData
       if there is a group tProperty of me then
-         set the editorValue of group tProperty of me to pData[tProperty]["value"]
-         set the editorEffective of group tProperty of me to pData[tProperty]["effective"]
+         local tKeys
+         put the keys of pData[tProperty]["value"] into tKeys
+         local tConflict, tValue
+         put false into tConflict
+         repeat for each line tLine in tKeys
+            if tValue is empty then
+               put pData[tProperty]["value"][tLine] into tValue
+               next repeat
+            end if
+            if tValue is not pData[tProperty]["value"][tLine] then
+               put true into tConflict
+               exit repeat
+            end if
+         end repeat
+         if tConflict then
+            set the editorConflicted of group tProperty of me to true
+         else
+            set the editorConflicted of group tProperty of me to false
+            set the editorValue of group tProperty of me to tValue
+            set the editorEffective of group tProperty of me to pData[tProperty]["effective"][line 1 of tKeys]
+         end if
          dispatch "editorUpdate" to group tProperty of me
       end if
    end repeat


### PR DESCRIPTION
This fixes the issue whereby multiple objects have their names assigned unexpectedly when switching tabs in the property inspector.
