### PR TITLE
Check for the existence of an object before adding it to the PB

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1036,6 +1036,7 @@ private function __dumpArrayRecurse pArray, pLevel, @pCounter, @pList
 end __dumpArrayRecurse
 
 function __revIDEError pMessage
+   global gRevDevelopment
    local tErrorContext, tErrorText, tLockedMessages
    put line -2 of the executioncontexts into tErrorContext
 
@@ -1044,8 +1045,12 @@ function __revIDEError pMessage
    unlock messages
 
    put "ERROR:" && pMessage & return & "line:" && item 3 of tErrorContext & return & "handler:" && item 2 of tErrorContext & return & "script object:" && item 1 of tErrorContext into tErrorText
-   put return & tErrorText after msg
-
+   
+   ## If in IDE development mode then show IDE errors in the message box
+   if gRevDevelopment is true then
+      put return & tErrorText after msg
+   end if
+   
    # if the messages were locked, lock them again
    if tLockedMessages is true then
       lock messages

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -118,6 +118,10 @@ on ideSelectedObjectChanged
 end ideSelectedObjectChanged
 
 on ideNewControl pTarget
+   if not exists(pTarget) then
+      exit ideNewControl
+   end if
+   
    put the long id of pTarget into pTarget
    if word  1 of pTarget is "stack" or  word  1 of pTarget is "card" then
       exit ideNewControl
@@ -129,10 +133,16 @@ on ideNewControl pTarget
 end ideNewControl
 
 on ideNewCard pTarget
+   if not exists(pTarget) then
+      exit ideNewCard
+   end if
    addCardToProjectBrowser pTarget
 end ideNewCard
 
 on ideNewStack pTarget
+   if not exists(pTarget) then
+      exit ideNewStack
+   end if
    addStackToProjectBrowser pTarget
 end ideNewStack
 
@@ -158,6 +168,11 @@ end ideReleaseStack
 
 on ideOpenStack pTarget
    local tStack
+   
+   if not exists(pTarget) then
+      exit ideOpenStack
+   end if
+   
    if word 1 of pTarget  is "card" then
       put ideStackOfObject(pTarget) into tStack
    else if word 1 of pTarget is "stack" then

--- a/notes/bugfix-17048.md
+++ b/notes/bugfix-17048.md
@@ -1,0 +1,1 @@
+# Check an object exists before adding to the list of object in the Project Browser


### PR DESCRIPTION
In some cases the Project Browser was receiving ideNewControl messages
for objects that had already been deleted, causing a "no such object"
error. The Project Browser now checks the existence of an object
before adding it to the display.

Additionally these IDE errors were being displayed in the Message Box.
IDE errors are now only shown in the Message Box if gRevDevelopment is
true.
