### PR TITLE
Show correct style and menuMode options for buttons in the PI

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Button.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Button.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Button					
 label												
 tooltip												
-style							standard	standard,transparent,opaque,rectangle,roundRect,shadow,menu,checkbox,radioButton				
+style							standard	standard,transparent,opaque,rectangle,roundRect,shadow,checkbox,radioButton				
 visible												
 opaque							true					
 showName							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Checkbox.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Checkbox.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Check					
 label												
 tooltip												
-style							checkbox	standard,transparent,opaque,rectangle,roundRect,shadow,menu,checkbox,radioButton				
+style							checkbox	standard,transparent,opaque,rectangle,roundRect,shadow,checkbox,radioButton				
 visible												
 opaque							false					
 showName							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.ComboBox.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.ComboBox.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							ComboBox Menu					
 label							Choice 1					
 tooltip												
-style							menu					
+style				false			menu					
 menuMode							combobox					
 menuMouseButton												
 visible							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DefaultButton.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DefaultButton.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Button					
 label												
 tooltip												
-style							standard	standard,transparent,opaque,rectangle,roundRect,shadow,menu,checkbox,radioButton				
+style							standard	standard,transparent,opaque,rectangle,roundRect,shadow,checkbox,radioButton				
 visible							true					
 opaque							true					
 showName							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.OptionMenu.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.OptionMenu.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Option Menu					
 label							Choice 1					
 tooltip												
-style							menu					
+style				false			menu					
 menuMode							option					
 menuMouseButton												
 visible							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PopupMenu.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PopupMenu.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							PopUp Menu					
 label												
 tooltip												
-style							menu					
+style				false			menu					
 menuMode							popup					
 menuMouseButton												
 visible							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PulldownMenu.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PulldownMenu.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Pulldown Menu					
 label												
 tooltip												
-style							menu					
+style				false			menu					
 menuMode							Pulldown					
 menuMouseButton												
 visible							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RadioButton.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RadioButton.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Radio					
 label												
 tooltip												
-style							radiobutton	standard,transparent,opaque,rectangle,roundRect,shadow,menu,checkbox,radioButton				
+style							radiobutton	standard,transparent,opaque,rectangle,roundRect,shadow,checkbox,radioButton				
 visible							true					
 opaque							false					
 showName							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RectangleButton.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RectangleButton.txt
@@ -6,7 +6,7 @@ Property : optional getter : optional setter	Label	Section	Editor	User Visible	R
 name							Button					
 label												
 tooltip												
-style							rectangle	standard,transparent,opaque,rectangle,roundRect,shadow,menu,checkbox,radioButton				
+style							rectangle	standard,transparent,opaque,rectangle,roundRect,shadow,checkbox,radioButton				
 visible							true					
 opaque							true					
 showName							true					

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TabPanel.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TabPanel.txt
@@ -45,8 +45,8 @@ top
 right												
 bottom												
 layer												
-style							menu					
-menumode							tabbed					
+style				false			menu					
+menumode				false			tabbed					
 dropShadow												
 innerShadow												
 outerGlow												

--- a/notes/bugfix-16623.md
+++ b/notes/bugfix-16623.md
@@ -1,0 +1,1 @@
+# Correct the options for the style and menuMode properties of buttons in the Property Inspector


### PR DESCRIPTION
As menu buttons require both their style and menuMode properties to
be set the option to set the style of a button (push, default,radio
etc) to "menu" in the Property Inspector has been removed. Similarly
the style editor for menu buttons has been hidden and the menuMode
editor shown. Tab panels cannot have their menuMode or style set in
the Property Inspector.
