### PR TITLE
Set the ID of any images created on IDE stacks to a reserved ID

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2438,6 +2438,26 @@ function revIDEIconID pIcon
    return the ID of image pIcon of card 1 of stack "reviconsnew"
 end revIDEIconID
 
+function revIDENewIconID
+   local tIconID, tIDList
+   
+   repeat with tImage = 1 to the number of images of stack "revTools" 
+      put the ID of image tImage of stack "revTools" & comma after tIDList
+   end repeat
+   
+   repeat with tImage = 1 to the number of images of stack "revMenubar" 
+      put the ID of image tImage of stack "revMenubar" & comma after tIDList
+   end repeat
+   
+   repeat with tImage = 1 to the number of images of stack "revIDELibrary" 
+      put the ID of image tImage of stack "revIDELibrary" & comma after tIDList
+   end repeat
+   if the last char of tIDList is comma then delete the last char of tIDList
+   
+   put max(tIDList) + 1 into tIconID
+   return tIconID
+end revIDENewIconID
+
 function revIDEThemePath
    # Get the platform and system version
    local tPlatformName, tSystemVersion
@@ -3885,6 +3905,7 @@ on revIDESetCursor pCursor
       set the filename of the templateimage to tImagePath
       set the visible of the templateimage to false
       create image pCursor
+      set the id of it to revIDENewIconID()
       reset the templateimage
    end if
 

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2438,24 +2438,24 @@ function revIDEIconID pIcon
    return the ID of image pIcon of card 1 of stack "reviconsnew"
 end revIDEIconID
 
+/*
+The IDE uses a number of referenced images as icons, to ensure these images do not clash with user images IDs in the reserved range are assigned. The reserved range is 101000 to 103000
+
+Returns (integer): The next available ID in the reserved range.
+*/
+
+constant kFirstReservedIconID = 101000
+
 function revIDENewIconID
-   local tIconID, tIDList
+   local tNextIconID, tIDList
    
-   repeat with tImage = 1 to the number of images of stack "revTools" 
-      put the ID of image tImage of stack "revTools" & comma after tIDList
-   end repeat
+   put the ID stack "revTools" & comma into tIDList
+   put the ID of stack "revMenubar" & comma after tIDList
+   put the ID of stack "revIDELibrary" & comma after tIDList
+   put kFirstReservedIconID after tIDList
    
-   repeat with tImage = 1 to the number of images of stack "revMenubar" 
-      put the ID of image tImage of stack "revMenubar" & comma after tIDList
-   end repeat
-   
-   repeat with tImage = 1 to the number of images of stack "revIDELibrary" 
-      put the ID of image tImage of stack "revIDELibrary" & comma after tIDList
-   end repeat
-   if the last char of tIDList is comma then delete the last char of tIDList
-   
-   put max(tIDList) + 1 into tIconID
-   return tIconID
+   put max(tIDList) + 1 into tNextIconID
+   return tNextIconID
 end revIDENewIconID
 
 function revIDEThemePath

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -346,16 +346,19 @@ on generateMenubarUI
          local tName
          put tItem & tDividerCount into tName
          create image tName in group "toolbar"of me
+         set the id of it to revIDENewIconID()
          set the filename of image tName of group "toolbar" of me to revMenubarButtonNameToIconPath(tItem)
          add 1 to tDividerCount
       else
          create invisible image tItem in group "icons" of me
+         set the id of it to revIDENewIconID()
          set the filename of image tItem of me to revMenubarButtonNameToIconPath(tItem)
          local tFilename
          repeat for each item tStyle in "hilited,disabled" 
             put revMenubarButtonNameToIconPath(tItem, tStyle) into tFilename
             if there is a file tFilename then
                create invisible image (tItem & "-" & tStyle) in group "icons" of me
+               set the id of it to revIDENewIconID()
                set the filename of image (tItem & "-" & tStyle) of me to tFilename
                if tStyle is "hilited" then 
                   set the hilitedIcon of the templatebutton to the id of image (tItem & "-" & tStyle) of group "icons" of me

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -271,6 +271,7 @@ on generatePalette
             set the name of the templateimage to tControlTypeID
             set the visible of the templateimage to true
             create image in group "errors" of group "contents"
+            set the id of it to revIDENewIconID()
          end if
          
          local tImageID
@@ -279,6 +280,7 @@ on generatePalette
             set the visible of the templateimage to false
             set the filename of the templateimage to sViewsData[tView][tControlTypeID]["icon"]
             create image in group "images" of group "contents"
+            set the id of it to revIDENewIconID()
             put the long id of image (tControlTypeID & ".icon.png") of group "images" of group "contents" into tImageID
             revIDEResizeImageInBounds tImageID, BLOCK_SIZE * 2,BLOCK_SIZE
             set the icon of the templatebutton to the ID of tImageID
@@ -288,6 +290,7 @@ on generatePalette
             set the visible of the templateimage to false
             set the filename of the templateimage to tThemePath & slash & tControlTypeID & ".icon.png"
             create image in group "images" of group "contents"
+            set the id of it to revIDENewIconID()
             put the long id of image (tControlTypeID & ".icon.png") of group "images" of group "contents" into tImageID
             revIDEResizeImageInBounds tImageID, BLOCK_SIZE * 2,BLOCK_SIZE
             set the icon of the templatebutton to the ID of tImageID


### PR DESCRIPTION
The Menubar, Tools Palette and revIDELibrary all use images, the IDs
of some of these images were conflicting with image IDs on user stacks
resulting in the icon chooser showing IDE images rather than user
images. Setting the ID of images on IDE stacks to within the
reserved range when they are created should prevent this conflict.

Closes #860
