### PR TITLE
[[ Project Browser ]] Fix numerous issues with stacks and substacks in the project browser

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1600,8 +1600,9 @@ command revGoScriptEditor pEditor, pPosition
    put empty into gREVStackStatus[the short name of pEditor]
    
    lock screen
+   lock messages
    toplevel pEditor
-   
+   unlock messages
    # AL-2015-10-01: [[ Bug 16016 ]] Ensure the palette rect is set after the go command
    #  as otherwise the engine closes and reopens the stack, resulting in it being bound 
    #  to the windowBoundingRect (due to some very specific properties of the script editor)

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5564,6 +5564,21 @@ on revIDECloseStack pStackID, pDestroy
    end if
 end revIDECloseStack
 
+private on __ideRemoveFromMemory pStackID
+   # OK-2008-08-18: Bug 6932 - Update the script editor here as messages is locked when deleting the stack
+   revIDEHandleObjectDeleted pStackID
+   
+   local tSubstacks
+   put the subStacks of stack pStackID into tSubstacks
+   
+   lock messages -- prevent user stack saving during the close, erasing substacks
+   repeat for each line tSubStack in tSubstacks
+      close stack tSubStack
+   end repeat
+   delete stack tMainStack
+   unlock messages
+end __ideRemoveFromMemory
+
 on revIDERemoveFromMemory pStackID
    local tMainstack
    put the mainStack of stack pStackID into tMainstack
@@ -5577,22 +5592,11 @@ on revIDERemoveFromMemory pStackID
    if it is "Cancel" then 
       exit revIDERemoveFromMemory
    end if
-
-   local tStackID
-   put the long id of stack tMainStack into tStackID
    
-   # OK-2008-08-18: Bug 6932 - Update the script editor here as messages is locked when deleting the stack
-   revIDEHandleObjectDeleted the long id of stack tMainStack
-   
-   lock messages -- prevent user stack saving during the close, erasing substacks
-   repeat for each line tSubStack in tSubstacks
-      close stack tSubStack
-   end repeat
-   delete stack tMainStack
-   unlock messages
+   __ideRemoveFromMemory the long id of tMainstack
    
    # Send the 'ideDestroyStack' message
-   ideMessageSend "ideDestroyStack", tStackID
+   ideMessageSend "ideDestroyStack", pStackID
 end revIDERemoveFromMemory
 
 on revIDEActionCloseStack
@@ -5628,13 +5632,24 @@ on revIDEDeleteSubstack pSubstackID
       exit revIDEDeleteSubstack
    end if
    
-   # Detach from mainstack
-   local tStackName
-   put the short name of pSubstackID into tStackName
-   set the mainstack of pSubstackID to tStackName
-   
-   # Close and remove from memory
-   revIDECloseStack the long id of stack tStackName, true
+   if revSaveCheck(pSubstackID) is not false then
+      answer warning "Really remove the stack file" && pSubstackID && "from memory?" & cr & "Any changes made since saving will be lost" with "Cancel" or "OK" as sheet
+      if it is "Cancel" then 
+         exit revIDEDeleteSubstack
+      end if
+      
+      # Detach from mainstack
+      local tStackName
+      lock messages
+      put the short name of pSubstackID into tStackName
+      set the mainstack of pSubstackID to tStackName
+      unlock messages
+      # Close and remove from memory
+      __ideRemoveFromMemory the long id of stack tStackName
+      
+      # Send the 'ideDestroyStack' message
+      ideMessageSend "ideDestroyStack", pSubstackID
+   end if
 end revIDEDeleteSubstack
 
 /*

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2563,7 +2563,7 @@ function revIDECardPropertiesOfStack pStackID, pLevel
    repeat for each line tStackID in tSubStackIDs
       add 1 to tIndex
 
-      dispatch function "__readPropertiesOfControl" to stack tStackID with sStackPropertiesToRead, tCardArray[tIndex]
+      dispatch function "__readPropertiesOfControl" to stack tStackID of pStackID with sStackPropertiesToRead, tCardArray[tIndex]
       put "substack" into  tCardArray[tIndex]["type"]
       put "container" into  tCardArray[tIndex]["style"]
       put pLevel+1 into  tCardArray[tIndex]["level"]

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2532,7 +2532,11 @@ function revIDEStackProperties pStackID, pLevel
 
    dispatch function "__readPropertiesOfControl" to pStackID with sStackPropertiesToRead, tStackArray
    --put the result into tStackArray
-   put "stack" into tStackArray["type"]
+   if word 3 of pStackID is "of" then
+      put "substack" into tStackArray["type"]
+   else
+      put "stack" into tStackArray["type"]
+   end if
    put "container" into tStackArray["style"]
    put pLevel into tStackArray["level"]
    put the number of lines in the cardIDs of pStackID into tStackArray["childCount"]

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2080,18 +2080,58 @@ part of the IDE.
 References: revIDEStackNameIsIDEStack (function)
 **/
 function ideUserMainStacks
