### PR TITLE
[Bug 17456] Prevent script editor getting confused with >10 scripts

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -5288,12 +5288,12 @@ private command __EditorFieldCacheFlush pRuggedObjectId
    if tField is empty then
       exit __EditorFieldCacheFlush
    end if
-   if the name of field tField is "Script" then
+   if the name of field tField of me is "Script" then
       exit __EditorFieldCacheFlush
    end if
 
    lock messages
-   delete field tField
+   delete field tField of me
    unlock messages
 
    delete variable sScriptEditorFieldCache[pRuggedObjectId]

--- a/notes/bugfix-17456.md
+++ b/notes/bugfix-17456.md
@@ -1,0 +1,1 @@
+# Prevent script editor from getting confused with > 10 open scripts


### PR DESCRIPTION
Add `of me` in some strategic places to make sure the behaviour
looks for cached fields in the right places.
