### PR TITLE
[[ PI ]] Put alignment section first in the list

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4680,7 +4680,7 @@ end revIDEPropertyReset
 
 function revIDEPropertySections
 	// AL-2015-03-03: [[ Bug 14769 ]] Add 'Table' section to the property inspector
-   return "Basic,Data Grid,Custom,Table,Colors,Effects,Icons,Position,Text,Advanced,Align Controls,Geometry Manager"
+   return "Align Controls,Basic,Data Grid,Custom,Table,Colors,Effects,Icons,Position,Text,Advanced,Geometry Manager"
 end revIDEPropertySections
 
 function revIDEPropertySectionNameToIconName pName


### PR DESCRIPTION
In the old PI, the alignment section was shown by default when first opening
the PI for multiple objects. It seems sensible to continue this behavior, as
it is probably the most common use for the multiple objects PI.
