### PR TITLE
[Bug 17404] UI fonts do not appear correctly in the menubar font list

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -86,6 +86,16 @@ private on setupTextMenu
    put the fontNames into tFontNames
    replace "/" with "\" in tFontNames
    sort lines of tFontNames
+   
+   /* Fake fonts begin with "(", but the menu code interprets a "(" at 
+   the beginning of the item to mean the item is disabled. 
+   So, to show a "(" instead of disabling, we need to double it */
+   repeat with tLine = 1 to the number of lines of tFontNames
+      if line tLine of tFontNames begins with "(" then
+         put "(" before line tLine of tFontNames
+      end if
+   end repeat
+   
    put "Use Owner's Font" & return & "-" & return before tFontNames
    
    local fontnum

--- a/notes/bugfix-17404.md
+++ b/notes/bugfix-17404.md
@@ -1,0 +1,1 @@
+#  Make sure font list in menubar has no disabled items


### PR DESCRIPTION
Fake fonts begin with "(", but the menu code interprets a "(" at the beginning of the item to mean the item is disabled. So, to show a "(" instead of disabling, we need to double it 
