### PR TITLE
[Bug 17158] More uniform implementation of revidemessagehandlerlibrary

### DIFF
--- a/Toolset/libraries/revidemessagehandlerlibrary.livecodescript
+++ b/Toolset/libraries/revidemessagehandlerlibrary.livecodescript
@@ -18,295 +18,299 @@ end revUnloadLibrary
 #################################
 local sSelectingObjects
 on selectedObjectChanged
-   if sSelectingObjects is true then exit selectedObjectChanged
-   if revIDEObjectIsOnIDEStack(the long id of the target) then pass selectedObjectChanged
-   
-   send "ideMessageSend" &&  "ideSelectedObjectChanged" to stack "revIDELibrary" in 0 milliseconds
+   if not sSelectingObjects and \
+         not revIDEObjectIsOnIDEStack(the long id of the target) then
+      send "ideMessageSend" &&  "ideSelectedObjectChanged" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass selectedObjectChanged
 end selectedObjectChanged
 
 on objectSelectionStarted
-   if revIDEObjectIsOnIDEStack(the long id of the target) then pass objectSelectionStarted
-   
-   put true into sSelectingObjects
-   send "ideMessageSend" &&  "ideObjectSelectionStarted" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(the long id of the target) then
+      put true into sSelectingObjects
+      send "ideMessageSend" &&  "ideObjectSelectionStarted" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass objectSelectionStarted
 end objectSelectionStarted
 
 on objectSelectionEnded
-   if revIDEObjectIsOnIDEStack(the long id of the target) then pass objectSelectionEnded
-   
-   put false into sSelectingObjects
-   send "ideMessageSend" &&  "ideSelectedObjectChanged" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(the long id of the target) then
+      put false into sSelectingObjects
+      send "ideMessageSend" &&  "ideSelectedObjectChanged" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass objectSelectionEnded
 end objectSelectionEnded
 
 on resizeControl
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass resizeControl
-   
-   send "ideMessageSend" &&  "ideResizeControl,tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideResizeControl,tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass resizeControl
 end resizeControl
 
 on resumeStack
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass resumeStack
-   
-   send "ideMessageSend" &&  "ideResumeStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideResumeStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass resumeStack
 end resumeStack
 
 on newCard
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newCard
-   
-   send "ideMessageSend" &&  "ideNewCard","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewCard","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newCard
 end newCard
 
 on newStack
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newStack
-
-   send "ideMessageSend" &&  "ideNewStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newStack
 end newStack
 
 on newField
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newField
-
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newField
 end newField
 
 on newGraphic
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newGraphic
-   
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
+   pass newGraphic
 end newGraphic
 
 on newGroup
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newGroup
-   
-   --revIDEMessageSend "ideNewControl",tTarget
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" && "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
+   pass newGroup
 end newGroup
 
 on newImage
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newImage
-   
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
+   pass newImage
 end newImage
 
 on newPlayer
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newPlayer
-
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
+   pass newPlayer
 end newPlayer
 
 on newScrollbar
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newScrollbar
-
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newScrollbar
 end newScrollbar
 
 on newButton
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newButton
-   
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newButton
 end newButton
 
 on newWidget
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newWidget
-
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newWidget
 end newWidget
 
 on newBackground
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass newBackground
-
-   send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass newBackground
 end newBackground
 
 on deleteBackground
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteBackground
-
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
+   pass deleteBackground
 end deleteBackground
 
 on deleteButton
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteButton
-
-   send "ideMessageSend" && "ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" && "ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteButton
 end deleteButton
 
 on deleteCard
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteCard
-   
-   send "ideMessageSend" &&  "ideCardDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend" &&  "ideCardDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteCard
 end deleteCard
    
 on deleteEPS
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteEPS
-
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteEPS
 end deleteEPS
 
 on deleteField
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteField
-   
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds 
+   if not revIDEObjectIsOnIDEStack(tTarget) then   
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds 
+   end if
    pass deleteField
 end deleteField
 
 on deleteGraphic
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteGraphic
-
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteGraphic
 end deleteGraphic
 
 on deleteGroup
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteGroup
-
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteGroup
 end deleteGroup
 
 on deleteImage
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteImage
-
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteImage
 end deleteImage
 
 on deletePlayer
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deletePlayer
-   
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then   
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deletePlayer
 end deletePlayer
 
 on deleteScrollbar
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteScrollbar
-
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteScrollbar
 end deleteScrollbar
 
 on deleteWidget 
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteWidget
-   
-   send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then   
+      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteWidget
 end deleteWidget
 
 on deleteStack
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass deleteStack
-
-   send "ideMessageSend ideStackDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideStackDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass deleteStack
 end deleteStack
 
 on libraryStack
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass libraryStack
-
-   send "ideMessageSend ideLibraryStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideLibraryStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass libraryStack
 end libraryStack
 
 on releaseStack
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass releaseStack
-
-   send "ideMessageSend ideReleaseStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then
+      send "ideMessageSend ideReleaseStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass releaseStack
 end releaseStack
 
 on nameChanged pOldName, pNewName
-   local tTarget
+   local tTarget, tParams
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass nameChanged
-   
-   local tParams
-   put pOldName into tParams[1]
-   put pNewName into tParams[2]
-   put tTarget into tParams[3]
-   send "ideMessageSendWithParameters ideNameChanged,tTarget,tParams" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then   
+      put pOldName into tParams[1]
+      put pNewName into tParams[2]
+      put tTarget into tParams[3]
+      send "ideMessageSendWithParameters ideNameChanged,tTarget,tParams" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass nameChanged
 end nameChanged
 
 on openCard
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass openCard
-   
-   send "ideMessageSend" &&  "ideOpenCard","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then   
+      send "ideMessageSend" &&  "ideOpenCard","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass openCard
 end openCard
 
 on openStack
    local tTarget
    put the long id of the target into tTarget
