### PR TITLE
[[ PI ]] Use there is not a to determine existence of pi objects

### DIFF
--- a/Toolset/palettes/inspector/revinspector.livecodescript
+++ b/Toolset/palettes/inspector/revinspector.livecodescript
@@ -364,7 +364,7 @@ on ideSelectedObjectChanged
    end if
    
    repeat with x = the number of lines in tObjects down to 1
-      if not exists(line x of tObjects) then
+      if there is not a (line x of tObjects) then
          delete line x of tObjects
       end if
    end repeat


### PR DESCRIPTION
Exists can take an arbitrary chunk expression, so exists (line x
of tVar) will attempt to evaluate tVar as a container (i.e. field).

Use `there is a` to force evaluation of a line of the variable as
an arbitrary object.
