### PR TITLE
Rename stack "DataViewControl"

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3741,7 +3741,7 @@ function revIDEInspectorBehavior
 end revIDEInspectorBehavior
 
 function revIDEDataViewBehavior
-   return the long ID of button "DataView Behavior" of stack "DataViewControl" of stack "revCore"
+   return the long ID of button "DataView Behavior" of stack "revDataViewControl" of stack "revCore"
 end revIDEDataViewBehavior
 
 local sMilliseconds

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -578,7 +578,7 @@ on mouseDown
    put revIDEEditableStacks() into tStackList
    put 1 into tStackCount
    repeat for each line tStackName in tStackList
-      if tStackName begins with  "DataViewControl" then next repeat
+      if tStackName begins with "revDataViewControl" then next repeat
       if tStackName is "revDragControl" then next repeat
       put the long ID of stack tStackName into tValidDropStacks[tStackCount]["long id"]
       put the rect of stack tStackName into tValidDropStacks[tStackCount]["rect"]


### PR DESCRIPTION
The "DataViewControl" stack is used for the Project Browser. It is something I originally wrote and the name conflicts with my own stack in my projects. This commit changes the references to the stack from "DataViewControl" to "revDataViewControl". In addition to this commit, the following code must be executed in order to change stack files within the IDE.
## Change DataView stack name

set the name of stack "DataViewControl" of stack "revCore" to "revDataViewControl"
save stack "revCore"
## Change behaviors of Project Browser DataView

set the behavior of group "objectList" of card "list" of stack "revIDEProjectBrowser" to the long id of button "DataView Behavior" of stack "revDataViewControl"
set the behavior of button "dvTrackDragDrop" of card "list" of stack "revIDEProjectBrowser" to the long id of button "dvTrackDragDrop Behavior" of stack "revDataViewControl"
set the behavior of scrollbar "dvVScrollbar" of card "list" of stack "revIDEProjectBrowser" to the long id of button "VScrollbar Behavior" of stack "revDataViewControl"
set the behavior of group "dvDropIndicator" of card "list" of stack "revIDEProjectBrowser" to empty
save stack "revIDEProjectBrowser"
