### PR TITLE
[[ Issue 796 ]] Clean up palette positioning

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4007,21 +4007,26 @@ on revIDEPositionPalette pStackName
             break
          case "message box"
          case "revDictionary"
-         case "revInspector"
+         default
             set the rect of stack pStackName to tRect
-            break
-         default 
-            if pStackName begins with revIDEScriptEditorPrefix() then
-               set the rect of stack pStackName to tRect
-               break
-            end if
-            # If we don't restore the position for this palette then position the stack in the default location
-            revIDEPositionPaletteDefault pStackName
             break
       end switch
    else
-      # If no sizing information can be found then position the stack in the default location
-      revIDEPositionPaletteDefault pStackName
+      # If no sizing information can be found then position the stack in the 
+      # default location. Only do this for specified stacks.
+      switch pStackName
+         case "revMenuBar"
+         case "revTools"
+         case "message box"
+         case "revDictionary"
+            revIDEPositionPaletteDefault pStackName
+            break
+         default
+            if pStackName begins with revIDEScriptEditorPrefix() then
+               revIDEPositionPaletteDefault pStackName
+            end if
+            break
+      end switch
    end if
    
    # AL-2015-09-15: [[ Bug 15745 ]] Ensure palettes don't get placed off screen
@@ -4047,21 +4052,6 @@ on revIDEPositionPaletteDefault pStackName
          break
       case "revDictionary"
          set the rect of stack pStackName to tScreenWidth * 0.5, 100, tScreenWidth * 0.9, tScreenHeight * 0.9
-         break
-      case "revInspector"
-         if revIDEStackIsIDEStack(the topstack) then
-            set the topleft of stack pStackName to tScreenWidth*0.3,the bottom of stack revIDEPaletteToStackName("menubar") + revIDEPaletteBarHeight(the long ID of stack pStackName)
-         else
-            set the top of stack pStackName to the top of the topstack            
-            # AL-2015-09-09: [[ Bug 15745 ]] Try and place PI to left of stack if it doesn't fit on the right
-            if the right of the topstack + 10 + the width of stack pStackName < tScreenWidth then
-               set the left of stack pStackName to the right of the topstack + 10
-            else if the left of the topstack - 10 - the width of stack pStackName > 0 then
-               set the right of stack pStackName to the left of the topstack - 10
-            else
-               set the left of stack pStackName to the right of the topstack + 10
-            end if
-         end if
          break
       default 
          # If no sizing information can be found position the stack in the center of the 

--- a/Toolset/palettes/inspector/revinspector.livecodescript
+++ b/Toolset/palettes/inspector/revinspector.livecodescript
@@ -245,7 +245,7 @@ on ideInspectObjects pObjects
       put revIDESelectedObjects() into tSelectedObjects
    end if
    
-   local tStackName, tTargetInspector, tKeys
+   local tStackName, tIndex, tTargetInspector, tKeys
    put the keys of inspectorList() into tKeys
    sort tKeys ascending numeric
    repeat for each line tKey in tKeys
@@ -254,6 +254,7 @@ on ideInspectObjects pObjects
       
       if tTargetInspector is empty then
          put tStackName into tTargetInspector
+         put tKey into tIndex
       else
          # Delete any unlocked inspectors other than the target
          deleteInspector tKey
@@ -265,22 +266,64 @@ on ideInspectObjects pObjects
    # If all the inspectors are locked, or there aren't any, create a new one.
    if tTargetInspector is empty then
       local tNewInspectorName
-      put kPropertyInspectorPrefix && sInspectorMax + 1 into tNewInspectorName
+      put sInspectorMax + 1 into tIndex
+      put inspectorStackName(tIndex) into tNewInspectorName
       clone invisible stack "revInspectorTemplate"
       set the name of it to tNewInspectorName
       set the behavior of stack tNewInspectorName to the long id of this me
       put tNewInspectorName into tTargetInspector
-      addInspectorToList sInspectorMax + 1
+      addInspectorToList tIndex
    end if
-   
    unlock messages
-   unlock screen
+   
    set the cSelectedObjects of stack tTargetInspector to tSelectedObjects
    
    lock messages
+   inspectorPositionPalette tIndex, tSelectedObjects
    palette stack tTargetInspector
    unlock messages
+   unlock screen
 end ideInspectObjects
+
+function inspectorStackName pIndex
+   return kPropertyInspectorPrefix && pIndex
+end inspectorStackName
+
+constant kNewInspectorOffset = 20
+on inspectorPositionPalette pIndex, pSelObj
+   local tStackName
+   put inspectorStackName(pIndex) into tStackName
+   local tRect
+   put revIDEGetPreference("palette_rect_" & tStackName) into tRect
+   
+   if __isRect(tRect) then
+      set the rect of stack tStackName to tRect
+      exit inspectorPositionPalette
+   end if
+   
+   local tPrevInspector
+   put inspectorStackName(pIndex - 1) into tPrevInspector
+   -- if we have an open inspector, just offset the new one by 10 pixels
+   if there is a stack tPrevInspector and the mode of stack tPrevInspector is not 0 then
+      set the topleft of stack tStackName to \
+            the left of stack tPrevInspector + kNewInspectorOffset, the top of stack tPrevInspector + kNewInspectorOffset
+   else
+      set the top of stack tStackName to the top of the topstack            
+      # AL-2015-09-09: [[ Bug 15745 ]] Try and place PI to left of stack if it doesn't fit on the right
+      if the right of the topstack + kNewInspectorOffset + the width of stack tStackName < tScreenWidth then
+         set the left of stack tStackName to the right of the topstack + kNewInspectorOffset
+      else if the left of the topstack - kNewInspectorOffset - the width of stack tStackName > 0 then
+         set the right of stack tStackName to the left of the topstack - kNewInspectorOffset
+      else
+         set the left of stack tStackName to the right of the topstack + kNewInspectorOffset
+      end if
+      
+      if intersect(the long id of stack tStackName, revIDEStackOfObject(line 1 of pSelObj)) then
+         revIDEPositionPaletteDefault tStackName
+      end if
+   end if
+end inspectorPositionPalette
+
 
 on ideResumeStack
    ideSelectedObjectChanged

--- a/Toolset/palettes/inspector/revinspectortemplate.livecodescript
+++ b/Toolset/palettes/inspector/revinspectortemplate.livecodescript
@@ -14,17 +14,11 @@ end preOpenStack
 on openStack   
    lock screen
    
-   if intersect(me, revIDEStackOfObject(line 1 of sSelectedObjects)) then
-      revIDEPositionPaletteDefault the short name of me
-   end if
-   
    # Register of IDE messages
    revIDESubscribe "idePreferenceChanged:idePropertyInspector_labels"
    
    # Get a list of the properties and groups we'll be displaying
    set the inspectorData of me to revIDEPropertiesInfo(sSelectedObjects)
-   
-   set the visible of me to true
    unlock screen
 end openStack
 


### PR DESCRIPTION
Closes #796
It doesn't make sense for the ide library to try and manage inspector
instance positioning, the revInspector stack should control such
things.
