### PR TITLE
Ensure text descenders on checkbox labels in the PI are not cut off

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.boolean.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.boolean.behavior.livecodescript
@@ -27,6 +27,7 @@ on editorResize
    lock messages
    set the width of button "checkbox" of me to the width of me
    set the width of button "checkbox" of me to the formattedwidth of button "checkbox" of me
+   set the height of button "checkbox" of me to the formattedheight of button "checkbox" of me
    set the top of button "checkbox" of me to the top of me
    set the left of button "checkbox" of me to the left of me
    unlock messages


### PR DESCRIPTION
Closes: #1039
