### PR TITLE
[Bug 17727] Fix launching the PDF version of the User Guide from the Resource Center

### DIFF
--- a/notes/bugfix-17727.md
+++ b/notes/bugfix-17727.md
@@ -1,0 +1,1 @@
+#  Make it possible to launch the PDF version of the User Guide from the Resource Center


### PR DESCRIPTION
Changes:

In the script of stack revResourceCenter:
Replaced:

```
on documentationLaunchUserGuide
   revDocumentationLaunchUserGuide
end documentationLaunchUserGuide
```

with:

```
on documentationLaunchUserGuide
   revIDELaunchResource "User Guide"
end documentationLaunchUserGuide
```
