### PR TITLE
Import images directly, automatically setting the repeatCount

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5879,13 +5879,13 @@ on revIDEImportControl pType, pFileName, pReferenced
    set the defaultStack to tTargetStack
    switch pType
       case "image"
-         revIDECreateObject "com.livecode.interface.classic.image", tTargetStack, tCreatedControlLocation
          if pReferenced is true then
+            revIDECreateObject "com.livecode.interface.classic.image", tTargetStack, tCreatedControlLocation
             put the long id of the last control into tCreatedControlID
             set the filename of tCreatedControlID to pFileName
          else
+            import paint from file pFileName
             put the long id of the last image into tCreatedControlID
-            set the text of tCreatedControlID to URL ("binfile:" & pFileName)
          end if
          set the borderWidth of tCreatedControlID to 0
          select tCreatedControlID

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5880,10 +5880,15 @@ on revIDEImportControl pType, pFileName, pReferenced
    switch pType
       case "image"
          if pReferenced is true then
+            ## Create a classic image control with default properties
+            ## Set the filename of the new image control to the referenced image
             revIDECreateObject "com.livecode.interface.classic.image", tTargetStack, tCreatedControlLocation
             put the long id of the last control into tCreatedControlID
             set the filename of tCreatedControlID to pFileName
          else
+            ## Create an image control by importing the image file onto the stack
+            ## Importing a paint file preserves the image file properties
+            ## In particualar the repeatCount property is set to -1 for animated gifs and 0 for other images
             import paint from file pFileName
             put the long id of the last image into tCreatedControlID
          end if


### PR DESCRIPTION
When imorting images using the File menu images will be imported
using the import paint from file command. This automatically sets
the repeatCount property of the new image.

Closes: #1026
