### PR TITLE
now using LC8 setup filename

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -267,9 +267,12 @@ on revInternal__openStack
                put quote & tCommand & quote && "install -update" into tCommand
                break
             case "Linux"
-               --put item 1 to -3 of the filename me into $PATH
-               --put ".setup.x86 install -update" into tCommand
-               put item 1 to -3 of the filename me & "/.setup.x86" into tCommand
+               -- MDW-2015-12-19 [[fix_installer]] LC8-style setup filename
+               if the processor is "x86_64" then
+               		put item 1 to -3 of the filename me & "/setup.x86_64" into tCommand
+               else
+               		put item 1 to -3 of the filename me & "/setup.x86" into tCommand
+               end if
                put tCommand && "install -update" into tCommand
                break
          end switch

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -8232,7 +8232,12 @@ command revIDECheckForUpdates
             put quote & tCommand & quote && "install -foregroundupdate" into tCommand
             break
          case "Linux"
-            put item 1 to -3 of the filename of stack "home" & "/.setup.x86" into tCommand
+            -- MDW-2015-12-19 [[fix_installer]] LC8-style setup filename
+            if the processor is "x86_64" then
+               	put item 1 to -3 of the filename me & "/setup.x86_64" into tCommand
+            else
+               	put item 1 to -3 of the filename me & "/setup.x86" into tCommand
+            end if
             put tCommand && "install -foregroundupdate" into tCommand
             break
       end switch


### PR DESCRIPTION
Since the linux setup filename has changed in LC8, a couple of scripts that have the name hard-coded need to be changed to match it. If we have to hard-code it (I'd still love to have global constants some day) I'd rather make this a script constant and use that, but I'd still have to do that in each of the two scripts, so I didn't bother.
