### PR TITLE
Enable substacks to be changed into main stacks using the PI

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2067,6 +2067,31 @@ function revIDEMainStacks
 end revIDEMainStacks
 
 /**
+A list of the stacks that can be set at the main stack of the given stack
+
+Returns: A list of the names of stacks, one per line
+
+Description:
+Use the <revIDEMainstackPropertyOptions> function to retrieve a list of the names of the 
+stacks that can be set as the main stack of the current stack, taking into account the 
+Show IDE Stacks preference.
+**/
+function revIDEMainstackPropertyOptions
+   local tStackList, tCurrentStack
+   put ideMainStacks() into tStackList
+   put revIDESelectedObjects() into tCurrentStack
+   
+   ## Allow the stack to be set as its own mainstack
+   if word 1 of tCurrentStack is "stack" then
+      if the short name of tCurrentStack is not among the lines of tStackList then
+         put return & the short name of tCurrentStack after tStackList
+      end if
+   end if
+   sort lines of tStackList
+   return tStackList
+end revIDEMainstackPropertyOptions
+
+/**
 A list of the current mainstacks
 
 Returns: A list of the names of the mainstacks currently in memory, one per line

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Stack.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Stack.txt
@@ -5,7 +5,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 ----------------------------------------------------------------------------------------------------
 name												
 title	
-mainStack								execute:get revIDEMainStacks()				
+mainStack								execute:get revIDEMainstackPropertyOptions()			
 decorations												
 windowShape												
 scaleFactor							1					

--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
@@ -104,7 +104,7 @@ location	Location	Position	com.livecode.pi.point	true	false		no_default
 lockLoc	Lock size and position	Position	com.livecode.pi.boolean	true	false	false		
 lockText	Lock text	Basic	com.livecode.pi.boolean	true	false			
 looping	Loop	Basic	com.livecode.pi.boolean	true	false		false	
-mainStack	Main stack	Basic	com.livecode.pi.enum	true	false			execute:get revIDEMainStacks()	
+mainStack	Main stack	Basic	com.livecode.pi.enum	true	false			execute:get revIDEMainstackPropertyOptions()	
 margins	Margins	Text	com.livecode.pi.string	true	false			
 mark	Marked	Basic	com.livecode.pi.boolean	true	false		false	
 markerDrawn	Draw shape at vertices	Basic	com.livecode.pi.boolean	true	false		false	

--- a/notes/bugfix-16414.md
+++ b/notes/bugfix-16414.md
@@ -1,0 +1,1 @@
+# Allow substacks to be made into mainstacks via the Property Inspector

--- a/notes/bugfix-17044.md
+++ b/notes/bugfix-17044.md
@@ -1,0 +1,1 @@
+# Allow substacks to be made into mainstacks via the Property Inspector

--- a/notes/bugfix-17044.md
+++ b/notes/bugfix-17044.md
@@ -1,1 +1,0 @@
-# Allow substacks to be made into mainstacks via the Property Inspector


### PR DESCRIPTION
The Mainstack property option list of a sunstacks now includes the
substack, allowing it to be selected and set as its own mainstack,
turning it into a mainstack.
