### PR TITLE
[[ PB ]] Handle backspacekey when PB control is focused

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -798,6 +798,10 @@ on cloneControls
    unlock screen
 end cloneControls
 
+on backSpaceKey
+   deleteControls
+end backSpaceKey
+
 on deleteControls
    local tControlID, tGroupID, tControlList
    put pbSelectedObjects() into tControlList


### PR DESCRIPTION
This prevents a potential deletion of a selected object on the stack
when the backspace key is pressed.
