### PR TITLE
Read only strings should still be able to be selected in the UI

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.string.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.string.behavior.livecodescript
@@ -16,7 +16,7 @@ on editorUpdate
    put the editorConflicted of me into tConflicted
    
    lock messages
-   set the enabled of field 1 of me to tEnabled
+   set the locktext of field 1 of me to not tEnabled
    if tEffective is true then
       if the focusedobject is not the long ID of field 1 of me then
          put tValue into field 1 of me
@@ -25,8 +25,12 @@ on editorUpdate
       set the textstyle["italic"] of field 1 of me to true
    else
       put tValue into field 1 of me
-      set the textcolor of field 1 of me to empty
       set the textstyle of field 1 of me to empty
+      if not tEnabled then
+      	set the textcolor of field 1 of me to "108,108,108"
+      else
+      	set the textcolor of field 1 of me to empty
+      end if
    end if
    
    if tConflicted then


### PR DESCRIPTION
Currently a read only string (e.g. widget <type>) field in the PI is disabled. This means you can't select the text and copy it. This commit sets the locktext property and the textcolor property rather than setting the enabled property.
