### PR TITLE
[[ Bug 16429 ]] Update custom props code to return 'per-object' array values

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1334,8 +1334,8 @@ private function __readControlPropertiesForDataView pList
 end __readControlPropertiesForDataView
 
 function __customPropertyData pLongID
-   local tArray, tSets, tProps
-
+   local tArray, tSets, tProps, tOldPropertySet
+   put the customPropertySet of pLongID into tOldPropertySet
    put the customPropertySets of pLongID into tSets
    if tSets is empty then
       put the customProperties of pLongID into tArray[""]--["customKeys"]
@@ -1350,9 +1350,10 @@ function __customPropertyData pLongID
       end repeat
       set the customPropertySet of pLongID to empty
    end if
+   set the customPropertySet of pLongID to tOldPropertySet
    local tDataArray
    put revIDEPropertyInfo("customProperties") into tDataArray["Custom properties"]["customProperties"]
-   put tArray into tDataArray["Custom properties"]["customProperties"]["value"]
+   put tArray into tDataArray["Custom properties"]["customProperties"]["value"][pLongID]
    return tDataArray
 end __customPropertyData
 

--- a/notes/bugfix-16429.md
+++ b/notes/bugfix-16429.md
@@ -1,0 +1,1 @@
+# Custom properties won't set in IDE 

--- a/tests/propertyinspector/customprops.livecodescript
+++ b/tests/propertyinspector/customprops.livecodescript
@@ -1,0 +1,66 @@
+﻿script "PropertyInspectorCustomProps"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetup
+   local tIDELibrary, tScript
+   put TestGetIDERepositoryPath() & "/Toolset/libraries/revidelibrary.8.livecodescript" into tIDELibrary
+   
+   -- Work around the fact that the property listener is not available in standalone mode
+   put the script of stack tIDELibrary into tScript
+   replace "_internal" with "--_internal" in tScript
+   replace "the revObjectListeners" with "empty" in tScript
+   set the script of stack tIDELibrary to tScript
+
+   insert the script of stack "revIDELibrary" into back
+   
+   create stack "home"
+   set the filename of stack "home" to (TestGetIDERepositoryPath() & "/Toolset/home-dummy.livecode")
+end TestSetup
+
+on TestBug16429
+   local tCustomPropsArray
+   put "cProp-empty" into tCustomPropsArray[""]["cProp"]
+   put "cProp-customPropSet" into tCustomPropsArray["customPropSet"]["cProp"]
+   
+   local tButtonID
+   create button
+   put the long id of it into tButtonID
+   
+   revIDECustomPropertySet tButtonID, tCustomPropsArray
+   
+   TestAssert "custom props set", the cProp of tButtonID is "cProp-empty"
+   
+   set the customPropertySet of tButtonID to "customPropSet"
+   
+   TestAssert "custom props set in custom property set", the cProp of tButtonID is "cProp-customPropSet"
+   
+   set the cProp2 of tButtonID to "cProp2-customPropSet"
+   
+   set the customPropertySet of tButtonID to empty
+   
+   set the cProp2 of tButtonID to "cProp2-empty"
+   
+   local tArray
+   put revIDECustomProperties(tButtonID) into tArray
+   
+   put "cProp2-customPropSet" into tCustomPropsArray["customPropSet"]["cProp2"]
+   put "cProp2-empty" into tCustomPropsArray[""]["cProp2"]
+   
+   TestAssert "custom props round trip", tArray["Custom properties"]["customProperties"]["value"][tButtonID] is tCustomPropsArray
+   
+end TestBug16429


### PR DESCRIPTION
The code which fetched custom properties for the property inspector hadn't
been updated to take into account the fact that it should be returned per-obejct
in order to allow for editor value conflicts.
