### PR TITLE
[[ Bug 16433 ]] Uninstall docs after updating the extension cache

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -500,23 +500,13 @@ on __extensionUninstallDeleteFiles pExtensionID
    end if
    
    # Next step
-   send "__extensionUninstallDocs" && pExtensionID to me in 0 milliseconds
-end __extensionUninstallDeleteFiles
-
-# Remove the guide from the IDE
-on __extensionUninstallDocs pExtensionID
-   # Update progress
-   __extensionSendProgressUpdate pExtensionID, "Removing API and user guide from documentation", 80
-   
-   revIDERegenerateBuiltDictionaryData
-   
    send "__extensionUninstallUpdateCache" && pExtensionID to me in 0 milliseconds
-end __extensionUninstallDocs
+end __extensionUninstallDeleteFiles
 
 # remove from cache
 on __extensionUninstallUpdateCache pExtensionID
    # Update progress
-   __extensionSendProgressUpdate pExtensionID, "Removing extension data", 90
+   __extensionSendProgressUpdate pExtensionID, "Removing extension data", 80
    
    local tCopies
    put __extensionPropertyGet(pExtensionID, "copies") into tCopies
@@ -526,14 +516,26 @@ on __extensionUninstallUpdateCache pExtensionID
       __extensionPropertySet pExtensionID, "status", "uninstalled"
    end if
    
+   send "__extensionUninstallDocs" && pExtensionID to me in 0 milliseconds
+end __extensionUninstallUpdateCache
+
+# Remove the guide from the IDE
+on __extensionUninstallDocs pExtensionID
+   # Update progress
+   __extensionSendProgressUpdate pExtensionID, "Removing API and user guide from documentation", 90
+   
+   revIDERegenerateBuiltDictionaryData
+   
+   send "__extensionUninstallComplete" && pExtensionID to me in 0 milliseconds
+end __extensionUninstallDocs
+
+on __extensionUninstallComplete pExtensionID
    # Notify IDE uninstallation complete
    __extensionSendProgressUpdate pExtensionID, "Complete", 100
    
    # Update the IDE
    __extensionsChanged
-end __extensionUninstallUpdateCache
-
-
+end __extensionUninstallComplete
 
 ##############################
 # PRIVATE SHARED

--- a/notes/bugfix-16433.md
+++ b/notes/bugfix-16433.md
@@ -1,0 +1,1 @@
+# Error when using <Uninstall> button in Extension Builder


### PR DESCRIPTION
The extension docs use the cached install paths to find the documentation
source for installed extensions. The cache must therefore be updated before
regenerating the docs, otherwise the docs generator will try to set a default
folder that doesn't exist.
