### PR TITLE
[[ Tools ]] Make sure tools palette opens at correct size

### DIFF
--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -434,7 +434,7 @@ on layoutPalette
    
    reset the templatebutton
    
-   set the rect of me to tStackLeft, the top of me, tStackLeft+tStackWidth, the formattedheight of group "contents" of me + tHeaderHeight + the top of me
+   set the rect of me to tStackLeft, the top of me, tStackLeft+tStackWidth, tTop + the top of me
    
    ideToolChanged
    --layoutFrame


### PR DESCRIPTION
The formattedRect of group "contents" seems to be incorrect, so the tools palette opens too tall.

Using the would-be placement of the next tool icon fixes the issue.