-   local tMainStack, tMainStacks
-      repeat for each line tMainStack in the mainstacks
-         if revIDEStackNameIsIDEStack(tMainStack) then next repeat
-         if tMainStacks is empty then
-            put tMainStack into tMainStacks
-         else
-            put return & tMainStack after tMainStacks
-         end if
-      end repeat
-   return tMainstacks
+   return __ideRemoveIDEStackNamesFromList(the mainstacks)
 end ideUserMainStacks
 
+private function __ideRemoveIDEStackNamesFromList pStackNames
+   local tFiltered
+   repeat for each line tName in pStackNames
+      if revIDEStackNameIsIDEStack(tName) then next repeat
+      if tFiltered is empty then
+         put tName into tFiltered
+      else
+         put return & tName after tFiltered
+      end if
+   end repeat
+   return tFiltered
+end __ideRemoveIDEStackNamesFromList
+
+private function __ideFilterStackNameListWithPreference pStackNames
+   # Are IDE stacks required
+   local tShowIDEStacks
+   put revIDEGetPreference("cShowRevolutionStacks") into tShowIDEStacks
+   
+   if tShowIDEStacks then
+      return pStackNames
+   end if
+   
+   return __ideRemoveIDEStackNamesFromList(pStackNames)
+end __ideFilterStackNameListWithPreference
+
+private function __ideRemoveIDEObjectIDsFromList pObjectList
+   local tFiltered
+   repeat for each line tID in pObjectList
+      if revIDEObjectIsOnIDEStack(tID) then next repeat
+      if tFiltered is empty then
+         put tID into tFiltered
+      else
+         put return & tID after tFiltered
+      end if
+   end repeat
+   return tFiltered
+end __ideRemoveIDEObjectIDsFromList
+
+private function __ideFilterObjectIDListWithPreference pObjectList
+   # Are IDE stacks required
+   local tShowIDEStacks
+   put revIDEGetPreference("cShowRevolutionStacks") into tShowIDEStacks
+   
+   if tShowIDEStacks then
+      return pObjectList
+   end if
+   
+   return __ideRemoveIDEObjectIDsFromList(pObjectList)
+end __ideFilterObjectIDListWithPreference
 
 function revIDEStacksForDataView pIndex
    # Are IDE stacks required
@@ -2122,38 +2162,16 @@ Gets the data associated with a stack. It recurses through the cards, containers
 returns (array): An array representing a tree structure of controls and their properties.
 */
 function revIDEStacks pExpandedStackList
-   # Are IDE stacks required
-   local tShowIDEStacks
-   put revIDEGetPreference("cShowRevolutionStacks") into tShowIDEStacks
-   
    # Get list of stacks to display
    local tMainStacks
-   if tShowIDEStacks then
-      put the mainstacks into tMainStacks
-   else
-      repeat for each line tMainStack in the mainstacks
-         if revIDEStackNameIsIDEStack(tMainStack) then 
-            next repeat
-         end if
-         
-         if tMainStacks is empty then
-            put tMainStack into tMainStacks
-         else
-            put return & tMainStack after tMainStacks
-         end if
-      end repeat
-   end if
+   put __ideFilterStackNameListWithPreference(the mainstacks) into tMainStacks
    
    # Recurse through the stacks to get their data
    local tStacksData, tCount
    put 1 into tCount
    repeat for each line tStack in tMainStacks
       put empty into tStacksData[tCount]
-      --if tStack is among the lines of pExpandedStackList then
       dispatch function "__readStructureOfStack" to stack tStack with tStacksData[tCount]
-      --else
-      --dispatch function "__readPropertiesOfControl" to stack tStack with sStackPropertiesToRead, tStacksData[tCount]
-      --end if
       add 1 to tCount
    end repeat
    return tStacksData
@@ -2166,20 +2184,14 @@ returns (array): A numerically keyed (for ordering) array with property:value pa
 */
 function revIDEFrontScripts
    # Get the list of frontscripts
+   # If IDE elements are on not showing, filter the list for rev stacks
    local tFrontScripts
