### PR TITLE
[Bug 16874] Correct script editor field flush logic.

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -5270,12 +5270,12 @@ private command __EditorFieldCacheFlush pRuggedObjectId
    if tField is empty then
       exit __EditorFieldCacheFlush
    end if
-   if the name of tField is "Script" then
+   if the name of field tField is "Script" then
       exit __EditorFieldCacheFlush
    end if
 
    lock messages
-   delete tField
+   delete field tField
    unlock messages
 
    delete variable sScriptEditorFieldCache[pRuggedObjectId]

--- a/notes/bugfix-16874.md
+++ b/notes/bugfix-16874.md
@@ -1,0 +1,1 @@
+# Correctly flush cached script editor fields when cache is full


### PR DESCRIPTION
Cached field names weren't being used correctly when trimming the
script editor field cache.
