### PR TITLE
[[ Message Box ]] Search script of current card as well as stack for send completion

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9444,41 +9444,85 @@ end revIDEGetGeometry
 #
 ##################################################
 
-private function __tryToDoScriptInObject pObject, pObjectScript, pToDo, @rValidScript
-   local tDoScript
-   set the itemdelimiter to ";"
-   repeat for each line tScriptLine in pObjectScript
-      if token 1 of tScriptLine is among the items of "on;command" and token 2 of tScriptLine is token 1 of pToDo then 
-         put "send" && item 1 of pToDo && "to" && pObject & ";" & item 2 to -1 of pToDo into tDoScript
-         put pToDo into rValidScript
-         return tDoScript
-      else if token 1 of tScriptLine is "function" then
-         local tTryAsFunction
-         put false into tTryAsFunction
-         if token 1 of pToDo is token 2 of tScriptLine then
-            put true into tTryAsFunction
-            put "put" && pToDo into tDoScript
-         else if token 1 of pToDo is "put" and token 2 of pToDo is token 2 of tScriptLine then
-            put true into tTryAsFunction
-            put pToDo into tDoScript
-         end if
-         if tTryAsFunction then
-            local tFirstItem
-            put item 1 of tDoScript into tFirstItem
-            # If the string is put <userfunction>(<params>) ... then try and evaluate <userfunction> with the params and replace with the result
-            local tParams
-            if matchText(token 2 to -1 of tFirstItem, token 2 of tScriptLine & "\(([^\)]*)?\)", tParams) is false then 
-               exit repeat
-            end if
-            put tDoScript into rValidScript
-            dispatch function (token 2 of tDoScript) to pObject with tParams
-            local tFunction
-            replace token 2 of tScriptLine & "(" & tParams & ")" with quote & the result & quote in tFirstItem
-            put tFirstItem & ";" & item 2 to -1 of tDoScript into tDoScript 
-            return tDoScript
-         end if
+private function __publicScriptHandlers pObject
+   local tScript, tHandlers
+   try
+      put the script of pObject into tScript
+   catch tError
+      return empty
+   end try
+   
+   repeat for each line tLine in tScript
+      if token 1 of tLine is among the items of "on,command" then
+         put "M" && token 2 of tLine & return after tHandlers
+      else if token 1 of tLine is "function" then
+         put "F" && token 2 of tLine & return after tHandlers
       end if
    end repeat
+   delete the last char of tHandlers
+   return tHandlers
+end __publicScriptHandlers
+
+private function __tryToDoScriptInObject pObject, pToDo, @rValidScript
+   local tHandlerList
+   if the environment is "development" then
+      put the effective revAvailableHandlers of pObject into tHandlerList
+   else
+      -- implementation for testing purposes
+      put __publicScriptHandlers(pObject) into tHandlerList
+   end if
+   -- revAvailableHandlers returns a list of handlers in the form
+   -- <handlerType>  <handlerName> <startLine> <endLine>
+   -- Check to see if any handler in the message path matches the executed script
+   
+   local tTargetHandler, tIsPut
+   put false into tIsPut
+   put token 1 of pToDo into tTargetHandler
+   if tTargetHandler is "put" then
+      put true into tIsPut
+      put token 2 of pToDo into tTargetHandler
+   end if
+   
+   local tDoScript
+   set the itemdelimiter to ";"
+   repeat for each line tLine in tHandlerList
+      local tHandlerName, tHandlerType
+      put segment 1 of tLine into tHandlerType
+      put segment 2 of tLine into tHandlerName
+      if tHandlerName is not tTargetHandler then
+         next repeat
+      end if
+      
+      if not tIsPut and tHandlerType is "M" then
+         -- If this is a command that matches, just send the message
+         put "send" && item 1 of pToDo && "to" && pObject & ";" & item 2 to -1 of pToDo into tDoScript
+         put pToDo into rValidScript
+         exit repeat
+      else if tHandlerType is "F" then
+         -- otherwise this is a function that matches
+         if tIsPut then
+            put pToDo into tDoScript
+         else
+            -- autocomplete the 'put' if necessary
+            put "put" && pToDo into tDoScript
+         end if
+         
+         local tFirstItem
+         put item 1 of tDoScript into tFirstItem
+         # If the string is put <userfunction>(<params>) ... then try and evaluate <userfunction> with the params and replace with the result
+         local tParams
+         if matchText(token 2 to -1 of tFirstItem, tHandlerName & "\(([^\)]*)?\)", tParams) is false then 
+            exit repeat
+         end if
+         put tDoScript into rValidScript
+         dispatch function (token 2 of tDoScript) to pObject with tParams
+         replace tHandlerName & "(" & tParams & ")" with quote & the result & quote in tFirstItem
+         put tFirstItem & ";" & item 2 to -1 of tDoScript into tDoScript 
+         exit repeat
+      end if
+   end repeat
+   
+   return tDoScript
 end __tryToDoScriptInObject
 
 command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode, @rValidScript