-   put the frontscripts into tFrontScripts
-
-   # If ID elements are on not showing, filter the list for rev stacks
-   local tShowIDEStacks
-   put revIDEGetPreference("cShowRevolutionStacks") into tShowIDEStacks
-   if tShowIDEStacks is not true then
-      filter tFrontScripts without "*/rev*"
-   end if
-
+   put __ideFilterObjectIDListWithPreference(the frontscripts) into tFrontScripts
+   
    # Create the list of properties to retrieve
    local tProperties
    put "short name" & return & "scriptlines" & return & "long id" into tProperties
-
+   
    # Loop through the frontscripts getting the required properties
    # and build the return array
    local tCount, tData
@@ -2198,16 +2210,10 @@ Gets the data associated with all backscrips.
 returns (array): A numerically keyed (for ordering) array with property:value pairs for each key.
 */
 function revIDEBackScripts
-   # Get the list of frontscripts
+   # Get the list of backscripts
+   # If IDE elements are on not showing, filter the list for rev stacks
    local tBackScripts
-   put the backscripts into tBackScripts
-
-   # If ID elements are on not showing, filter the list for rev stacks
-   local tShowIDEStacks
-   put revIDEGetPreference("cShowRevolutionStacks") into tShowIDEStacks
-   if tShowIDEStacks is not true then
-      filter tBackScripts without "*/rev*"
-   end if
+   put __ideFilterObjectIDListWithPreference(the backscripts) into tBackScripts
 
    # Create the list of properties to retrieve
    local tProperties
@@ -2233,7 +2239,7 @@ returns (array): A numerically keyed (for ordering) array with property:value pa
 function revIDEStacksInUse
    # Get the list of frontscripts
    local tStacksInUse
-   put the stacksinuse into tStacksInUse
+   put __ideFilterStackNameListWithPreference(the stacksInUse) into tStacksInUse
 
    # Create the list of properties to retrieve
    local tProperties

--- a/Toolset/libraries/revidemessagehandlerlibrary.livecodescript
+++ b/Toolset/libraries/revidemessagehandlerlibrary.livecodescript
@@ -306,3 +306,16 @@ on newTool pTool
    send "ideMessageSend" &&  "ideToolChanged" to stack "revIDELibrary" in 0 milliseconds
    pass newTool
 end newTool
+
+on mainstackChanged pOldMainstack, pNewMainStack
+   local tTarget
+   put the long id of the target into tTarget
+   if revIDEStackIsIDEStack(tTarget) then pass mainstackChanged
+   
+   local tParams
+   put pOldMainstack into tParams[1]
+   put pNewMainStack into tParams[2]
+   put tTarget into tParams[3]
+   send "ideMessageSendWithParameters" &&  "ideMainstackChanged,tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   pass mainstackChanged
+end mainstackChanged

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -120,11 +120,7 @@ on ideNewCard pTarget
 end ideNewCard
 
 on ideNewStack pTarget
-   if the mainStack of pTarget is the short name of pTarget then
-      addStackToProjectBrowser pTarget
-   else
-      addSubStackToProjectBrowser pTarget
-   end if
+   addStackToProjectBrowser pTarget
 end ideNewStack
 
 on ideControlDeleted pTarget
@@ -150,16 +146,12 @@ end ideReleaseStack
 on ideOpenStack pTarget
    local tStack
    if word 1 of pTarget  is "card" then
-      put the name of the owner of pTarget into tStack
+      put ideStackOfObject(pTarget) into tStack
    else if word 1 of pTarget is "stack" then
       put pTarget into tStack
    end if
    
-   if the mainStack of tStack is the short name of tStack then
-      addStackToProjectBrowser tStack
-   else
-      addSubStackToProjectBrowser tStack
-   end if
+   addStackToProjectBrowser tStack
 end ideOpenStack
 
 on ideDestroyStack pTarget
@@ -1372,8 +1364,17 @@ end levelConnectors
 #######################################
 
 on addStackToProjectBrowser pTarget
+   if not exists(pTarget) then
+      exit addStackToProjectBrowser
+   end if
+   
    # If the target has already been added then don't do anything
    if getRow(pTarget) is not empty then
+      exit addStackToProjectBrowser
+   end if
+   
+   if word 3 of pTarget is "of" then
+      addSubstackToProjectBrowser pTarget
       exit addStackToProjectBrowser
    end if
    
@@ -1393,15 +1394,15 @@ on addStackToProjectBrowser pTarget
    end if
    put tVisibleRows into sDisplayArray["visible object keys"]
    
-   refreshProjectView
+   buildProjectView true
 end addStackToProjectBrowser
 
 on addSubstackToProjectBrowser pTarget
