### PR TITLE
[[ PI ]] Reinstate tab panel text editor

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -651,6 +651,10 @@ private function __orderPropSubArray pSectionA, pIsGroupList
          put tProp into tOrderedA[tCount]["label"]
          put pSectionA[tSubKey][tProp]["subsection"] into tOrderedA[tCount]["subsection"]
          put __orderPropSubArray(pSectionA[tSubKey][tProp], false) into tOrderedA[tCount]["proplist"]
+         # Inherit the prop label if there is only one
+         if the number of elements in tOrderedA[tCount]["proplist"] is 1 then
+            put tOrderedA[tCount]["proplist"][1]["label"] into tOrderedA[tCount]["label"]
+         end if
       else
          if pSectionA[tSubKey][tProp]["popup"] is not empty then
             put __orderPropSubArray(pSectionA[tSubKey][tProp]["popup"], true) into pSectionA[tSubKey][tProp]["popup"]

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TabPanel.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TabPanel.txt
@@ -9,7 +9,7 @@ tooltip
 visible							true					
 disabled							false					
 showName							false					
-text	Tabs (one per line)						Tab 1\nTab 2\nTab 3	
+text	Tabs (one per line)			true			Tab 1\nTab 2\nTab 3	
 layerMode												
 behavior												
 foregroundColor						Text Fill						


### PR DESCRIPTION
Closes #803
Also fixes an oversight causing property labels not to override
the group label if there is only one property.
