### PR TITLE
[Bug 17414] Prevent unwanted deletion of a Group

### DIFF
--- a/Toolset/libraries/revfrontscriptlibrary.livecodescript
+++ b/Toolset/libraries/revfrontscriptlibrary.livecodescript
@@ -655,9 +655,9 @@ on backspaceKey
          --PM-2015-10-30: [[ Bug 16304 ]] Balance lock screen
          unlock screen
          pass backspaceKey
+      else 
+         pass backSpaceKey to metaCard
       end if
-   else 
-      pass backSpaceKey to metaCard
    end if
    unlock screen
 end backspaceKey
@@ -668,9 +668,9 @@ on deleteKey
       if not gREVSuppressMessages or (gREVSuppressMessages and revOKTarget()) then 
          unlock screen
          pass deleteKey
+      else
+         pass deleteKey to metaCard
       end if
-   else 
-      pass deleteKey to metaCard
    end if
    unlock screen
 end deleteKey

--- a/notes/bugfix-17414.md
+++ b/notes/bugfix-17414.md
@@ -1,0 +1,1 @@
+#  Placed Groups are no longer incorrectly deleted via dialog


### PR DESCRIPTION
This is a regression caused by incorrect conversion of the nested `if-then-else` from one-line form to multiple-lines form, in PR https://github.com/livecode/livecode-ide/pull/618
