### PR TITLE
[Bug 16922] Ensure script editor find UI has enough vertical space

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -80,7 +80,7 @@ command resize
 
    local tFindHeight
    if sePrefGet("editor,findvisible") then
-      put the height of tControls["find"] into tFindHeight
+      put the formattedheight of tControls["find"] into tFindHeight
    else
       put 0 into tFindHeight
    end if

--- a/notes/bugfix-16922.md
+++ b/notes/bugfix-16922.md
@@ -1,0 +1,1 @@
+# Ensure script editor find UI has enough vertical space


### PR DESCRIPTION
Fixes a bug where the find UI only was given 1 px of vertical space on
the first time it was opened.
