### PR TITLE
docs: Make blockquote font same size as other body text

### DIFF
--- a/Documentation/html_viewer/css/lcdoc.css
+++ b/Documentation/html_viewer/css/lcdoc.css
@@ -73,7 +73,9 @@
 #lcdoc_body .lcdoc_glossary_table td{width:37%}
 #lcdoc_body .lcdoc_glossary_table td:first-of-type{width:26%}
 
-
+#lcdoc_body blockquote {
+    font-size: inherit;
+}
 
 @media (min-width: 768px) {
   #lcdoc_list.affix{

--- a/Documentation/html_viewer/css/userguide.css
+++ b/Documentation/html_viewer/css/userguide.css
@@ -76,6 +76,7 @@ blockquote {
   padding: 0 0 0 15px;
   margin: 0 0 20px;
   border-left: 5px solid #eeeeee;
+  font-size: inherit;
 }
  
 code,


### PR DESCRIPTION
Override a slightly strange setting in the minified bootstrap
CSS file.
