### PR TITLE
Support for test stack reuse

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -493,20 +493,24 @@ on __revIDEDeveloperExtensionDoCreateTestStack pPath, tRectsA, pDetailsA
       exit __revIDEDeveloperExtensionDoCreateTestStack
    end if
    
-   lock screen
-   lock messages
-   create stack "LiveCode Extension Test Window"
-   if tRectsA["rect"] is not empty then
-      set the rect of stack "LiveCode Extension Test Window" to tRectsA["rect"]
+   if there is a stack (pPath & slash & "test.livecode") then
+      go stack (pPath & slash & "test.livecode") 
    else
-      set the loc of stack "LiveCode Extension Test Window" to tRectsA["loc"]
+      lock screen
+      lock messages
+      create stack "LiveCode Extension Test Window"
+      if tRectsA["rect"] is not empty then
+         set the rect of stack "LiveCode Extension Test Window" to tRectsA["rect"]
+      else
+         set the loc of stack "LiveCode Extension Test Window" to tRectsA["loc"]
+      end if
+      set the destroyStack of stack "LiveCode Extension Test Window" to true
+      set the title of it to pDetailsA["name"]
+      set the script of it to __testStackScript()
+      go stack "LiveCode Extension Test Window"
+      create widget as pDetailsA["id"]
+      unlock messages
    end if
-   set the destroyStack of stack "LiveCode Extension Test Window" to true
-   set the title of it to pDetailsA["name"]
-   set the script of it to __testStackScript()
-   go stack "LiveCode Extension Test Window"
-   create widget as pDetailsA["id"]
-   unlock messages
    
    if there is not a widget 1 of stack "LiveCode Extension Test Window" then
       __revIDEDeveloperExtensionSendError "failed to create widget" && pDetailsA["id"]

--- a/notes/feature-lcb_test_stack.md
+++ b/notes/feature-lcb_test_stack.md
@@ -1,0 +1,5 @@
+# LCB Test Stack
+
+Support for a stack named test.livecode to be placed in the extension
+directory which if found will be opened instead of creating a new stack
+when an extension is loaded by the Extension Builder.


### PR DESCRIPTION
At the moment the extension builder creates a new stack each time the
user tests a widget etc which can be annoying if you want to script some
handlers or just add a few buttons to set properties. This commit adds
support for a stack named test.livecode to be placed in the extension
directory which if found will be loaded instead of creating a new stack.
