### PR TITLE
[[ Geometry ]] Improve robustness of geometry setting

### DIFF
--- a/Toolset/libraries/revgeometrylibrary.livecodescript
+++ b/Toolset/libraries/revgeometrylibrary.livecodescript
@@ -1011,34 +1011,35 @@ on revCleanSetGeometry pWhichProperty, pWhatValue
 end revCleanSetGeometry
 
 on revSetGeometry pWhichProperty,pWhatValue
-  revCheckGeoDefaultStack
-  --empty card cache
-  set the cREVGeometryCache["order"] of this card of this stack to empty
-  set the cREVGeometryCache["total"] of this card of this stack to empty
-  set the customKeys["cREVGeometryCacheIDs"] of this card of this stack to empty
-  if "revCacheGeometry" is not in the pendingMessages then
-    send "revCacheGeometry true" to this cd of this stack in 50 milliseconds
-  end if
-  --determine the profile to edit 
-  local tProfileName
-  put the cREVGeneral["profile"] of lGeometryObject into tProfileName
-  if tProfileName is empty or tProfileName is the cREVGeneral["masterName"] of lGeometryObject then
-    put "Master" into tProfileName
-  end if
-  --check that some geo has been set
-  set the cREVGeometry[tProfileName] of lGeometryObject to true
-  --update expected rect
- 
-  set the cREVGeometry[tProfileName & comma & "expectedRect"] of lGeometryObject to the rect of lGeometryObject
-  --check if property contains "objectRef" and replace with milliseconds ID if so
-  if "objectRef" is in pWhichProperty and pWhatValue is not "card" and there is a control pWhatValue then
-    put the cREVGeneral["revUniqueID"] of control pWhatValue into pWhatValue
-  end if
-  --set property
-  set the cREVGeometry[tProfileName,pWhichProperty] of lGeometryObject to pWhatValue
-  --calculate relative distances if applicable
-  # if "absolute" is in pWhichProperty and pWhatValue is false then revCalculateGeometryDistances
-  revCalculateGeometryCardRank
+   local tTargetCard
+   put revIDECardOfObject(lGeometryObject) into tTargetCard
+   --empty card cache
+   set the cREVGeometryCache["order"] of tTargetCard to empty
+   set the cREVGeometryCache["total"] of tTargetCard to empty
+   set the customKeys["cREVGeometryCacheIDs"] of tTargetCard to empty
+   if "revCacheGeometry" is not in the pendingMessages then
+      send "revCacheGeometry true" to tTargetCard in 50 milliseconds
+   end if
+   --determine the profile to edit 
+   local tProfileName
+   put the cREVGeneral["profile"] of lGeometryObject into tProfileName
+   if tProfileName is empty or tProfileName is the cREVGeneral["masterName"] of lGeometryObject then
+      put "Master" into tProfileName
+   end if
+   --check that some geo has been set
+   set the cREVGeometry[tProfileName] of lGeometryObject to true
+   --update expected rect
+   
+   set the cREVGeometry[tProfileName & comma & "expectedRect"] of lGeometryObject to the rect of lGeometryObject
+   --check if property contains "objectRef" and replace with milliseconds ID if so
+   if "objectRef" is in pWhichProperty and pWhatValue is not "card" and there is a control pWhatValue then
+      put the cREVGeneral["revUniqueID"] of control pWhatValue into pWhatValue
+   end if
+   --set property
+   set the cREVGeometry[tProfileName,pWhichProperty] of lGeometryObject to pWhatValue
+   --calculate relative distances if applicable
+   # if "absolute" is in pWhichProperty and pWhatValue is false then revCalculateGeometryDistances
+   revCalculateGeometryCardRank
 end revSetGeometry
 
 function revGetGeometry pWhichValue


### PR DESCRIPTION
In particular, we no longer rely on `this card` and instead derive
the correct card reference from the geometry object.
