### PR TITLE
[[ Bug 16909 ]] Prevent stuttering gradient stops

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.gradientramp.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.gradientramp.behavior.livecodescript
@@ -12,7 +12,9 @@ on editorUpdate
    put the editorEffective of me into tEffective
    
    lock messages
-   set the gradientstops of widget 1 of me to tValue
+   if the mouse is not "down" then
+      set the gradientstops of widget 1 of me to tValue
+   end if
    unlock messages
    subeditorUpdate
    unlock screen


### PR DESCRIPTION
This prevents the PI update mechanism from changing the position
of the current gradient stop while it is being dragged by the user.
Fix provided by @BerndN
