### PR TITLE
[[ Bug 16432 ]] Ensure actions occur on substacks

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2374,7 +2374,7 @@ function ideMainStackOfObject pLongID
 end ideMainStackOfObject
 
 function revIDEStackOfObject pLongID
-   return ideMainStackOfObject(pLongID)
+   return ideStackOfObject(pLongID)
 end revIDEStackOfObject
 
 on revIDEMoveControl pControl, pNewCard, pLayerNumber

--- a/notes/bugfix-16432.md
+++ b/notes/bugfix-16432.md
@@ -1,0 +1,1 @@
+# Can't create controls on substacks


### PR DESCRIPTION
Previously revIDEStackOfObject referred to the substack containing
the object, not the mainstack. This reinstates that behavior.