@@ -9500,24 +9544,10 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
    end if
    
    -- check if word 1 of pScript is a handler in the intelligence object's script or the default stack's script
-   local tIntelligenceScript, tCardStackScript, tScriptLine, tScriptError
-   
-   put false into tScriptError
-   try
-      put the script of pIntelligenceObject into tIntelligenceScript
-   catch tError
-   end try
-   
-   try 
-      put the script of the defaultStack into tCardStackScript
-      put return & the script of this card of the defaultStack after tCardStackScript
-   catch tError
-   end try
-   
    local tDoScript, tValidScript
-   put __tryToDoScriptInObject(pIntelligenceObject, tIntelligenceScript, pScript, tValidScript) into tDoScript
+   put __tryToDoScriptInObject(pIntelligenceObject, pScript, tValidScript) into tDoScript
    if tDoScript is empty then
-      put __tryToDoScriptInObject(the long id of this card of the defaultStack, tCardStackScript, pScript, tValidScript) into tDoScript
+      put __tryToDoScriptInObject(the long id of this card of the defaultStack, pScript, tValidScript) into tDoScript
    end if
    
    if tDoScript is not empty then

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9464,6 +9464,10 @@ private function __publicScriptHandlers pObject
 end __publicScriptHandlers
 
 private function __tryToDoScriptInObject pObject, pToDo, @rValidScript
+   if pObject is empty then
+      return empty
+   end if
+   
    local tHandlerList
    if the environment is "development" then
       put the effective revAvailableHandlers of pObject into tHandlerList
@@ -9475,11 +9479,11 @@ private function __tryToDoScriptInObject pObject, pToDo, @rValidScript
    -- <handlerType>  <handlerName> <startLine> <endLine>
    -- Check to see if any handler in the message path matches the executed script
    
-   local tTargetHandler, tIsPut
-   put false into tIsPut
+   local tTargetHandler, tIsPutOrGet
+   put false into tIsPutOrGet
    put token 1 of pToDo into tTargetHandler
-   if tTargetHandler is "put" then
-      put true into tIsPut
+   if tTargetHandler is among the items of "put,get" then
+      put true into tIsPutOrGet
       put token 2 of pToDo into tTargetHandler
    end if
    
@@ -9493,14 +9497,14 @@ private function __tryToDoScriptInObject pObject, pToDo, @rValidScript
          next repeat
       end if
       
-      if not tIsPut and tHandlerType is "M" then
+      if not tIsPutOrGet and tHandlerType is "M" then
          -- If this is a command that matches, just send the message
          put "send" && item 1 of pToDo && "to" && pObject & ";" & item 2 to -1 of pToDo into tDoScript
          put pToDo into rValidScript
          exit repeat
       else if tHandlerType is "F" then
          -- otherwise this is a function that matches
-         if tIsPut then
+         if tIsPutOrGet then
             put pToDo into tDoScript
          else
             -- autocomplete the 'put' if necessary

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9444,6 +9444,42 @@ end revIDEGetGeometry
 #
 ##################################################
 
