### PR TITLE
[[ IDE Messages ]] Send appropriate messages for clear and paste context menu items

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6620,8 +6620,23 @@ on revIDEPasteOntoStack pStack
    lock messages
    set the defaultStack to pStack
    paste
+   
+   local tSelObj
+   put the selobj into tSelObj
+   
+   local tMessage
+   if tSelObj is empty then
+      put the long id of this card into tSelObj
+      put "ideNewCard" into tMessage
+   else
+      put "ideNewControl" into tMessage
+   end if
    unlock messages
    unlock screen
+   
+   repeat for each line tObj in tSelObj
+      revIDEMessageSend tMessage, tObj
+   end repeat
 end revIDEPasteOntoStack
 
 on revIDEActionPasteUnformatted
@@ -6690,9 +6705,16 @@ on revIDEActionClear
    
    # Otherwise delete objects or text
    set the defaultStack to the topStack
+   local tSelObj
+   put the selobj into tSelObj
+   
    delete
    
    unlock messages
+   repeat for each line tObj in tSelObj
+      revIDEMessageSend "ideControlDeleted", tObj
+   end repeat
+   
    ideMessageSend "ideSelectedObjectChanged"
    unlock screen
 end revIDEActionClear


### PR DESCRIPTION
Closes #735

After pasting onto a stack, either nothing is selected (in which case a card has been pasted) or the newly pasted objects are selected. Send the appropriate 'ideNew...' message for these cases.

Similarly, when delete results from 'Clear' in a contextual menu, send an ideControlDeleted for all the selected controls.
