### PR TITLE
[Bug 16992] Make sure handling "saveStackRequest" cancels IDE save

### DIFF
--- a/Toolset/libraries/revfrontscriptlibrary.livecodescript
+++ b/Toolset/libraries/revfrontscriptlibrary.livecodescript
@@ -277,23 +277,6 @@ on preOpenStack
    if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then pass preOpenStack
 end preOpenStack
 
-# OK-2007-07-06 : Reworked recent paths system
-command revUpdateRecentFiles pStack
-   if there is no stack pStack then
-      exit revUpdateRecentFiles
-   end if
-
-   if revIDEStackNameIsIDEStack(pStack) then
-      exit revUpdateRecentFiles
-   end if
-
-   if the effective filename of stack pStack is empty then
-      exit revUpdateRecentFiles
-   end if
-
-   revIDEAddRecentStack the effective filename of stack pStack
-end revUpdateRecentFiles
-
 on rawKeyUp pWhich
    if pWhich is 65386 then
       revIDEHelpKeyPressed

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9958,3 +9958,20 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter
    delete the last char of tMenu
    return tMenu
 end revIDEObjectSelectionMenu
+
+# OK-2007-07-06 : Reworked recent paths system
+command revUpdateRecentFiles pStack
+   if there is no stack pStack then
+      exit revUpdateRecentFiles
+   end if
+
+   if revIDEStackNameIsIDEStack(pStack) then
+      exit revUpdateRecentFiles
+   end if
+
+   if the effective filename of stack pStack is empty then
+      exit revUpdateRecentFiles
+   end if
+
+   revIDEAddRecentStack the effective filename of stack pStack
+end revUpdateRecentFiles

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6178,6 +6178,42 @@ function revIDEStackFileVersion pStackFile
       end if
 end revIDEStackFileVersion
 
+-- The revIDESaveStack and revIDESaveStackAs handlers use the "save"
+-- command with messages locked, which prevents the "saveStackRequest"
+-- message from being sent to the stack being operated on.  However,
+-- stacks may want to do work in "saveStackRequest", or even try block
+-- saving entirely by handling the message rather than passing it.
+--
+-- This function synthesizes a "saveStackRequest" message to the stack
+-- <tStackName>.  If the message was handled by the stack, but not
+-- passed, it returns "handled"; otherwise, it returns "passed" or
+-- "unhandled".
+--
+-- In order to prevent "saveStackRequest" from being intercepted by
+-- revfrontscriptlibrary, this function sets the magical global
+-- variable gREVAllowSaveStackRequest.
+--
+-- See bug 5569, bug 5890 and bug 16992
+private function ideDispatchSaveStackRequest pStackName
+   local tDispatchStatus, tDefaultStack
+   global gREVAllowSaveStackRequest
+
+   put true into gREVAllowSaveStackRequest
+   put the defaultStack into tDefaultStack
+   put "unhandled" into tDispatchStatus
+
+   try
+      set the defaultStack to pStackName
+      dispatch "saveStackRequest" to this card of stack pStackName
+      put it into tDispatchStatus
+   end try
+
+   put false into gREVAllowSaveStackRequest
+   set the defaultStack to tDefaultStack
+
+   return tDispatchStatus
+end ideDispatchSaveStackRequest
+
 on revIDESaveStack pStackID
    local tDefaultStack
    put the defaultStack into tDefaultStack
@@ -6277,28 +6313,18 @@ on revIDESaveStack pStackID
    
    local tSaveResult
    
-   # TH - 27/11/07 : Bug 5569, savestack request not sent to the users stack because messages are locked at this point
-   try
-      # OK-2008-03-14 : Bug 5890. When saving a stack with suppress messages turned on
-      # execution of the revSave command terminates after the sending of saveStackRequest
-      # to the target stack. This is because revFrontScript handles the message and passes
-      # to metaCard, which prevents further execution. This bug is worked round with a nasty
-      # hack involving a global...
-      global gREVAllowSaveStackRequest
-      put true into gREVAllowSaveStackRequest
-      
-      set the defaultStack to tStackName
-      send "saveStackRequest" to this card of stack tStackName
-      set the defaultStack to tDefaultStack
-   end try
+   -- Synthesize a "saveStackRequest" message
+   if ideDispatchSaveStackRequest(tStackName) is "handled" then
+      put empty into tSaveResult
 
-   if tStackFileVersion is not empty then
-      save stack tStackName with format tStackFileVersion
    else
-      save stack tStackName with newest format
+      if tStackFileVersion is not empty then
+         save stack tStackName with format tStackFileVersion
+      else
+         save stack tStackName with newest format
+      end if
+      put the result into tSaveResult
    end if
