### PR TITLE
Update the Project Browser when a control is pasted into a group

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -111,6 +111,7 @@ on ideSelectedObjectChanged
 end ideSelectedObjectChanged
 
 on ideNewControl pTarget
+   put the long id of pTarget into pTarget
    if word  1 of pTarget is "stack" or  word  1 of pTarget is "card" then
       exit ideNewControl
    else if word  1 of pTarget is "group" then

--- a/notes/bugfix-17170.md
+++ b/notes/bugfix-17170.md
@@ -1,0 +1,1 @@
+# Update the Project Browser correctly when Paste into Group is used


### PR DESCRIPTION
The Project Browser receives the ideNewControl message when a control
is pasted into a group but the object ID passed with the message
does not include the fact that the new control is grouped. By using
the long ID of the passed object ID the Project Browser correctly updates
with the new, grouped control.
