### PR TITLE
[Bug 17354] Make sure msg box always remembers previous location

### DIFF
--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -90,19 +90,20 @@ on openStack
    
    lock messages
    set the minHeight of me to tMinHeight
-   moveStack
+   moveMsgBoxStack
    unlock messages
    unlock screen
 end openStack
 
-on moveStack
+--PM-2016-04-29: [[ Bug 17534 ]] Make sure the correct handler is called
+on moveMsgBoxStack
    --set the position of the stack as a custom property so when it is reopened/different card is selected it remains in the same location
    set the cREVLeft of me to the left of me
    set the cREVTop of me to the top of me
-end moveStack
+end moveMsgBoxStack
 
 on closeStack
-   moveStack
+   moveMsgBoxStack
 end closeStack
 
 command setUpDataView

--- a/notes/bugfix-17534.md
+++ b/notes/bugfix-17534.md
@@ -1,0 +1,1 @@
+#  Make sure msg box always remembers previous position


### PR DESCRIPTION
When the msg box was opened/closed, the `moveStack` handler of stack `revMessageBoxBehavior` should be called to set the position of the stack as a custom property. Instead, the `moveStack` handler of stack `revIdeMessageHandlerLibrary` was called, which was changing the `top` of the msg box under the condition:

```
if pTop < the bottom of stack tMenuBar and the right of stack revTargetStack() < the right of stack tMenuBar + 5 then
   set the top of stack revTargetStack() to the bottom of stack tMenuBar + 20
end if
```

This patch makes sure that the correct handler (i.e. the one of stack `revMessageBoxBehavior`) will be called.