+private function __tryToDoScriptInObject pObject, pObjectScript, pToDo, @rValidScript
+   set the itemdelimiter to ";"
+   repeat for each line tScriptLine in pObjectScript
+      if token 1 of tScriptLine is among the items of "on;command" and token 2 of tScriptLine is token 1 of pToDo then 
+         put "send" && item 1 of pToDo && "to" && pObject & ";" & item 2 to -1 of pToDo into tDoScript
+         put pToDo into rValidScript
+         return tDoScript
+      else if token 1 of tScriptLine is "function" then
+         local tTryAsFunction
+         put false into tTryAsFunction
+         if token 1 of pToDo is token 2 of tScriptLine then
+            put true into tTryAsFunction
+            put "put" && pToDo into tDoScript
+         else if token 1 of pToDo is "put" and token 2 of pToDo is token 2 of tScriptLine then
+            put true into tTryAsFunction
+            put pToDo into tDoScript
+         end if
+         if tTryAsFunction then
+            local tFirstItem
+            put item 1 of tDoScript into tFirstItem
+            # If the string is put <userfunction>(<params>) ... then try and evaluate <userfunction> with the params and replace with the result
+            local tParams
+            if matchText(token 2 to -1 of tFirstItem, token 2 of tScriptLine & "\(([^\)]*)?\)", tParams) is false then 
+               exit repeat
+            end if
+            put tDoScript into rValidScript
+            dispatch function (token 2 of tDoScript) to pObject with tParams
+            local tFunction
+            replace token 2 of tScriptLine & "(" & tParams & ")" with quote & the result & quote in tFirstItem
+            put tFirstItem & ";" & item 2 to -1 of tDoScript into tDoScript 
+            return tDoScript
+         end if
+      end if
+   end repeat
+end __tryToDoScriptInObject
+
 command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode, @rValidScript
    local tOldDefault
    put the defaultStack into tOldDefault
@@ -9463,63 +9499,25 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
    end if
    
    -- check if word 1 of pScript is a handler in the intelligence object's script or the default stack's script
-   local tScript, tScriptLine, tScriptError
+   local tIntellgenceScript, tCardStackScript, tScriptLine, tScriptError
    
    put false into tScriptError
    try
-      put the script of pIntelligenceObject into tScript
+      put the script of pIntelligenceObject into tIntelligenceScript
    catch tError
-      put true into tScriptError
    end try
    
-   if tScriptError is true then
-      put false into tScriptError
-      put the long id of the defaultStack into pIntelligenceObject
-      try 
-         put the script of the defaultStack into tScript
-      catch tError
-         put true into tScriptError
-      end try
-   end if
+   try 
+      put the script of the defaultStack into tCardStackScript
+      put return & the script of this card of the defaultStack after tCardStackScript
+   catch tError
+   end try
    
    local tDoScript, tValidScript
-   
-   if tScriptError is false then
-      set the itemdelimiter to ";"
-      repeat for each line tScriptLine in tScript
-         if token 1 of tScriptLine is among the items of "on;command" and token 2 of tScriptLine is token 1 of pScript then 
-            put "send" && item 1 of pScript && "to" && pIntelligenceObject & ";" & item 2 to -1 of pScript into tDoScript
-            put pScript into tValidScript
-            exit repeat
-         else if token 1 of tScriptLine is "function" then
-            local tTryAsFunction
-            put false into tTryAsFunction
-            if token 1 of pScript is token 2 of tScriptLine then
-               put true into tTryAsFunction
-               put "put" && pScript into tDoScript
-            else if token 1 of pScript is "put" and token 2 of pScript is token 2 of tScriptLine then
-               put true into tTryAsFunction
-               put pScript into tDoScript
-            end if
-            if tTryAsFunction then
-               local tFirstItem
-               put item 1 of tDoScript into tFirstItem
-               # If the string is put <userfunction>(<params>) ... then try and evaluate <userfunction> with the params and replace with the result
-               local tParams
-               if matchText(token 2 to -1 of tFirstItem, token 2 of tScriptLine & "\(([^\)]*)?\)", tParams) is false then 
-                  exit repeat
-               end if
-               put tDoScript into tValidScript
-               dispatch function (token 2 of tDoScript) to pIntelligenceObject with tParams
-               local tFunction
-               replace token 2 of tScriptLine & "(" & tParams & ")" with quote & the result & quote in tFirstItem
-               put tFirstItem & ";" & item 2 to -1 of tDoScript into tDoScript 
-               exit repeat
-            end if
-         end if
-      end repeat
-      set the itemdelimiter to comma
-   end if  
+   put __tryToDoScriptInObject(pIntelligenceObject, tIntelligenceScript, pScript, tValidScript) into tDoScript
+   if tDoScript is empty then
+      put __tryToDoScriptInObject(the long id of this card of the defaultStack, tCardStackScript, pScript, tValidScript) into tDoScript
+   end if
    
    if tDoScript is not empty then
       ideDoMessage tDoScript, pDebugMode

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9445,6 +9445,7 @@ end revIDEGetGeometry
 ##################################################
 
 private function __tryToDoScriptInObject pObject, pObjectScript, pToDo, @rValidScript
+   local tDoScript
    set the itemdelimiter to ";"
    repeat for each line tScriptLine in pObjectScript
       if token 1 of tScriptLine is among the items of "on;command" and token 2 of tScriptLine is token 1 of pToDo then 
