### PR TITLE
[[ Message Box ]] Make sure message box behavior always refers to 'me' rather than 'this stack'

### DIFF
--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -61,15 +61,14 @@ on openStack
    
    #Preferences
    --frame item: Name                                            Location  Type              Label                                           Value Type  Value                                         Callback Message      Callback Target
-   addFrameItem "ideMessageBox_autoupdate",           "header",  "preference",  "Auto Update Pending Messages",  "boolean",     "true,false",                                  "preferenceChanged",  the long id of this stack
-   addFrameItem "ideMessageBox_intelligenceobject", "header",  "preference",  "Select Intelligence Object",            "enum",         "selectedObject,mouseControl",   "preferenceChanged",  the long id of this stack
+   addFrameItem "ideMessageBox_autoupdate",           "header",  "preference",  "Auto Update Pending Messages",  "boolean",     "true,false",                                  "preferenceChanged",  the long id of me
+   addFrameItem "ideMessageBox_intelligenceobject", "header",  "preference",  "Select Intelligence Object",            "enum",         "selectedObject,mouseControl",   "preferenceChanged",  the long id of me
    
    hiliteFrameItem "single line"
    showCard "Single Line"
    
    lock messages
    set the revMessageBoxRedirect to the long id of me
-   set the textSize of this stack to 11
    unlock messages
    
    --if there is a stack currently being debugged then the debug mode is true, if no stack is currently being debugged then the debug mode is false
@@ -91,17 +90,16 @@ on openStack
    put 4*kHalfMessageFieldHeight + the headerHeight of me + the footerHeight of me into tMinHeight
    
    lock messages
-   set the minHeight of this stack to tMinHeight
-   set the left of this stack to the cREVLeft of this stack
-   set the top of this stack to the cREVTop of this stack
+   set the minHeight of me to tMinHeight
+   moveStack
    unlock messages
    unlock screen
 end openStack
 
 on moveStack
    --set the position of the stack as a custom property so when it is reopened/different card is selected it remains in the same location
-   set the cREVLeft of this stack to the left of this stack
-   set the cREVTop of this stack to the top of this stack
+   set the cREVLeft of me to the left of me
+   set the cREVTop of me to the top of me
 end moveStack
 
 on closeStack
@@ -141,7 +139,7 @@ command showCard pCard
    go to card lSelectedCard
    ##GH : will need localising
    --set the title of this stack to revIDELocalisedString("Message Box" && "(" & lSelectedCard & ")")
-   set the title of this stack to "Message Box" && "(" & lSelectedCard & ")"
+   set the title of me to "Message Box" && "(" & lSelectedCard & ")"
    
    --get message history for Single Line and Multiple Lines
     if pCard is among the items of "Single Line,Multiple Lines" then 
@@ -574,7 +572,7 @@ function ideMessageBoxFormatErrorForDisplay pErrorTrace
 end ideMessageBoxFormatErrorForDisplay
 
 command revIDEUpdateIntelligenceObject
-   set the cREVIntelligenceObject of this stack to revIDEGetPreference("ideMessageBox_intelligenceobject")
+   set the cREVIntelligenceObject of me to revIDEGetPreference("ideMessageBox_intelligenceobject")
 end revIDEUpdateIntelligenceObject
 
 #   Updates the message box mode to reflect whether or not we are debugging something.

--- a/notes/bugfix-16837.md
+++ b/notes/bugfix-16837.md
@@ -1,0 +1,1 @@
+# Ensure message box location preference is honored


### PR DESCRIPTION
And don't try to set topleft of message box on open - this is handled
by the palette behavior.