-   local tVisbleRows, tParentID, tParentRow, tIndex, tParentExpanded, tVisibleRows, tVisibleRows2
+   local tParentID, tParentRow, tIndex, tParentExpanded, tVisibleRows, tVisibleRows2
    local tChildren, tSubStackInfo, tLevelConnectors
    
    put sDisplayArray["visible object keys"] into tVisibleRows
-   put the long name of stack (the mainStack of pTarget) into tParentID
+   put ideMainStackOfObject(pTarget) into tParentID
    put getRow(tParentID) into tParentRow
    if tParentRow is empty then exit addSubstackToProjectBrowser
    put sDisplayArray["objects"][tParentRow]["expanded"] into tParentExpanded
@@ -1462,7 +1463,7 @@ on addSubstackToProjectBrowser pTarget
    if the last char of tVisibleRows2 is comma then delete the last char of tVisibleRows2
    put tVisibleRows2 into sDisplayArray["visible object keys"]
    
-   refreshProjectView
+   buildProjectView true
 end addSubstackToProjectBrowser
 
 on addCardToProjectBrowser pTarget
@@ -1760,6 +1761,10 @@ on addControlToProjectBrowser pTarget
 end addControlToProjectBrowser   
 
 on deleteStackFromProjectBrowser pTarget
+   if getRow(pTarget) is empty then
+      return false
+   end if
+   
    local tVisibleRows, tRow, tChildren, tChildOffset
    
    put sDisplayArray["visible object keys"] into tVisibleRows
@@ -1796,6 +1801,7 @@ on deleteStackFromProjectBrowser pTarget
    put tVisibleRows into sDisplayArray["visible object keys"]
    
    refreshProjectView
+   return true
 end deleteStackFromProjectBrowser
 
 on deleteCardFromProjectBrowser pTarget

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -1372,6 +1372,11 @@ end levelConnectors
 #######################################
 
 on addStackToProjectBrowser pTarget
+   # If the target has already been added then don't do anything
+   if getRow(pTarget) is not empty then
+      exit addStackToProjectBrowser
+   end if
+   
    local tVisibleRows, tRow, tChildren, tChildOffset, tKeys
    local tIndex
    

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -895,15 +895,6 @@ end toggleGroup
 #######################################
 
 function getRow pLongID
-   --   if exists(pLongID) then
-   --      if word 1 of pLongID is "stack" and not(pLongID contains "of") then put the name of pLongID into pLongID
-   --   end if
-   ## Stack double check
-   if word 1 of pLongID is "stack" then
-      if pLongID is not among the keys of sLongIDToRow then
-         if not(pLongID contains "of") then put the name of pLongID into pLongID
-      end if
-   end if
    return sLongIDToRow[pLongID]
 end getRow
 

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -51,6 +51,7 @@ on preOpenStack
    revIDESubscribe "ideReleaseStack"
    
    revIDESubscribe "ideNameChanged"
+   revIDESubscribe "ideMainstackChanged"
    
    revIDESubscribe "idePreferenceChanged:cShowRevolutionStacks"
    revIDESubscribe "idePreferenceChanged:ideProjectBrowser_sortOrder"
@@ -164,9 +165,41 @@ on ideResumeStack pTarget
    --   highlightObjects tObject
 end ideResumeStack
 
-on ideNameChanged pTarget
-   updateObjectRows pTarget, "name", the short name of pTarget
+on ideNameChanged pOldName, pNewName, pTarget
+   # if the target is a stack, we need to deal with the name change
+   # separately, as the long id is changed.
+   if word 1 of pTarget is "stack" then
+      local tOldTarget
+      put pTarget into tOldTarget
+      put quote & pOldName & quote into word 2 of tOldTarget
+      deleteStackFromProjectBrowser tOldTarget
+      addStackToProjectBrowser pTarget
+      exit ideNameChanged
+   end if
+   
+   updateObjectRows pTarget, "name", pNewName
 end ideNameChanged
+
+on ideMainstackChanged pOldName, pNewName, pTarget
+   # The long id of the target will have changed.
+   # Try and find the old stack which will have been added to the pb
+   local tOldTarget
+   # First check if the target was previously the substack of another stack
+   local tDeleted
+   put pTarget into tOldTarget
+   put quote & pOldName & quote into word 5 of tOldTarget
+   deleteStackFromProjectBrowser tOldTarget
+   put the result into tDeleted
+   
+   # Otherwise the target was previously a mainstack
+   if not tDeleted then
+      put word 1 to 2 of pTarget into tOldTarget
+      deleteStackFromProjectBrowser tOldTarget
+      put the result into tDeleted
+   end if
+   
+   addStackToProjectBrowser pTarget
+end ideMainstackChanged
 
 on preferenceChanged pPreference, pValue
    local tOldValue

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -328,7 +328,7 @@ command buildProjectView pRememberExpansion
    if pRememberExpansion then
       repeat for each line tKey in the keys of sDisplayArray["objects"]
          if sDisplayArray["objects"][tKey]["expanded"] is true then
