### PR TITLE
[[ Bug 16424 ]] Ensure geometry manager info isn't empty

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -634,7 +634,9 @@ private function __objectPropertiesInfo pObjectType, pOrganiseInSections, pOptio
       # Restrict to group, if present
       if pOptionalSection is not empty then
          local tSectionProps
-         put tPropertiesArray[pOptionalSection] into tSectionProps[pOptionalSection]
+         if tPropertiesArray[pOptionalSection] is not empty then
+            put tPropertiesArray[pOptionalSection] into tSectionProps[pOptionalSection]
+         end if
          put tSectionProps into tPropertiesArray
       end if
    else

--- a/notes/bugfix-16424.md
+++ b/notes/bugfix-16424.md
@@ -1,0 +1,1 @@
+# interobject links in geometry manager not active


### PR DESCRIPTION
The property info array for the Geometry Manager section already
contained a Geometry Manager key with an empty array, causing the
union not to add the necessary info.
