### PR TITLE
[[ Bug 16483 ]] Fix graphic effect and gradient popup

### DIFF
--- a/Toolset/palettes/inspector/behaviors/revinspectorpopupstackbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectorpopupstackbehavior.livecodescript
@@ -7,6 +7,9 @@ on setAsBehavior pTarget
 end setAsBehavior
 
 on preOpenStack
+   local tMargin
+   put the paletteMargin of me into tMargin
+   lock messages
    set the style of the templatebutton to "standard"
    set the width of the templatebutton to "82"
    set the height of the templatebutton to "22"
@@ -14,19 +17,29 @@ on preOpenStack
    set the default of the templatebutton to true
    create button "OK"
    
-   set the topright of button "OK" to the width of me -  the palettemargin of me, the height of me
+   set the topright of button "OK" to the width of me -  tMargin, the height of me
    set the resizable of me to false
-   set the height of me to the height of me + the height of button "OK" of me + the palettemargin of me
+   set the height of me to the height of me + the height of button "OK" of me + tMargin
    
    reset the templatebutton
+   unlock messages
 end preOpenStack
 
 on openStack
-   set the left of me to the right of stack "revInspector" + 5
+   lock screen
+   lock messages
+   set the left of me to the right of revIDEStackOfObject(sTarget) + 5
+   show me
+   unlock messages
+   unlock screen
 end openStack
 
 on editorValueChanged pProperty, pValue, pLockUpdates
-   dispatch "valueChanged" to sTarget with pProperty, pValue
+   try
+      dispatch "valueChanged" to sTarget with pProperty, pValue
+   catch tError
+      send "popupDismissed" to sTarget in 0 millisecs
+   end try
 end editorValueChanged
 
 on mouseUp

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.gradient.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.gradient.behavior.livecodescript
@@ -33,12 +33,12 @@ on editorUpdate
    end if
    
    local tPopupData
-   put tValue["type"] into tPopupData["Type"]["gradientType"]["value"]
-   put tValue["repeat"] into tPopupData["Repeat"]["gradientRepeat"]["value"]
-   put tValue["mirror"] into tPopupData["Mirror"]["gradientMirror"]["value"]
-   put tValue["wrap"] into tPopupData["Wrap"]["gradientWrap"]["value"]
-   put tValue["ramp"] into tPopupData["Ramp"]["gradientRamp"]["value"]
-   put tValue["quality"] into tPopupData["Quality"]["gradientQuality"]["value"]
+   put tValue["type"] into tPopupData["Type"]["gradientType"]["value"]["popup"]
+   put tValue["repeat"] into tPopupData["Repeat"]["gradientRepeat"]["value"]["popup"]
+   put tValue["mirror"] into tPopupData["Mirror"]["gradientMirror"]["value"]["popup"]
+   put tValue["wrap"] into tPopupData["Wrap"]["gradientWrap"]["value"]["popup"]
+   put tValue["ramp"] into tPopupData["Ramp"]["gradientRamp"]["value"]["popup"]
+   put tValue["quality"] into tPopupData["Quality"]["gradientQuality"]["value"]["popup"]
    
    set the editorPopupData of me to tPopupData
    

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.graphiceffect.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.graphiceffect.behavior.livecodescript
@@ -41,15 +41,15 @@ on editorUpdate
    end if
    
    local tPopupData
-   put tValue["color"] into tPopupData["Color"]["effectColor"]["value"]
-   put tValue["opacity"] into item 4 of tPopupData["Color"]["effectColor"]["value"]
+   put tValue["color"] into tPopupData["Color"]["effectColor"]["value"]["popup"]
+   put tValue["opacity"] into item 4 of tPopupData["Color"]["effectColor"]["value"]["popup"]
    
-   put tValue["size"] into tPopupData["Size"]["effectSize"]["value"]
-   put tValue["spread"] into tPopupData["Spread"]["effectSpread"]["value"]
-   put tValue["distance"] into tPopupData["Distance"]["effectDistance"]["value"]
-   put tValue["blendMode"] into tPopupData["Blend Mode"]["effectBlendMode"]["value"]
-   put tValue["filter"] into tPopupData["Filter"]["effectFilter"]["value"]
-   put tValue["angle"] into tPopupData["Angle"]["effectAngle"]["value"]
+   put tValue["size"] into tPopupData["Size"]["effectSize"]["value"]["popup"]
+   put tValue["spread"] into tPopupData["Spread"]["effectSpread"]["value"]["popup"]
+   put tValue["distance"] into tPopupData["Distance"]["effectDistance"]["value"]["popup"]
+   put tValue["blendMode"] into tPopupData["Blend Mode"]["effectBlendMode"]["value"]["popup"]
+   put tValue["filter"] into tPopupData["Filter"]["effectFilter"]["value"]["popup"]
+   put tValue["angle"] into tPopupData["Angle"]["effectAngle"]["value"]["popup"]
    set the editorPopupData of me to tPopupData
    
    local tSize, tColor, tDistance, tOpacity, tSpread
@@ -138,11 +138,22 @@ on valueChanged pProperty, pValue
    if tValue is empty then
       put the storedValue of me into tValue
    end if
-   
    switch pProperty
       case "effectColor"
-         put item 1 to 3 of pValue into tValue["color"]
-         put item 4 of pValue into tValue["opacity"]
+         local tColor, tOpacity, tNumItems
+         put the number of items of pValue into tNumItems
+         if tNumItems is 3 then
+            put item 1 to 3 of pValue into tColor
+            put 100 into tOpacity
+         else if tNumItems is 4 then
+            put item 1 to 3 of pValue into tColor
+            put item 4 of pValue into tOpacity
+         else if tNumItems is 2 then
+            put item 2 of pValue into tOpacity
+            put empty into tColor
+         end if
+         put tColor into tValue["color"]
+         put tOpacity into tValue["opacity"]
          break
       case "effectSize"
       case "effectSpread"

--- a/notes/bugfix-16483.md
+++ b/notes/bugfix-16483.md
@@ -1,0 +1,1 @@
+# Graphic Effects not working


### PR DESCRIPTION
These had been broken by the multiple object conflicted value support
which requires values of an editor to be an array keyed by the long id
of the target object.

This is fixed by just adding a 'popup' pseudo object to the values as
set by the editors.

There was also an issue with a lack of lock messages causing the creation of a button to lead to `ideSelectedObjectChanged`, with fairly disastrous consequences for the property inspector.
