### PR TITLE
Ensure the Property Inspector shows the correct value for lockLoc

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
@@ -102,7 +102,7 @@ linkColor	Link color	Colors	com.livecode.pi.color	true	false
 listBehavior	List behavior	Basic	com.livecode.pi.boolean	true	false			
 liveResizing	Live resizing	Basic	com.livecode.pi.boolean	true	false		false	
 location	Location	Position	com.livecode.pi.point	true	false		no_default	
-lockLoc	Lock size and position	Position	com.livecode.pi.boolean	true	false	false		
+lockLoc	Lock size and position	Position	com.livecode.pi.boolean	true	false		false		
 lockText	Lock text	Basic	com.livecode.pi.boolean	true	false			
 looping	Loop	Basic	com.livecode.pi.boolean	true	false		false	
 mainStack	Main stack	Basic	com.livecode.pi.enum	true	false			execute:get revIDEMainstackPropertyOptions()	

--- a/notes/bugfix-17162.md
+++ b/notes/bugfix-17162.md
@@ -1,0 +1,1 @@
+# Ensure the Property Inspector shows the correct value for lockLoc


### PR DESCRIPTION
The definition for the lockLoc property has been corrected so it does
not belong to a group, and the default value is false.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/livecode/livecode-ide/1062)

<!-- Reviewable:end -->
