### PR TITLE
[[ Debugging ]] Add some lock messages that help IDE debugging

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1600,8 +1600,9 @@ command revGoScriptEditor pEditor, pPosition
    put empty into gREVStackStatus[the short name of pEditor]
    
    lock screen
+   lock messages
    toplevel pEditor
-   
+   unlock messages
    # AL-2015-10-01: [[ Bug 16016 ]] Ensure the palette rect is set after the go command
    #  as otherwise the engine closes and reopens the stack, resulting in it being bound 
    #  to the windowBoundingRect (due to some very specific properties of the script editor)

--- a/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
@@ -510,12 +510,14 @@ private command updateBreakpoints pOffset, pSelectedLine, pOldNumber, pNewNumber
       local tImage
       put getBreakpointImageId(tState) into tImage
       
+      lock messages
       copy tImage to group "Mutables" of me
       
       # Breakpoints must be given random names. We can't use the line number or tBreakpoint as the name
       # because breakpoints can be moved, allowing a situation where two could have the same name.
       set the name of it to controlRandomName()
       put the long id of it into tImage
+      unlock messages 
       
       set the cMutable of tImage to true
       set the cBreakpoint of tImage to true


### PR DESCRIPTION
We'd rather not receive messages relating to refocusing on the script
editor or creating breakpoints, as these significantly disrupt attempts
to debug certain scripts.
