### PR TITLE
[[ Bug 16510 ]] Don't call to update message box from script editor

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -253,9 +253,6 @@ command revSESetMode pMode
    send "setCurrentTab tLastSelectedPane" to group "Pane Tabs" of me
    send "update" to group "Toolbar" of me
    
-   # OK-2008-06-24 : Fix for bug where message box does not always update when entering debugging mode
-   send "revMessageBoxUpdateMode" to stack "Message Box"
-   
    actionResizeStack
 end revSESetMode
 

--- a/notes/bugfix-16510.md
+++ b/notes/bugfix-16510.md
@@ -1,0 +1,1 @@
+# breakpoints in v8 dp8 and up ignored when message box is closed


### PR DESCRIPTION
This is not necessary any more, as any updates the message box needs
will come from its subscribed messages.
