### PR TITLE
[[ Bug 17279 ]] Relativize appropriate stackFile paths

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5704,6 +5704,63 @@ on revIDESetGradientProperty pObject, pProperty, pValue
    end repeat
 end revIDESetGradientProperty
 
+private function __resolveStackFilePath pBasePath, pOtherPath
+   -- First absolutize other path (if possible)
+   local tOldFolder
+   put the folder into tOldFolder
+   set the itemDelimiter to slash
+   
+   local tFolderResult
+   set the folder to item 1 to -2 of pOtherPath
+   put the result into tFolderResult
+   if tFolderResult is not empty then
+      set the folder to tOldFolder
+      return pOtherPath
+   end if
+   put the folder & slash & item -1 of pOtherPath into pOtherPath
+   set the folder to tOldFolder
+   
+   -- At this point tOtherPath should be absolute, so if its
+   -- (component-wise) prefix is pBasePath we relativize again.
+   local tBasePathFolder
+   put item 1 to -2 of pBasePath & slash into tBasePathFolder
+   if pOtherPath begins with tBasePathFolder then
+      delete char 1 to (the number of chars in tBasePathFolder) of pOtherPath
+   end if
+   
+   return pOtherPath
+end __resolveStackFilePath
+
+command revIDESetStackFilesProperty pObject, pProperty, pValue
+   local tProcessedValue
+   put empty into tProcessedValue
+   
+   -- If the stack in question has a filename then we process.
+   local tBaseFilename
+   put the effective filename of pObject into tBaseFilename
+   if tBaseFilename is not empty then
+      repeat for each line tEntry in pValue
+         local tStackName, tStackPath
+         put item 1 of tEntry into tStackName
+         put item 2 to -1 of tEntry into tStackPath
+         
+         -- Attempt to resolve the referenced stack's path relative to
+         -- the base path. This will have no effect if the stack path cannot
+         -- be resolved.
+         local tResolvedStackPath
+         put __resolveStackFilePath(tBaseFilename, tStackPath) into tStackPath
+         
+         put tStackName & comma & tStackPath & return after tProcessedValue
+      end repeat
+      delete the last char of tProcessedValue
+   else
+      put pValue into tProcessedValue
+   end if
+   
+   -- Set the stackFile property to the processed stackFile list
+   set the stackFiles of pObject to tProcessedValue
+end revIDESetStackFilesProperty
+
 #############
 # Standalone Settings
 #############

--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
@@ -163,7 +163,7 @@ showLines	Text baselines	Table	com.livecode.pi.boolean	true	false
 showName	Show name	Basic	com.livecode.pi.boolean	true	false			
 showSelection	Hilite selection	Basic	com.livecode.pi.boolean	true	false			
 showValue	Show value	Basic	com.livecode.pi.boolean	true	false		false			
-stackFiles	Stack files	Stack Files	com.livecode.pi.stackfiles	true	false			
+stackFiles::revIDESetStackFilesProperty	Stack files	Stack Files	com.livecode.pi.stackfiles	true	false			
 startAngle	Start	Basic	com.livecode.pi.number	true	false			
 startArrow	Start arrow	Basic	com.livecode.pi.boolean	true	false			
 startTime	Start	Basic	com.livecode.pi.integer	true	false					0		1			

--- a/notes/bugfix-17279.md
+++ b/notes/bugfix-17279.md
@@ -1,0 +1,6 @@
+# Relativize appropriate stackFile paths.
+
+When adding a stackFile to a stack with a filename, the IDE will
+now relativize the referenced stack's path if it is in the same
+folder, or a folder beneath that of the target stack.
+


### PR DESCRIPTION
This patch adds a custom setprop handler for the stackFiles property
of stacks.

The custom setprop handler will relativize any file paths in the new
value relative to the target object in the case where the referenced
file is in the same folder, or in a folder beneath the folder containing
the target object.
