### PR TITLE
[Bug 16848] Force documentation HTML regeneration if missing

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10349,15 +10349,24 @@ private command revIDEGenerateDistributedAPI
 end revIDEGenerateDistributedAPI
 
 on revIDEEnsureDictionaryUrl pWhich
-   local tLastGenerated, tLastModified
+   local tNeedUpdate, tLastGenerated, tLastModified
    set the itemdelimiter to slash
    local tFile
    put revIDEGetDictionaryHTMLTemplate(pWhich) into tFile
    put revIDELastModifiedTimeOfFile(item 1 to -2 of tFile, item -1 of tFile) into tLastModified
    put revIDEGetDictionaryUrl(pWhich) into tFile
-   put revIDELastModifiedTimeOfFile(item 1 to -2 of tFile, item -1 of tFile) into tLastGenerated
-   
-   if tLastModified > tLastGenerated then
+
+   if there is not a file tFile then
+      put true into tNeedUpdate
+   else
+      put revIDELastModifiedTimeOfFile(item 1 to -2 of tFile, \
+            item -1 of tFile) into tLastGenerated
+      if tLastModified > tLastGenerated then
+         put true into tNeedUpdate
+      end if
+   end if
+
+   if tNeedUpdate is true then
       revIDEGenerateDictionaryHTML pWhich
    end if
 end revIDEEnsureDictionaryUrl


### PR DESCRIPTION
Sometimes the IDE documentation builder can get wedged -- it can think
that the documentation doesn't need regenerating, even though the
`api.html` file is missing from the documentation cache.

Sometimes, the documentation builder remains wedged even when the
whole `~/.runrev` directory is removed!

This patch changes the logic for ensuring the dictionary is available
to explicitly check for the presence (or otherwise) of the `api.html`
file.  Hopefully this will help unwedge some users dictionaries.
