### PR TITLE
[[ IDE ]] Don't set the splash status to a path during startup

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1274,7 +1274,6 @@ command revInternal__InitialiseUserLibraries
   local tEnvironmentIcons, tUserIcons, tList
   
   revInternal__Log "Enter", "User Libraries Initialisation"
-  revInternal__setSplashStatus revEnvironmentResourcesPath("Icon Libraries")
   put revAbsoluteFolderListing(revEnvironmentResourcesPath("Icon Libraries")) into tEnvironmentIcons
   put revAbsoluteFolderListing(revEnvironmentUserResourcesPath("Icon Libraries")) into tUserIcons
   put revCombineFilePaths(tUserIcons,tEnvironmentIcons) into tList


### PR DESCRIPTION
This was added for temporary logging purposes.
