### PR TITLE
[[ Dictionary ]] Prevent entry visibility when scrolled behind header

### DIFF
--- a/Documentation/html_viewer/api.html.template
+++ b/Documentation/html_viewer/api.html.template
@@ -44,8 +44,8 @@
     	</div>
  
         <div class="col-md-9">
-        	<div id="header_panel_holder">
-				<div class="panel panel-default affix" id="lcdoc_list">
+        	<div id="header_panel_holder" class="affix_right">
+				<div class="panel panel-default affix_right" id="lcdoc_list">
 				  <div class="panel-heading " >
 					  <div class="row">
 					  	

--- a/Documentation/html_viewer/css/lcdoc.css
+++ b/Documentation/html_viewer/css/lcdoc.css
@@ -38,16 +38,21 @@
 
 #table_list .active{ background-color:#00ff00}
 
-#header_panel_holder{ background-color:#00ff88}
-
+#header_panel_holder {
+	background-color: #FFFFFF;
+	top: 0;
+	padding-top: 25px;
+}
 
 #lcdoc_body{
 	margin-top:270px
 }
 
-#lcdoc_list.affix{
+.affix_right
+{
 	width:848px;
 	z-index:100;
+	position: fixed;
 }
 
 .lcdoc_section_title{ font-weight:bold; text-transform:capitalize}
@@ -78,7 +83,7 @@
 }
 
 @media (min-width: 768px) {
-  #lcdoc_list.affix{
+  .affix_right{
 	width:90%;
 	margin-left:auto;
 	margin-right:auto;
@@ -86,13 +91,13 @@
 }
 
 @media (min-width: 992px) {
-  #lcdoc_list.affix{
+ .affix_right{
 	width:697px;
 	}
 }
 
 @media (min-width: 1200px) {
- #lcdoc_list.affix{
+ .affix_right{
 	width:848px;
 	}
 }


### PR DESCRIPTION
Closes #822
This affixes the container of the menu div, sets its background to
white and adds padding so that it extends to the top of the page,
thus hiding any content that scrolls behind it.
