### PR TITLE
[[ Bug ]] Icons should be default display style, if no pref set

### DIFF
--- a/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
@@ -332,10 +332,10 @@ on generateFrame
       set the isHeader of widget "header_background" of group "background" of me to true
       set the navData of widget "header_background" of group "background" of me to tHeaderNavDataA
       set the actionData of widget "header_background" of group "background" of me to tHeaderActionDataA
-      if sNavStyle is "icons" then
-         set the showNavIcons of widget "header_background" of group "background" of me to true
-      else
+      if sNavStyle is "names" then
          set the showNavIcons of widget "header_background" of group "background" of me to false
+      else
+         set the showNavIcons of widget "header_background" of group "background" of me to true
       end if
       set the selectedNavColor of widget "header_background" of group "background" of me to revIDEColor("edition_color")
    else


### PR DESCRIPTION
sNavStyle is empty if no pref is set, and if the child stack doesn't fix its style. As the message box now doesn't fix its style to allow user pref, it uses the default setting, which was labels rather than icons.
