### PR TITLE
[[ Bug 15963 & 15964 ]] Handle no found character ranges to replace

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -4940,6 +4940,11 @@ command replaceAll pQuery, pString, pIsRegExp, pUseWildCards, pWholeMatch, pIgno
       findText tScript, true, 1, "", tSearch
       put the result into tResults
       
+      # Move to next object if no search results found
+      if tResults is empty then
+         next repeat
+      end if
+      
       # Build the replacements into a single operation so it can be undone
       local tAt, tNewText, tOldText
       replaceBuildSingleOperation tScript, tResults, pString, tAt, tNewText, tOldText

--- a/notes/bugfix-15963-15964.md
+++ b/notes/bugfix-15963-15964.md
@@ -1,0 +1,1 @@
+# Finding a string that doesn't exist in the script during replace all should not leave the dialog and cursor in a broken state


### PR DESCRIPTION
Finding a string that doesn't exist in the script during replace all
was leaving the dialog and cursor in a broken state
