### PR TITLE
Ensure cached script editor fields are hidden

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -5380,6 +5380,7 @@ private command EditorFieldCacheSwap pOldRuggedObjectId, pNewRuggedObjectId
 
       lock messages
       clone invisible field "Script" of me
+      relayer it before field "Script" of me
       set the name of it to tCachedName
       unlock messages
 


### PR DESCRIPTION
When the engine was set to show invisible objects, the script editor
became unusable because the cached editor fields would be displayed on
top of the "real" editor field.

This patch ensures that cached fields are sent to the bottom layer and
uncached fields are brought to the front.

Closes #910.
