### PR TITLE
Show the number property in the Property Inspector

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Button.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Button.txt
@@ -69,4 +69,5 @@ left
 top												
 right												
 bottom												
-layer												
+layer
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Card.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Card.txt
@@ -43,4 +43,5 @@ left					true
 top					true							
 right					true							
 bottom					true							
-layer												
+layer		
+number					false											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Checkbox.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Checkbox.txt
@@ -68,5 +68,6 @@ location
 left												
 top												
 right												
-bottom												
-layer												
+bottom											
+layer
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.ComboBox.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.ComboBox.txt
@@ -68,4 +68,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.CurveGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.CurveGraphic.txt
@@ -47,4 +47,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DataGrid.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DataGrid.txt
@@ -60,3 +60,4 @@ right
 bottom												
 layer		
 layerMode
+number

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DataGridForm.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DataGridForm.txt
@@ -42,3 +42,4 @@ right
 bottom												
 layer		
 layerMode
+number

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DefaultButton.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.DefaultButton.txt
@@ -72,4 +72,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Field.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Field.txt
@@ -77,4 +77,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Group.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Group.txt
@@ -64,4 +64,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Image.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Image.txt
@@ -50,4 +50,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.LabelField.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.LabelField.txt
@@ -72,4 +72,5 @@ left
 top												
 right												
 bottom												
-layer												
+layer	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.LineGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.LineGraphic.txt
@@ -48,4 +48,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.ListField.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.ListField.txt
@@ -78,4 +78,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.LittleArrows.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.LittleArrows.txt
@@ -48,4 +48,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay		
+number										

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.OptionMenu.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.OptionMenu.txt
@@ -71,4 +71,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.OvalGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.OvalGraphic.txt
@@ -48,4 +48,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Player.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Player.txt
@@ -63,4 +63,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PolygonGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PolygonGraphic.txt
@@ -53,4 +53,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PopupMenu.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PopupMenu.txt
@@ -67,4 +67,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Progressbar.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Progressbar.txt
@@ -44,4 +44,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PulldownMenu.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.PulldownMenu.txt
@@ -70,4 +70,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RadioButton.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RadioButton.txt
@@ -70,4 +70,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RectangleButton.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RectangleButton.txt
@@ -71,4 +71,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RectangleGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RectangleGraphic.txt
@@ -46,4 +46,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RegularGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RegularGraphic.txt
@@ -48,4 +48,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RoundRectGraphic.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.RoundRectGraphic.txt
@@ -48,4 +48,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Scrollbar.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Scrollbar.txt
@@ -50,4 +50,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay	
+number											

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Slider.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Slider.txt
@@ -53,4 +53,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TabPanel.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TabPanel.txt
@@ -51,4 +51,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TableField.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TableField.txt
@@ -78,4 +78,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TextArea.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TextArea.txt
@@ -84,4 +84,5 @@ dropShadow
 innerShadow												
 outerGlow												
 innerGlow												
-colorOverlay												
+colorOverlay
+number												

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.widget.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.widget.txt
@@ -24,4 +24,5 @@ layer
 textFont												
 textAlign												
 textSize												
-traversalOn		Advanced					false										
+traversalOn		Advanced					false	
+number									

--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
@@ -125,7 +125,7 @@ minWidth	Min width	Position	com.livecode.pi.number	true	false		32
 multipleHilites	Multi-line	Basic	com.livecode.pi.boolean	true	false		false	
 name	Name	Basic	com.livecode.pi.string	true	false		no_default		
 nonContiguousHilites	Non-contiguous	Basic	com.livecode.pi.boolean	true	false			
-number	Number	Basic	com.livecode.pi.number	true	false			
+number	Number	Advanced	com.livecode.pi.integer	true	true		no_default			1		1		
 numberFormat	Value format	Basic	com.livecode.pi.string	true	false			
 opaque	Opaque	Basic	com.livecode.pi.boolean	true	false			
 orientation	Orientation	Basic	com.livecode.pi.enum	true	true			Horizontal,Vertical

--- a/notes/bugfix-17079.md
+++ b/notes/bugfix-17079.md
@@ -1,0 +1,1 @@
+# Show the number property of objects in the Property Inspector


### PR DESCRIPTION
The number property is shown on the Advanced pane and is read only for
all objects except cards, where it is editable.
