### PR TITLE
Reinstate the Sample Stacks browser in the IDE

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7504,7 +7504,8 @@ on revIDELaunchResource pName
          launch document revEnvironmentDocumentationPath() & "/pdf/LiveCode User Guide.pdf"
          break
       case "Sample Stacks"
-         launch url "http://livecode.com/links/livecode/revonline"
+         set the _ideoverride of stack "revonline" to true
+         go stack "revOnline"
          break
       case "Sample Scripts"
          launch url "http://lessons.runrev.com/m/2592"
@@ -10056,3 +10057,30 @@ command revUpdateRecentFiles pStack
 
    revIDEAddRecentStack the effective filename of stack pStack
 end revUpdateRecentFiles
+
+/*
+Share the stack to revOnline/LiveCode Share
+*/
+command revIDEShareStack pStackID
+   # Upload stack to RevOnline
+   revOnlinePrefLoad
+   put the effective filename of the topStack into tStackPath
+   if tStackPath is empty then
+      # Stack must be saved to be uploaded to revonline
+      revSaveAs the short name of the topStack,false
+   end if
+   put the effective filename of the topStack into tStackPath
+   if tStackPath is not empty then
+      # Check remember username and password prefs
+      if revOnlineSession() is empty then
+         # No session so need to login
+         revOnlineShowLoginDialog
+      end if
+      # If login was successful
+      if revOnlineSession() is not empty then
+         revGoOnline
+         send "rvoShareThisStack tStackPath" to stack "revonline"
+      end if
+   end if
+   break
+end revIDEShareStack

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -1254,6 +1254,9 @@ private function revMenubarFileMenu pContext
    put enableMenuItem("&Revert to Saved...", tIsUserTarget and the effective filename of the topStack is not empty) & return after tFile
    put "-" & return after tFile
    
+   put enableMenuItem("&Share this stack...", tCanSaveStack) & return after tFile
+   put "-" & return after tFile
+   
    put enableMenuItem("Standalone Application Settings...", tIsUserTarget) & return after tFile
    put enableMenuItem("Save as Standalone Application...", tIsUserTarget) & return after tFile
    put "-" & return after tFile
@@ -2492,6 +2495,9 @@ on revMenubarFileMenuPick pWhich
          break
       case "Save As Standalone Application..."
          revIDESaveAsStandalone the long id of the topStack
+         break
+      case "Share this stack..."
+         revIDEShareStack the long id of the topStack
          break
       case "Standalone Application Settings..."
          revIDEStandaloneSettingsForStack the long id of the topStack

--- a/notes/bugfix-17176.md
+++ b/notes/bugfix-17176.md
@@ -1,0 +1,1 @@
+# Share This Stack no longer on menu

--- a/notes/bugfix-17192.md
+++ b/notes/bugfix-17192.md
@@ -1,0 +1,1 @@
+# Re-instate the Sample Stacks browser stack


### PR DESCRIPTION
Open the revOnline browser stack from the Sample Stack button in the
Menu Bar and Sample Projects button in the Start Center.

Reinstate the "Share this stack..." option in the File menu.
