### PR TITLE
[[ Extension Builder ]] Make sure full path to extension file is used when launching document

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -563,7 +563,7 @@ end revIDEDeveloperExtensionUninstall
 
 on revIDEDeveloperExtensionEditScript pFolder
    local tFile
-   put __revIDEDeveloperExtensionFetchModuleInFolder(pFolder) into tFile
+   put pFolder & slash & __revIDEDeveloperExtensionFetchModuleInFolder(pFolder) into tFile
    
    # AL-2015-04-01: [[ Bug 15130 ]] First check to see if there is an existing association
    launch document tFile


### PR DESCRIPTION
Closes #635
