### PR TITLE
[[ Bug ]] Set default properties of objects correctly

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3168,7 +3168,7 @@ private command __setPropertiesToDefaults pObjectID, pPropsInfoA
       if "default" is not among the keys of tPropInfoA then next repeat
       if tPropInfoA["default"] is "no_default" then next repeat
       if tPropInfoA["read_only"] is true then next repeat
-      revIDESetPropertyOfObject pObjectID, tProperty, tPropInfoA["default"]
+      __setPropertyOfObject pObjectID, tProperty, tPropInfoA["default"]
    end repeat
 end __setPropertiesToDefaults
 
@@ -5605,6 +5605,10 @@ function revIDEGetDataGridColumns pObject, pProperty
 end revIDEGetDataGridColumns
 
 on revIDESetDataGridColumnProperty pObject, pProperty, pValue
+   if sCurrentColumn is empty then
+      exit revIDESetDataGridColumnProperty
+   end if
+   
    switch pProperty
       case "column name"
          set the dgColumnName[sCurrentColumn] of pObject to pValue
@@ -5787,7 +5791,7 @@ on revIDESetTableProperty pObject, pProperty, pValue
                set the cREVTable["currentview"] of pObject to the text of pObject
             end if
          end if
-         revDisplayFormattedData
+         revDisplayFormattedData pObject
          if pValue then
             set the vScrollbar of pObject to true
             set the hScrollbar of pObject to true

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -905,7 +905,7 @@ function ideObjectTypeFromObject pObjectID
          end if
          break
       case "field"
-         if the basicTableObject of pObjectID then
+            if revIDEGetTableProperty(pObjectID, "basicTableObject") then
             return "com.livecode.interface.classic.TableField"
          else if the listbehavior of pObjectID is true then
             return "com.livecode.interface.classic.ListField"

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5775,10 +5775,14 @@ command revIDENewDataGridColumnBehavior pObject
 end revIDENewDataGridColumnBehavior
 
 on revIDESetTableProperty pObject, pProperty, pValue
+   local tWasTableObject
+   put the cREVGeneral["table"] of pObject into tWasTableObject
    switch pProperty
       case "celledit"
          set the cRevTable[pProperty] of pObject to pValue
+         if tWasTableObject then
          set the locktext of pObject to pValue
+         end if
          break
       case "basicTableObject"
          set the cREVGeneral["table"] of pObject to pValue
@@ -5791,10 +5795,14 @@ on revIDESetTableProperty pObject, pProperty, pValue
                set the cREVTable["currentview"] of pObject to the text of pObject
             end if
          end if
+         
+         # Only change the contents if this was a table or is becoming one
+         if pValue or tWasTableObject then
          revDisplayFormattedData pObject
+         end if
+         
          if pValue then
             set the vScrollbar of pObject to true
-            set the hScrollbar of pObject to true
          end if
          break
       case "cellformat"

--- a/tests/core/objectprops/objectdefaultprops.livecodescript
+++ b/tests/core/objectprops/objectdefaultprops.livecodescript
@@ -24,6 +24,7 @@ on TestSetup
    put the script of stack tIDELibrary into tScript
    replace "_internal" with "--_internal" in tScript
    replace "the revObjectListeners" with "empty" in tScript
+   replace "revDisplayFormattedData" with "--revDisplayFormattedData" in tScript	
    set the script of stack tIDELibrary to tScript
 
    insert the script of stack "revIDELibrary" into back

--- a/tests/core/objectprops/objectprops.livecodescript
+++ b/tests/core/objectprops/objectprops.livecodescript
@@ -24,6 +24,7 @@ on TestSetup
    put the script of stack tIDELibrary into tScript
    replace "_internal" with "--_internal" in tScript
    replace "the revObjectListeners" with "empty" in tScript
+   replace "revDisplayFormattedData" with "--revDisplayFormattedData" in tScript
    set the script of stack tIDELibrary to tScript
 
    insert the script of stack "revIDELibrary" into back

--- a/tests/core/objectprops/objecttypes.livecodescript
+++ b/tests/core/objectprops/objecttypes.livecodescript
@@ -24,6 +24,7 @@ on TestSetup
    put the script of stack tIDELibrary into tScript
    replace "_internal" with "--_internal" in tScript
    replace "the revObjectListeners" with "empty" in tScript
+   replace "revDisplayFormattedData" with "--revDisplayFormattedData" in tScript
    set the script of stack tIDELibrary to tScript
 
    insert the script of stack "revIDELibrary" into back


### PR DESCRIPTION
- Use setters from prop definition files when setting object default props
- Prevent table props from clobbering other props
- Fix error in tests due to using table library