-   if revIDEObjectIsOnIDEStack(tTarget) then pass openStack
-   
-   send "ideMessageSend" &&  "ideOpenStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEObjectIsOnIDEStack(tTarget) then   
+      send "ideMessageSend" &&  "ideOpenStack","tTarget" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass openStack
 end openStack
 
@@ -317,77 +321,74 @@ on newTool pTool
 end newTool
 
 on mainstackChanged pOldMainstack, pNewMainStack
-   local tTarget
+   local tTarget, tParams
    put the long id of the target into tTarget
-   if revIDEStackIsIDEStack(tTarget) then pass mainstackChanged
-   
-   local tParams
-   put pOldMainstack into tParams[1]
-   put pNewMainStack into tParams[2]
-   put tTarget into tParams[3]
-   send "ideMessageSendWithParameters" &&  "ideMainstackChanged,tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEStackIsIDEStack(tTarget) then
+      put pOldMainstack into tParams[1]
+      put pNewMainStack into tParams[2]
+      put tTarget into tParams[3]
+      send "ideMessageSendWithParameters" &&  "ideMainstackChanged,tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass mainstackChanged
 end mainstackChanged
 
 on moveStack pLeft, pTop
+   local tMenuBar
    if the platform is "MacOS" then -- prevent stack getting stuck under menu bar
-      if pTop < the bottom of stack revIDEPaletteToStackName("menubar") and the right of stack revTargetStack() < the right of stack revIDEPaletteToStackName("menubar") + 5 then
-         set the top of stack revTargetStack() to the bottom of stack revIDEPaletteToStackName("menubar") + 20
+      put revIDEPaletteToStackName("menubar") into tMenuBar
+      if pTop < the bottom of stack tMenuBar and the right of stack revTargetStack() < the right of stack tMenuBar + 5 then
+         set the top of stack revTargetStack() to the bottom of stack tMenuBar + 20
       end if
    end if
    
    # IDE to notify any objects subscribed to the ideStackMoved Message
    local tLongID
+   -- moveStack is sent to the card, so the owner of the target is the stack
    put the long id of the owner of the target into tLongID
    send "ideMessageSendWithTrigger" &&  "ideStackMoved, tLongID, tLongID" to stack "revIDELibrary" in 0 milliseconds
    pass moveStack
 end moveStack
 
 on mouseDown pButton
-   local tTarget
+   local tTarget, tParams
    put the long id of the target into tTarget
-   if revIDEStackIsIDEStack(tTarget) then pass mouseDown
-   
-   local tParams
-   put pButton into tParams[1]
-   put tTarget into tParams[2]
-   
-   send "ideMessageSendWithParameters" &&  "ideMouseDown, tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEStackIsIDEStack(tTarget) then
+      put pButton into tParams[1]
+      put tTarget into tParams[2]
+      send "ideMessageSendWithParameters" &&  "ideMouseDown, tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass mouseDown
 end mouseDown
 
 on mouseUp pButton
-   local tTarget
+   local tTarget, tParams
    put the long id of the target into tTarget
-   if revIDEStackIsIDEStack(tTarget) then pass mouseUp
-   
-   local tParams
-   put pButton into tParams[1]
-   put tTarget into tParams[2]
-   
-   send "ideMessageSendWithParameters" &&  "ideMouseUp, tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEStackIsIDEStack(tTarget) then
+      put pButton into tParams[1]
+      put tTarget into tParams[2]
+      send "ideMessageSendWithParameters" &&  "ideMouseUp, tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass mouseUp
 end mouseUp
 
 on mouseDoubleUp pButton
-   local tTarget
+   local tTarget, tParams
    put the long id of the target into tTarget
-   if revIDEStackIsIDEStack(tTarget) then pass mouseDoubleUp
-   
-   local tParams
-   put pButton into tParams[1]
-   put tTarget into tParams[2]
-   
-   send "ideMessageSendWithParameters" &&  "ideMouseDoubleUp, tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEStackIsIDEStack(tTarget) then
+      put pButton into tParams[1]
+      put tTarget into tParams[2]
+      send "ideMessageSendWithParameters" &&  "ideMouseDoubleUp, tTarget, tParams" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass mouseDoubleUp
 end mouseDoubleUp
 
 on closeStackRequest
    # IDE to notify any objects subscribed to the ideCloseStackRequest Message
    local tLongID
+   -- closeStackRequest is sent to the card, so the owner of the target is the stack
    put the long id of the owner of the target into tLongID
-   if revIDEStackIsIDEStack(tLongID) then pass closeStackRequest
-   
-   send "ideMessageSendWithTrigger" &&  "ideCloseStackRequest, tLongID, tLongID" to stack "revIDELibrary" in 0 milliseconds
+   if not revIDEStackIsIDEStack(tLongID) then   
+      send "ideMessageSendWithTrigger" &&  "ideCloseStackRequest, tLongID, tLongID" to stack "revIDELibrary" in 0 milliseconds
+   end if
    pass closeStackRequest
 end closeStackRequest

--- a/notes/bugfix-17158.md
+++ b/notes/bugfix-17158.md
@@ -1,0 +1,1 @@
+# Ensure IDE frontscripts don't block messages unnecessarily


### PR DESCRIPTION
Ensure that all handlers in the IDE message handler library are
implemented in the same form:

```
 if it's a user stack then
    send an IDE message
 end if
 pass message
```

This is intended to make it harder to miss out a `pass` when making
changes to the library in the future.
