### PR TITLE
[Bug 17301] Make sure grouping controls respects the layer order

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3452,16 +3452,15 @@ on revIDEGroupObjects pObjectIDs
 
    repeat for each line tControl in pObjectIDs
       if the layer of tControl < tLayer then put the layer of tControl into tLayer
-      put tControl & " and " after tList
    end repeat
 
-   delete char -5 to -1 of tList
-   put "group " before tList
-
-   do tList
+   // PM-2016-04-07: [[ Bug 17301 ]] Use the "group" command (without an objectList)
+   // so as to group the selection in layer order
+   group
    
    put the long id of the owner of tObj into tGroupID
    set the layer of tGroupID to tLayer
+   unlock screen
    return tGroupID
 end revIDEGroupObjects
 

--- a/notes/bugfix-17301.md
+++ b/notes/bugfix-17301.md
@@ -1,0 +1,1 @@
+#  Grouping controls using the menubar "Group" button now respects the layer order 


### PR DESCRIPTION
The `selectedObject` property is an ordered list of selected objects - ordered by the order in which they were selected.

The IDE was building a group command containing all the objects in the selected object list, which caused the objects to be grouped _in that order_. In this patch, the IDE uses the simple `group` command (i.e. with no objectList as a parameter) which groups the selection in layer order.
