### PR TITLE
[[ Project Browser ]] Allow use of the PB without affecting current selection or focus

### DIFF
--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontainerrowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontainerrowbehavior.livecodescript
@@ -217,17 +217,13 @@ on mouseUp
          edit the script of the cBehaviorLongID of me
          break
       default
-         pass mouseUp
-   end switch
+         pass mouseUp      
+   end switch   
+   --unlock messages
 end mouseUp
 
 on mouseDoubleUp 
-   if the short name of the target is "name" then
-      set the textColor of field "name" of me to revIDEColor("text_1")
-      CreateFieldEditorForField the long id of field "name" of me, "name"
-   else
-      goToObject the cObjectLongID of me
-   end if
+   goToObject the cObjectLongID of me
 end mouseDoubleUp
 
 on CloseFieldEditor pFieldEditor, pRow, pKey, pClosingTriggeredBy
@@ -242,9 +238,13 @@ on ExitFieldEditor pFieldEditor, pRow, pKey, pClosingTriggeredBy
    # The text the user entered is the same as the current value of the target field.
 end ExitFieldEditor
 
-on mouseDown pButton   
+on mouseDown pButton
    if pButton is 3 then       
       revIDEPopupContextualMenu the cObjectLongID of me
+   else if the short name of the target is "name" and \
+         the dvRow of me is the dvHilitedRow of the owner of me then
+      set the textColor of field "name" of me to revIDEColor("text_1")
+      CreateFieldEditorForField the long id of field "name" of me, "name"
    else
       pass mouseDown
    end if

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontainerrowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontainerrowbehavior.livecodescript
@@ -217,9 +217,8 @@ on mouseUp
          edit the script of the cBehaviorLongID of me
          break
       default
-         pass mouseUp      
-   end switch   
-   --unlock messages
+         pass mouseUp
+   end switch
 end mouseUp
 
 on mouseDoubleUp 

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
@@ -161,7 +161,7 @@ end dvHilite
 
 on  mouseUp
    --lock messages
-   switch 
+   switch the short name of the target
       case "scriptLines"
          edit the script of the cObjectLongID of me
          break

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
@@ -161,7 +161,7 @@ end dvHilite
 
 on  mouseUp
    --lock messages
-   switch the short name of the target
+   switch 
       case "scriptLines"
          edit the script of the cObjectLongID of me
          break
@@ -177,18 +177,17 @@ end mouseUp
 on mouseDown pButton
    if pButton is 3 then       
       revIDEPopupContextualMenu the cObjectLongID of me
+   else if the short name of the target is "name" and \
+         the dvRow of me is the dvHilitedRow of the owner of me then
+      set the textColor of field "name" of me to revIDEColor("text_1")
+      CreateFieldEditorForField the long id of field "name" of me, "name"
    else
       pass mouseDown
    end if
 end mouseDown
 
 on mouseDoubleUp 
-   if the short name of the target is "name" then
-      set the textColor of field "name" of me to revIDEColor("text_1")
-      CreateFieldEditorForField the long id of field "name" of me, "name"
-   else
-      goToObject the cObjectLongID of me
-   end if
+   goToObject the cObjectLongID of me
 end mouseDoubleUp
 
 on CloseFieldEditor pFieldEditor, pRow, pKey, pClosingTriggeredBy

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
@@ -186,6 +186,8 @@ on mouseDoubleUp
    if the short name of the target is "name" then
       set the textColor of field "name" of me to revIDEColor("text_1")
       CreateFieldEditorForField the long id of field "name" of me, "name"
+   else
+      goToObject the cObjectLongID of me
    end if
 end mouseDoubleUp
 

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsergrouprowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsergrouprowbehavior.livecodescript
@@ -220,6 +220,8 @@ on mouseDoubleUp
    if the short name of the target is "name" then
       set the textColor of field "name" of me to revIDEColor("text_1")
       CreateFieldEditorForField the long id of field "name" of me, "name"
+   else 
+      goToObject the cObjectLongID of me
    end if
 end mouseDoubleUp
 

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsergrouprowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsergrouprowbehavior.livecodescript
@@ -191,6 +191,10 @@ end mouseUp
 on mouseDown pButton
    if pButton is 3 then       
       revIDEPopupContextualMenu the cObjectLongID of me
+   else if the short name of the target is "name" and \
+         the dvRow of me is the dvHilitedRow of the owner of me then
+      set the textColor of field "name" of me to revIDEColor("text_1")
+      CreateFieldEditorForField the long id of field "name" of me, "name"
    else
       pass mouseDown
    end if

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -105,10 +105,10 @@ end closeStack
 ####### Subscribed IDE messages #######
 ###################################
 on ideSelectedObjectChanged
-   local tObject
-   put revIDESelectedObjects() into tObject
+   --   local tObject
+   --   put revIDESelectedObjects() into tObject
    
-   highlightObjects tObject
+   --   highlightObjects tObject
 end ideSelectedObjectChanged
 
 on ideNewControl pTarget
@@ -540,6 +540,9 @@ command highlightObjects pObject
 end highlightObjects
 
 on selectObjects pObjectList
+   // AL-2015-12-17: Don't select objects anymore when they are selected
+   // in the PB
+   /*
    local tSelectedRows, tObjectList, tVisibleRows
    local tCards
    
@@ -586,7 +589,8 @@ on selectObjects pObjectList
    unlock messages
    
    ## Select objects
-   revIDESelectObjects tObjectList   
+   revIDESelectObjects tObjectList  
+   */ 
 end selectObjects
 
 on selectionChanged pHilitedRows, pPreviouslyHilitedRows
@@ -633,14 +637,21 @@ on selectionChanged pHilitedRows, pPreviouslyHilitedRows
 end selectionChanged
 
 on goToObject pObjectID
-   lock messages
+   ## Don't go to object if it is part of the project browser
+   If ideStackOfObject(pObjectID) is the long id of me then
+      exit goToObject
+   end if
    
+   lock messages
    if word 1 of pObjectID is "stack"  then
       if not the visible of pObjectID then show pObjectID
       go pObjectID 
    else if word 1 of pObjectID is "card"  then
       if not the visible of the owner of pObjectID then show the owner of pObjectID
       go pObjectID
+   else
+      go ideStackOfObject(pObjectID)
+      revIDESelectObjects pObjectID
    end if
    unlock messages
 end goToObject


### PR DESCRIPTION
The PB now only navigates/selects when the item is double-clicked.
- Closes #714
- CLoses #693 (navigates successfully on double click)
- Closes #694 
