### PR TITLE
[[ Bug ]] Don't clobber the selected object when cleaning up SE/Debugger interaction

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2645,8 +2645,17 @@ command deselectLastGoneToLine
    get the selectedChunk
    -- MM-2012-06-20: [[ Bug 10027 ]] Make sure there was a last line selected - causes bugs deselects elsewhere within the IDE.
    if sLastSelectedGoneToChunk is not empty and word 2 of it is item 1 of sLastSelectedGoneToChunk and word 4 of it is item 2 of sLastSelectedGoneToChunk then
+      lock screen
+      lock messages
+      local tSelobj
+      put revIDESelectedObjects() into tSelobj
       select empty
+      if tSelobj is not the long id of field "Script" of me then
+         revIDESelectObjects tSelobj
+      end if
       set the backgroundColor of char (item 1 of sLastSelectedGoneToChunk) to (item 2 of sLastSelectedGoneToChunk) of field "Script" of me to empty
+      unlock messages
+      unlock screen
    end if
    put empty into sLastSelectedGoneToChunk
    


### PR DESCRIPTION
This bug makes it very hard to debug the property inspector.