@@ -9499,7 +9500,7 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
    end if
    
    -- check if word 1 of pScript is a handler in the intelligence object's script or the default stack's script
-   local tIntellgenceScript, tCardStackScript, tScriptLine, tScriptError
+   local tIntelligenceScript, tCardStackScript, tScriptLine, tScriptError
    
    put false into tScriptError
    try

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -131,3 +131,19 @@ on TestIntelligenceObjectMultipleCommand
 	
 	TestAssertBroken "intelligence object mutiple commands", the cValue of tStack is "value", "Bug 16318"
 end TestIntelligenceObjectMultipleCommand
+
+on TestDefaultStackCardScript
+	local tScript
+	put "on preOpenCard; set the cValue of this stack to" && quote & "value" & quote && "; end preOpenCard" into tScript
+
+	local tStack
+	create stack
+	put the long id of it into tStack
+	set the script of card 1 of tStack to tScript
+	
+	local tValidScript
+	ideExecuteScript "preOpenCard", tStack, empty, false, tValidScript
+	
+	TestAssert "intelligence object command result", the cValue of tStack is "value"
+	TestAssert "intelligence object command executed", tValidScript is "preOpenCard"
+end TestDefaultStackCardScript

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -24,6 +24,7 @@ on TestSetup
    put the script of stack tIDELibrary into tScript
    replace "_internal" with "--_internal" in tScript
    replace "the revObjectListeners" with "empty" in tScript
+   replace "the effective revAvailableHandlers of pObject" with "empty" in tScript
    set the script of stack tIDELibrary to tScript
 
    insert the script of stack "revIDELibrary" into back

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -67,6 +67,8 @@ on TestGlobalPropertyCompleted
 	TestAssert "global prop value with 'put the' prepended", msg is "none"
 	TestAssert "global prop executed with 'put the' prepended", tValidScript is "put the backdrop"
 	
+	put empty into msg
+	
 	ideExecuteScript "the backdrop", empty, empty, false, tValidScript
 	
 	TestAssert "global prop value with 'put' prepended", msg is "none"
@@ -89,6 +91,8 @@ on TestIntelligenceObjectMultilineCommand
 	TestAssert "intelligence object multiple command result", msg is "value"
 	TestAssert "intelligence object multiple command executed", tValidScript is "valueCommand; put the result"
 	
+	put empty into msg
+	
 	ideExecuteScript "put valueFunction(); put msg", empty, tStack, false, tValidScript
 	
 	TestAssert "intelligence object multiple function result", msg is "value"
@@ -110,6 +114,8 @@ on TestIntelligenceObject
 	
 	TestAssert "intelligence object command result", the cValue of tStack is "value"
 	TestAssert "intelligence object command executed", tValidScript is "valueCommand"
+	
+	put empty into msg
 	
 	ideExecuteScript "valueFunction()", empty, tStack, false, tValidScript
 	
@@ -148,3 +154,34 @@ on TestDefaultStackCardScript
 	TestAssert "intelligence object command result", the cValue of tStack is "value"
 	TestAssert "intelligence object command executed", tValidScript is "preOpenCard"
 end TestDefaultStackCardScript
+
+
+on TestIntelligenceObjectPutFunction
+	local tScript
+	put "function valueFunction; return" && quote & "value" & quote & "; end valueFunction" into tScript
+
+	local tStack
+	create stack
+	put it into tStack
+	set the script of tStack to tScript
+
+	local tValidScript
+	ideExecuteScript "put valueFunction()", empty, tStack, false, tValidScript
+	
+	TestAssert "intelligence object put function", msg is "value"
+end TestIntelligenceObjectPutFunction
+
+on TestIntelligenceObjectGetFunction
+	local tScript
+	put "function valueFunction; return" && quote & "value" & quote & "; end valueFunction" into tScript
+
+	local tStack
+	create stack
+	put it into tStack
+	set the script of tStack to tScript
+
+	local tValidScript
+
+	ideExecuteScript "get valueFunction(); put it", empty, tStack, false, tValidScript
+	TestAssert "intelligence object get function result", msg is "value"
+end TestIntelligenceObjectGetFunction


### PR DESCRIPTION
Closes #705
Both the script of the intelligence object and the script of the
current card and stack should be searched for possible completion
of commands in the script editor.

To achieve this I've refactored the logic that works out if the message 
makes sense in the context of a given object, and made sure to try it
in the context of the current card if it doesn't make sense in the context 
of the intelligence object.
