### PR TITLE
Set the initial size and position of the Script Editor to be on screen

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4100,7 +4100,13 @@ on revIDEPositionPaletteDefault pStackName
       default 
          # If no sizing information can be found position the stack in the center of the 
          # default screen
-         set the loc of stack pStackName to the screenloc
+         
+         ## If the stack is a Script Editor ensure it will fit on screen
+         if pStackName begins with revIDEScriptEditorPrefix() then 
+            set the rect of stack pStackName to tScreenWidth * 0.3, tScreenHeight * 0.2, tScreenWidth * 0.7, tScreenHeight * 0.8
+         else
+            set the loc of stack pStackName to the screenloc
+         end if
          break
    end switch
    

--- a/notes/bugfix-16838.md
+++ b/notes/bugfix-16838.md
@@ -1,0 +1,1 @@
+# Set the initial rect of the Script Editor to be fully on screen


### PR DESCRIPTION
Calculate a size and position for the initial Script Editor that is
proportional to the working screen rect and fully on screen.
