### PR TITLE
[[ IDE ]] Fix some cropped text

### DIFF
--- a/Toolset/palettes/reverrordisplay.livecodescript
+++ b/Toolset/palettes/reverrordisplay.livecodescript
@@ -70,7 +70,7 @@ on preOpenStack
    set the vgrid of it to true
    set the lockText of it to true
    set the dontwrap of it to true
-   set the tabstops of it to "60,2000"
+   set the tabstops of it to "100,2000"
    set the margins of it to "8,14,8,8"
    set the bordercolor of it to "220,220,220"
    set the showfocusborder of it to false

--- a/Toolset/palettes/script editor/behaviors/revsedocumentationpanebehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsedocumentationpanebehavior.livecodescript
@@ -65,7 +65,6 @@ command paneOpenControl
    set the name of the templateButton to "LaunchDocs"
    set the label of the templateButton to "Launch Documentation"
    set the lockLocation of the templateButton to true
-   set the width of the templateButton to sMetrics["launchButtonWidth"]
    set the height of the templateButton to sMetrics["launchButtonHeight"]
    create button in me
    reset the templateButton
@@ -89,10 +88,19 @@ end paneCloseControl
 
 command paneResizeControl
    metricsInit
-  set the rect of field "View" of me to (the left of me),(the top of me),(the right of me),(the bottom of me - sMetrics["bottombarHeight"])
-  set the bottomRight of button "FullMode" of me to (item 1 of the bottomRight of me + sMetrics["toggleButtonMargin"]), (item 2 of the bottomRight of me)
-  set the bottomLeft of button "LaunchDocs" of me to (item 1 of the bottomLeft of me + sMetrics["launchButtonMargin"]), (item 2 of the bottomLeft of me - 1)
-  scrollbarCheck
+   local tRect
+   put the rect of me into tRect
+   split tRect by comma
+   set the rect of field "View" of me to tRect[1], tRect[2], tRect[3], \
+         tRect[4] - sMetrics["bottombarHeight"]
+   set the bottomRight of button "FullMode" of me to \ 
+         tRect[3] + sMetrics["toggleButtonMargin"], tRect[4]
+   set the width of button "LaunchDocs" of me to \ 
+         the formattedWidth of button "LaunchDocs" of me + \ 
+         sMetrics["launchButtonPadding"]
+   set the bottomLeft of button "LaunchDocs" of me to tRect[1] + \ 
+         sMetrics["launchButtonMargin"], tRect[4] - 1
+   scrollbarCheck
 end paneResizeControl
 
 # Description
@@ -391,8 +399,8 @@ private command metricsInit
    put "8,20,110,8" into sMetrics["viewFieldMargins"]
    put 96 into sMetrics["toggleButtonWidth"]
    put 24 into sMetrics["toggleButtonHeight"]
-   put 124 into sMetrics["launchButtonWidth"]
    put 24 into sMetrics["launchButtonHeight"]
+   put 12 into sMetrics["launchButtonPadding"]
    put 26 into sMetrics["bottombarHeight"]
    put 1 into sMetrics["launchButtonMargin"]
    


### PR DESCRIPTION
Closes #985
- Leave enough space for left tabs in error display
- Expand Launch Documentation button in SE to fit
