### PR TITLE
dictionary: Make crossrefs in description blocks look like normal text

### DIFF
--- a/Documentation/html_viewer/css/lcdoc.css
+++ b/Documentation/html_viewer/css/lcdoc.css
@@ -124,3 +124,13 @@
     display:block;
   }
 }
+
+.lcdoc_description a.load_entry {
+    color: inherit;
+    text-decoration: inherit;
+}
+
+.lcdoc_description a.load_entry:hover {
+    color: #428BCA;
+    text-decoration: underline;
+}

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -417,7 +417,7 @@
 	
 				tMarkdown = replace_link_placeholders_with_links(tMarkdown,tEntryObject);
 		
-				tHTML += '<div class="col-md-2 lcdoc_section_title">description</div><div class="col-md-10" style="margin-bottom:10px">';
+				tHTML += '<div class="col-md-2 lcdoc_section_title">description</div><div class="col-md-10 lcdoc_description" style="margin-bottom:10px">';
 						tHTML += marked(tMarkdown);
 						tHTML += '</div>';
 				}


### PR DESCRIPTION
Some dictionary entries have a _lot_ of cross references in their
description blocks, which can be extremely visually noisy.  Since all
the cross references in the description are already listed in the
dictionary entry's references section, it's okay to make the links in
the description block look like normal text until mouseover - it
doesn't hinder discoverability but it does make it easier to read.
