### PR TITLE
Prevent the IDE handling newBackground and deleteBackground messages

### DIFF
--- a/Toolset/libraries/revidemessagehandlerlibrary.livecodescript
+++ b/Toolset/libraries/revidemessagehandlerlibrary.livecodescript
@@ -149,24 +149,6 @@ on newWidget
    pass newWidget
 end newWidget
 
-on newBackground
-   local tTarget
-   put the long id of the target into tTarget
-   if not revIDEObjectIsOnIDEStack(tTarget) then
-      send "ideMessageSend" &&  "ideNewControl","tTarget" to stack "revIDELibrary" in 0 milliseconds
-   end if
-   pass newBackground
-end newBackground
-
-on deleteBackground
-   local tTarget
-   put the long id of the target into tTarget
-   if not revIDEObjectIsOnIDEStack(tTarget) then
-      send "ideMessageSend ideControlDeleted","tTarget" to stack "revIDELibrary" in 0 milliseconds
-   end if
-   pass deleteBackground
-end deleteBackground
-
 on deleteButton
    local tTarget
    put the long id of the target into tTarget


### PR DESCRIPTION
When a group is created newGroup and newBackground messages are sent,
the newBackground messgage is for compatibility with HyperCard. Both
messages are mapped to an ideNewControl message which was causing the
Project Browser to believe 2 new groups had been deleted and update
accordingly. Removing the newBackground message from the Message
Handler Library ensures only the newGroup message is handler.

The deleteBackground message has also been removed for the same reason.

Closes #1127 
