### PR TITLE
[PI] Handle navbar item renaming correctly.

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.navbar.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.navbar.behavior.livecodescript
@@ -38,9 +38,9 @@ end valueChanged
 
 on textEdited pValue, pNumber
    local tNames
-   put the navLabels of widget 1 of me into tNames
+   put the itemLabels of widget 1 of me into tNames
    put pValue into item pNumber of tNames
-   set the navLabels of widget 1 of me to tNames
+   set the itemLabels of widget 1 of me to tNames
    valueChanged
 end textEdited
 


### PR DESCRIPTION
The **navLabels** property was renamed to **itemLabels** but the
property inspector behaviour script wasn't updated correctly.
