### PR TITLE
[[ Bug 17321 ]] Don't send preOpenStack to tools palette

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1321,26 +1321,27 @@ command revInternal__InitialiseErrors
 end revInternal__InitialiseErrors
 
 command revInternal__InitialiseTools
-  revInternal__Log "Enter", "Tools Initialisation"
-  
-  local tToolsStackName
-  put revIDEPaletteToStackName("Tools") into tToolsStackName
-  
-  lock screen
-  send "preOpenStack" to stack tToolsStackName
-  set the topLeft of stack tToolsStackName to the cToolsTopLeft of stack "revPreferences"
-  palette stack tToolsStackName
-  
-  # IM-2016-03-01: [[ Bug 16244 ]] IDE stacks should always hide invisible objects
-  set the showInvisibles of stack tToolsStackName to false
-  
-  --PM-2015-10-05: [[ Bug 16099 ]] IDE should default to Pointer tool and highlight its icon on the Tools palette
-  revIDESetTool "pointer"
-  unlock screen 
-  
-  revInternal__Log "Leave", "Tools Initialisation"
-  
-  return true
+   revInternal__Log "Enter", "Tools Initialisation"
+   
+   local tToolsStackName
+   put revIDEPaletteToStackName("Tools") into tToolsStackName
+   
+   --PM-2015-10-05: [[ Bug 16099 ]] IDE should default to Pointer tool and highlight its icon on the Tools palette
+   revIDESetTool "pointer"
+   
+   lock screen
+   go invisible stack tToolsStackName as palette
+   revIDEPositionPalette("tools")
+   
+   # IM-2016-03-01: [[ Bug 16244 ]] IDE stacks should always hide invisible objects
+   set the showInvisibles of stack tToolsStackName to false
+   
+   show stack tToolsStackName
+   unlock screen 
+   
+   revInternal__Log "Leave", "Tools Initialisation"
+   
+   return true
 end revInternal__InitialiseTools
 
 command revInternal__InitialiseIcons

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4415,11 +4415,18 @@ on revIDEPositionPalette pStackName
       # default location. Only do this for specified stacks.
       switch pStackName
          case "revMenuBar"
-         case "revTools"
          case "message box"
          case "revDictionary"
             revIDEPositionPaletteDefault pStackName
             break
+         case "revTools"
+            local tOldPref
+            put revIDEGetPreference("cToolsTopLeft") into tOldPref
+            if tOldPref is not empty then
+               set the topleft of stack pStackName to tOldPref
+            else
+               revIDEPositionPaletteDefault pStackName
+            end if
          default
             if pStackName begins with revIDEScriptEditorPrefix() then
                revIDEPositionPaletteDefault pStackName
@@ -4433,6 +4440,7 @@ on revIDEPositionPalette pStackName
    
 end revIDEPositionPalette
 
+constant kToolsMenubarGap = 25
 on revIDEPositionPaletteDefault pStackName
    # No previous rect was found for stack to calculate the appropriate position for the stack
    local tScreenHeight, tScreenWidth
@@ -4444,7 +4452,12 @@ on revIDEPositionPaletteDefault pStackName
          set the topleft of stack pStackName to 0,0
          break
       case "revTools"
-         set the topleft of stack pStackName to 0,the bottom of stack revIDEPaletteToStackName("menubar") + revIDEPaletteBarHeight(the long ID of stack pStackName)
+         local tMenuBar
+         put revIDEPaletteToStackName("menubar") into tMenuBar
+         local tTop
+         put the bottom of stack tMenuBar into tTop
+         add kToolsMenubarGap to tTop
+         set the topleft of stack pStackName to the left of stack tMenuBar,tTop
          break
       case "message box"
          set rect of stack pStackName to 0,tScreenHeight * 0.75, tScreenWidth * 0.3, tScreenHeight

--- a/notes/bugfix-17321.md
+++ b/notes/bugfix-17321.md
@@ -1,0 +1,1 @@
+# Ensure tools palette is unsubscribed from msgs when closed


### PR DESCRIPTION
There is no need for this hack any more, and it was causing an
additional tools palette subscription.

Also tweak tools palette positioning to respect old preference, if
no new pref is present.
