### PR TITLE
[[ PB ]] control dragged under card is subsequently on the 'top' layer, not layer 1

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -2072,7 +2072,7 @@ on reorderRows pDraggedRowList,pNewStartingRow, pDroppedAfterRow
          repeat for each item tRow in pDraggedRowList
             put getAbsoluteRow(tRow) into tAbs
             put sDisplayArray["objects"][tAbs]["long id"] into tLongID
-            revIDERelayerControl tLongID, 1, tDraggedCard
+            revIDERelayerControl tLongID, "top", tDraggedCard
          end repeat
          
          set the relayerGroupedControls to false


### PR DESCRIPTION
Closes #579
