### PR TITLE
[[ Geometry Manager ]] Ensure default stack is correct when setting geometry

### DIFF
--- a/Toolset/libraries/revgeometrylibrary.livecodescript
+++ b/Toolset/libraries/revgeometrylibrary.livecodescript
@@ -1005,6 +1005,10 @@ on revCleanSetGeometry pWhichProperty, pWhatValue
 end revCleanSetGeometry
 
 on revSetGeometry pWhichProperty,pWhatValue
+   local tDefaultStack
+   put the defaultStack into tDefaultStack
+   set the defaultStack to ideStackOfObject(lGeometryObject)
+   
    local tTargetCard
    put revIDECardOfObject(lGeometryObject) into tTargetCard
    --empty card cache
@@ -1034,6 +1038,7 @@ on revSetGeometry pWhichProperty,pWhatValue
    --calculate relative distances if applicable
    # if "absolute" is in pWhichProperty and pWhatValue is false then revCalculateGeometryDistances
    revCalculateGeometryCardRank
+   set the defaultStack to tDefaultStack
 end revSetGeometry
 
 function revGetGeometry pWhichValue

--- a/notes/bugfix-16826.md
+++ b/notes/bugfix-16826.md
@@ -1,0 +1,1 @@
+# Geometry Manager settings should work


### PR DESCRIPTION
The object reference in the geometry array is the `name` of the referenced object
rather than the long id, so the defaultStack must be set the the object's stack.