-            if sDisplayArray["objects"][tKey]["type"] is "stack" then
+            if sDisplayArray["objects"][tKey]["type"] is "stack" or sDisplayArray["objects"][tKey]["type"] is "substack" then
                put sDisplayArray["objects"][tKey]["long id"] & comma & 1 &  return after tOldExpandedControls
             else if  sDisplayArray["objects"][tKey]["type"] is "card" then
                put sDisplayArray["objects"][tKey]["long id"] & comma & 2 &  return after tOldExpandedControls
@@ -1011,8 +1011,8 @@ function itemise pStacks, pFrontScripts, pBackScripts, pLibraryStacks, pInitialI
    
    put the keys of  tStackObjects into tKeys
    sort lines of tKeys ascending numeric
-   put line 1 of tKeys & comma after tVisibleRows
    repeat for each line tKey in tKeys
+      put tKey & comma after tVisibleRows
       put tStackObjects[tKey] into tItemisedArray["objects"][tKey]
    end repeat
    put line -1 of tKeys into tIndex

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -55,6 +55,11 @@ on preOpenStack
    
    revIDESubscribe "idePreferenceChanged:cShowRevolutionStacks"
    revIDESubscribe "idePreferenceChanged:ideProjectBrowser_sortOrder"
+   revIDESubscribe "idePreferenceChanged:ideProjectBrowser_thumbnails"
+   revIDESubscribe "idePreferenceChanged:ideProjectBrowser_groupThumbnails" 
+   revIDESubscribe "idePreferenceChanged:ideProjectBrowser_objectType"
+   revIDESubscribe "idePreferenceChanged:ideProjectBrowser_order"
+   revIDESubscribe "idePreferenceChanged:ideProjectBrowser_show"
    
    put empty into sDisplayArray
    loadImages
@@ -220,19 +225,18 @@ on preferenceChanged pPreference, pValue
          revIDESetPreference pPreference, pValue
          break
    end switch
-   
-   buildProjectView   
 end preferenceChanged
 
 on idePreferenceChanged pPreference, pValue
-   local tValue
-   
-   put revIDEGetPreference(pPreference) into tValue   
    switch pPreference
-      case "cShowRevolutionStacks"
+      case "ideProjectBrowser_thumbnails"
+      case "ideProjectBrowser_groupThumbnails" 
       case "ideProjectBrowser_sortOrder"
+      case "ideProjectBrowser_objectType"
+      case "ideProjectBrowser_order"
+      case "ideProjectBrowser_show"
+      default
          buildProjectView true
-         break
    end switch
 end idePreferenceChanged
 
@@ -349,8 +353,11 @@ command buildProjectView pRememberExpansion
    end repeat
    
    ## If all are switched off the show stacks
-   if tSections is empty then put "stacks" into tSections
-   revIDESetPreference "ideProjectBrowser_show",tSections
+   if tSections is empty then 
+      put "stacks" into tSections
+      revIDESetPreference "ideProjectBrowser_show",tSections
+      exit buildProjectView
+   end if
    
    if "Front Scripts" is among the items of tSections then
       put revIDEFrontScripts() into tFrontScripts

--- a/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
@@ -510,12 +510,14 @@ private command updateBreakpoints pOffset, pSelectedLine, pOldNumber, pNewNumber
       local tImage
       put getBreakpointImageId(tState) into tImage
       
+      lock messages
       copy tImage to group "Mutables" of me
       
       # Breakpoints must be given random names. We can't use the line number or tBreakpoint as the name
       # because breakpoints can be moved, allowing a situation where two could have the same name.
       set the name of it to controlRandomName()
       put the long id of it into tImage
+      unlock messages 
       
       set the cMutable of tImage to true
       set the cBreakpoint of tImage to true

--- a/notes/bugfix-16311.md
+++ b/notes/bugfix-16311.md
@@ -1,0 +1,1 @@
+# Blank lines in Project Browser when creating new stack from msg box 


### PR DESCRIPTION
The project browser is now ok with
- Creating named stacks in script
- Creating named substacks in script
- Changing the mainstack of a stack in script
- Changing the name (and therefore long id) of a stack in script
- Deleting a substack

It also now respects the show ide stacks preference for stacks in use.