-   put the result into tSaveResult
-   
    
    ## MJ - 17/07/2006 : Bug 3722, it appears these two lines here override the result...
    ## Hence the introduction of the above variable.
@@ -6534,22 +6560,10 @@ on revIDEActionSaveStackAs pStackID, pSubstackOnly
    # Because you're saving as a new stack, this fingerprint should be removed.
    revRemoveRevOnlineKey "fingerprint",tShortName
 
-   # TH-2007-11-27: Bug 5569, savestack request not sent to the users stack because messages are locked at this point
-   try
-      # OK-2008-03-14 : Bug 5890. When saving a stack with suppress messages turned on
-      # execution of the revSave command terminates after the sending of saveStackRequest
-      # to the target stack. This is because revFrontScript handles the message and passes
-      # to metaCard, which prevents further execution. This bug is worked round with a nasty
-      # hack involving a global...
-      global gREVAllowSaveStackRequest
-      put true into gREVAllowSaveStackRequest
-
-      set the defaultStack to tShortName
-      send "saveStackRequest" to this card of stack tShortName
-      set the defaultStack to tDefaultStackBackup
-   end try
-
-   revIDESaveStackAs the long id of stack tShortName, tFilePath, tType
+   -- Synthesize a "saveStackRequest" message
+   if ideDispatchSaveStackRequest(tShortName) is not "handled" then
+      revIDESaveStackAs the long id of stack tShortName, tFilePath, tType
+   end if
 
    unlock messages
 

--- a/notes/bugfix-16992.md
+++ b/notes/bugfix-16992.md
@@ -1,0 +1,1 @@
+# Ensure that IDE save operation respects blocked "saveStackRequest"

--- a/tests/core/idelibrary/savestackrequest.livecodescript
+++ b/tests/core/idelibrary/savestackrequest.livecodescript
@@ -1,0 +1,71 @@
+﻿script "TestSaveStackRequest"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+private function SanitiseForTests pScript
+   replace "_internal" with "--_internal" in pScript
+   replace "the revObjectListeners" with "empty" in pScript
+   replace "the effective revAvailableHandlers of pObject" with "empty" in pScript
+   return pScript
+end SanitiseForTests
+
+on TestSetup
+   local tIDELibrary, tScript
+   put TestGetIDERepositoryPath() & "/Toolset/libraries/revidelibrary.8.livecodescript" into tIDELibrary
+
+   -- Work around the fact that the property listener is not available in standalone mode
+   put the script of stack tIDELibrary into tScript
+   put SanitiseForTests(tScript) into tScript
+
+   -- Fix revIDESpecialFolderPath
+   local tReplace, tReplacement
+   put "the filename of stack" && quote & "home" & quote into tReplace
+   put quote & TestGetIDERepositoryPath() & "/Toolset/home.livecodescript" & quote into tReplacement
+   replace tReplace with tReplacement in tScript
+
+   put "stack" && quote & "revpreferences" & quote into tReplace
+   put "me" into tReplacement
+   replace tReplace with tReplacement in tScript
+
+   set the script of stack tIDELibrary to tScript
+
+   insert the script of stack tIDELibrary into back
+
+   -- Load the revSaving stack
+   local tSavingStack
+   put TestGetIDERepositoryPath() & "/Toolset/palettes/revsaving.livecode" into tSavingStack
+   go invisible tSavingStack
+
+   set the defaultStack to me
+end TestSetup
+
+constant kFilename = "TestSaveStackRequest.livecode"
+
+-- Test that handling saveStackRequest cancels saving a stack
+on TestSaveStackRequest
+   local tStack
+
+   create invisible stack "SaveTest"
+   put it into tStack
+
+   set the script of tStack to "on saveStackRequest; end saveStackRequest"
+   set the filename of tStack to kFileName
+
+   revIDESaveStack tStack
+
+   TestAssert "Handling saveStackRequest cancels save", there is not a file kFileName
+end TestSaveStackRequest


### PR DESCRIPTION
According to the dictionary, handling the `saveStackRequest` message
(and failing to pass it) should cancel the `save` command.

The IDE calls the `save` command with messages locked, which prevents
the current stack from receiving the normal `saveStackRequest`
message.  The IDE therefore synthesizes one.

Previously, the IDE ignored whether or not the `saveStackRequest`
message was handled, and continued with the save operation regardless.
This prevented some useful applications of of intercepting the `save`
command (e.g. forcing the on-disk format to a specific stack format
version).  This patch ensures that the IDE save operation is cancelled
if the `saveStackRequest` message is blocked.
