### PR TITLE
Add dependency checking primitive to IDE library

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -32,18 +32,16 @@ end __revIDEDeveloperCompilationError
 
 private function __revIDEDeveloperExtensionShouldRecompile pFolder, pFile
    # To avoid excessive recompilation, test to see if the compiled module exists and is up to date.
-   
-   # Recompile because manifest file is missing.
-   if there is not a file (pFolder & slash & "manifest.xml") then 
-      return true
-   end if
-   
-   # Check timestamps to see if compiled module is out of date.
-   local tLastCompiled, tLastModified
-   put revIDELastModifiedTimeOfFile(pFolder, "module.lcm") into tLastCompiled
-   put revIDELastModifiedTimeOfFile(pFolder, pFile) into tLastModified
-   
-   return (tLastCompiled is empty or tLastModified > tLastCompiled)
+   local tCompileInputs, tCompileOutputs, tNeedUpdate, tError
+
+   put pFolder & slash & pFile into tCompileInputs[1]
+
+   put pFolder & slash & "manifest.xml" into tCompileOutputs[1]
+   put pFolder & slash & "module.lcm" into tCompileOutputs[2]
+
+   put revIDEIsFilesetStale(tCompileInputs, tCompileOutputs, false, tError) \
+         into tNeedUpdate
+   return tNeedUpdate is not false
 end __revIDEDeveloperExtensionShouldRecompile
 
 private on __revIDEDeveloperExtensionRemoveFolder pFolder

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -1145,11 +1145,12 @@ on revIDEExtensionUpdateAPI pFolder, pExtensionSource
    end if
    
    # Check timestamps to see if API  is out of date.
-   local tLastGenerated, tLastModified
-   put revIDELastModifiedTimeOfFile(pFolder, "api.lcdoc") into tLastGenerated
-   put revIDELastModifiedTimeOfFile(pFolder, pExtensionSource) into tLastModified
+   local tNeedUpdate, tError
+   put revIDEIsFilesetStale(pFolder & slash & pExtensionSource, \
+      pFolder & slash & api.lcdoc, false, tError) into tNeedUpdate
+   if tNeedUpdate is empty then put true into tNeedUpdate
    
-   if tLastGenerated is empty or tLastModified > tLastGenerated then
+   if tNeedUpdate then
       local tAPI
       dispatch function "revDocsGenerateDocsFileFromModularFile" to stack "revDocsParser" with (pFolder & slash & pExtensionSource) 
       put the result into tAPI 

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11099,3 +11099,192 @@ function revIDEDatabaseDriversMapping
    dispatch function "revSBDatabaseDriversMapping" to stack "revSBLibrary"
    return the result
 end revIDEDatabaseDriversMapping
+
+----------------------------------------------------------------
+-- Dependency management functions
+----------------------------------------------------------------
+
+/**
+Summary: Compute whether derived files are up-to-date
+
+Syntax: revIDEIsFilesetStale(pInputs, pOutputs, pRecursive)
+
+Parameters:
+pInputs: A numerically-keyed array of filenames, or a filename
+pOutputs: A numerically-keyed array of filenames, or a filename
+pRecursive: True if folders should be checked recursively
+
+Description:
+Checks whether the <pOutputs> are up-to-date relative to the <pInputs>,
+by checking the modification times on the files.  Returns true if any
+of the <pInputs> are newer than any of the <pOutputs>, or if any of the
+<pOutputs> are missing.
+
+The <pInputs> and the <pOutputs> are file sets, and can either be a
+single filename as a string, or a numerically-keyed array of filenames.
+It is an error for either file set is an array with non-numeric keys, or
+for any filename to be the empty string.
+
+If either file set is empty, the return value is true.  It is an error
+for any of the input filenames to be missing.
+
+If <pRecursive> is true, any filename in the <pInputs> or <pOutputs>
+that is a directory is scanned recursively and its files are added to
+the fileset.  If <pRecursive> is false, it is an error for either file
+set to contain directories.
+*/
+function revIDEIsFilesetStale pInputs, pOutputs, pRecursive
+   if pRecursive is empty then
+      put false into pRecursive
+   end if
+   
+   -- Make sure both filesets are non-empty arrays
+   local tInputs, tOutputs
+   put __CheckFileset(pInputs) into tInputs
+   put __CheckFileset(pOutputs) into tOutputs
+   if (tInputs is false) or (tOutputs is false) then
+      return false -- consider everything to be up-to-date
+   end if
+   
+   -- Gather dates from each fileset
+   local tInputTimes, tOutputTimes
+   put __ScanFilesetMTimes(tOutputs, pRecursive, true) into tOutputTimes
+   if (tOutputTimes is false) then
+      return true -- an output file is missing, so update is required
+   end if
+   
+   put __ScanFilesetMTimes(tInputs, pRecursive, false) into tInputTimes
+   
+   if (tInputTimes is not an array or tOutputTimes is not an array) then
+      throw "This should never happen"
+   end if
+   
+   return tInputTimes["max"] > tOutputTimes["min"]
+end revIDEIsFilesetStale
+
+-- Converts pFileset to an array of at least one element and returns it.
+-- Return false if pFileset is an empty array or the empty string.
+function __CheckFileset pFileset
+   if pFileset is an array then
+      if the number of elements in pFileset is 0 then
+         return false
+      else
+         return pFileset
+      end if
+   end if
+
+   local tFileset
+   if pFileset is empty then
+      return false
+   else
+      put pFileset into tFileset[1]
+      return tFileset
+   end if
+end __CheckFileset
+
+-- Scan pFileset, returning the minimum and maximum modification
+-- times found as an array with "min" and "max" keys.
+--
+-- If pRecursive is true, scan directories in pFileset for the
+-- modification times of each file they contain; otherwise,
+-- encountering a directory is an error.
+--
+-- If pAllowMissing is true, return false on encountering a missing
+-- file; otherwise, it is an error for pFileset to contain a
+-- missing file.
+private function __ScanFilesetMTimes pFileset, pRecursive, pAllowMissing
+   local tResult
+   put (infinity + 0) into tResult["min"]
+   put 0 into tResult["max"]
+
+   if pFileset is not an array then
+      throw "Fileset is not an array"
+   end if
+
+   local tFilename
+   repeat for each element tFilename in pFileset
+      if not __ScanFileMTime(tFilename, pRecursive, pAllowMissing, \
+            tResult["min"], tResult["max"]) then
+         return false
+      end if
+   end repeat
+   
+   return tResult
+end __ScanFilesetMTimes
+
+private function __ScanFileMTime pFilename, pRecursive, pAllowMissing, \
+      @xMin, @xMax
+   
+   local tDirname, tBasename
+   
+   set the itemdelimiter to slash
+   put item 1 to -2 of pFilename into tDirname
+   put item -1 of pFilename into tBasename
+   if tDirname is empty then
+      put "." into tDirname
+   end if
+
+   if tBasename is empty then
+      throw "Failed to check modification time: invalid filename"
+   end if
+
+   -- Regular file
+   local tMTime
+   if there is a file pFilename then
+      put revIDELastModifiedTimeOfFile(tDirname, tBasename) into tMTime
+      if tMTime is empty then
+         throw "Failed to check modification time for file"
+      end if
+      if tMTime < xMin then
+         put tMTime into xMin
+      end if
+      if tMTime > xMax then
+         put tMTime into xMax
+      end if
+      return true
+   end if
+   
+   -- Directory
+   local tContents, tInnerFilename
+   if there is a folder pFilename then
+      if pRecursive then
+         
+         -- List directory contents
+         revIDEPushDefaultFolder pFilename
+         if the result is not empty then
+            throw "Failed to set default folder"
+         end if
+         
+         put files() & return & folders() into tContents
+         filter tContents without ".."
+
+         revIDEPopDefaultFolder pFilename
+         if the result is not empty then
+            throw "Failed to set default folder"
+         end if
+
+         if tContents is empty then
+            return true
+         end if
+
+         -- Recursively scan files & folders
+         repeat for each line tInnerFilename in tContents
+            put pFilename & slash before tInnerFilename
+            if not __ScanFileMTime(tInnerFilename, pRecursive, pAllowMissing, xMin, xMax) then
+               return false
+            end if
+         end repeat
+         
+         return true
+      else
+         throw "Failed to check modification time: unexpected folder"
+      end if
+   end if
+   
+   -- Missing
+   if pAllowMissing then
+      return false
+   else
+      throw "Failed to check modification time: missing file"
+   end if
+end __ScanFileMTime

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10157,17 +10157,13 @@ private function revIDEGetDocsAPIData
       put revEnvironmentUserDocsPath() & slash & the last item of tFolder into tCachedDataFolder
       revIDEEnsurePath tCachedDataFolder
 
-      local tLastModified, tLastGenerated
-      put revIDELastModifiedTimeOfFile(tFolder, tSource) into tLastModified
-      put revIDELastModifiedTimeOfFile(tCachedDataFolder, "api.lcdoc") into tLastGenerated
-      
-      # If there is no lcdoc file and no source, we can't generate the docs
-      if tLastModified is empty and tLastGenerated is empty then
-         next repeat
-      end if
+      local tNeedUpdate, tError
+      put revIDEIsFilesetStale(tFolder & slash & tSource, \
+            tCachedDataFolder & slash & "api.lcdoc", false, tError) \
+            into tNeedUpdate
       
       # Regenerate the lcdoc file if required
-      if tLastModified > tLastGenerated then
+      if tNeedUpdate is true then
          # Generate the docs text in lcdoc format 
          local tDoc
          dispatch function "revDocsGenerateDocsFileFromModularFile" to stack "revDocsParser" with tFolder & slash & tSource
@@ -10178,11 +10174,15 @@ private function revIDEGetDocsAPIData
       end if
       
       # Check if the .js is out of date
-      put revIDELastModifiedTimeOfFile(tCachedDataFolder, "api.lcdoc") into tLastModified
-      put revIDELastModifiedTimeOfFile(tCachedDataFolder, "api.js") into tLastGenerated
-      if tLastModified < tLastGenerated then
+      if tNeedUpdate is not true then
+         put revIDEIsFilesetStale(tCachedDataFolder & "/api.lcdoc", \
+               tCachedDataFolder & "/api.js", false, tError) \
+               into tNeedUpdate
+      end if
+
+      if tNeedUpdate is false then
          put url ("binfile:" & tCachedDataFolder & slash & "api.js") into tExtensionAPI
-      else
+      else if tNeedUpdate is true then
          local tLibraryArray, Lcdoc
          dispatch function "revDocsParseDocFileToLibraryArray" to stack "revDocsParser" with (tCachedDataFolder & slash & "api.lcdoc"), tExtensionData["title"], tExtensionData["author"]
          put the result into tLibraryArray
@@ -10225,12 +10225,13 @@ private function revIDEGetDocsGuideData
       revIDEEnsurePath tCachedDataFolder
       
       # Check if the .js is out of date
-      local tLastModified, tLastGenerated
-      put revIDELastModifiedTimeOfFile(tFolder, "guide.md") into tLastModified
-      put revIDELastModifiedTimeOfFile(tCachedDataFolder, "guide.js") into tLastGenerated
-      if tLastModified < tLastGenerated then
+      local tNeedUpdate, tError
+      put revIDEIsFilesetStale(tFolder & "/guide.md", \
+            tCachedDataFolder & "/guide.js", false, tError) into tNeedUpdate
+
+      if tNeedUpdate is false then
          put url ("binfile:" & tCachedDataFolder & slash & "guide.js") into tExtensionGuide
-      else
+      else if tNeedUpdate is true then
          local tGuide
          put url ("binfile:" & tFolder & slash & "guide.md") into tGuide
          put textDecode(tGuide, "utf-8") into tGuide
@@ -10244,6 +10245,9 @@ private function revIDEGetDocsGuideData
             
             put textEncode(tExtensionGuide, "utf-8") into url ("binfile:" & tCachedDataFolder & slash & "guide.js")
          end if
+      else
+         -- FIXME There is some inconsistency in the guide's files that we
+         -- can't cope with
       end if
       
       if tExtensionGuide is not empty then
@@ -10329,16 +10333,20 @@ private on revIDEGenerateDistributedGuide
       put "repo" into tGuideFoldersWithLocationA[2]["location"]
    end if
    
+   local tGuideJSONFile
+   put revIDESpecialFolderPath("guide") & slash & "distributed_guide.js" \
+         into tGuideJSONFile
+
    # Check if the distributed guide is out of date
-   local tLastModified, tLastGenerated
-   set the itemdelimiter to ":"
-   repeat for each element tGuideFolderWithLocationA in tGuideFoldersWithLocationA
-      put max(tLastModified, revIDELastModifiedTimeOfFilesInFolder(tGuideFolderWithLocationA["folder"])) into tLastModified
+   local tKey, tInputFiles, tNeedUpdate, tError
+   repeat for each key tKey in tGuideFoldersWithLocationA
+      put tGuideFoldersWithLocationA[tKey]["folder"] into tInputFiles[tKey]
    end repeat
-   put revIDELastModifiedTimeOfFile(revIDESpecialFolderPath("guide"), "distributed_guide.js") into tLastGenerated
-   
+   put revIDEIsFilesetStale(tInputFiles, tGuideJSONFile, true, tError) \
+         into tNeedUpdate
+
    # If we don't need to regenerate, exit
-   if tLastModified < tLastGenerated then
+   if tNeedUpdate is not true then
       exit revIDEGenerateDistributedGuide
    end if
    
@@ -10355,7 +10363,7 @@ private on revIDEGenerateDistributedGuide
    delete the last char of tGuideData
    
    # Write out to apropriate location
-   put textEncode(tGuideData, "utf-8") into url ("binfile:" & revIDESpecialFolderPath("guide") & slash & "distributed_guide.js")
+   put textEncode(tGuideData, "utf-8") into url ("binfile:" & tGuideJSONFile)
 end revIDEGenerateDistributedGuide
 
 private command revIDEGenerateDistributedAPI
@@ -10467,15 +10475,15 @@ private command revIDEGenerateDistributedAPI
 end revIDEGenerateDistributedAPI
 
 on revIDEEnsureDictionaryUrl pWhich
-   local tLastGenerated, tLastModified
-   set the itemdelimiter to slash
-   local tFile
-   put revIDEGetDictionaryHTMLTemplate(pWhich) into tFile
-   put revIDELastModifiedTimeOfFile(item 1 to -2 of tFile, item -1 of tFile) into tLastModified
-   put revIDEGetDictionaryUrl(pWhich) into tFile
-   put revIDELastModifiedTimeOfFile(item 1 to -2 of tFile, item -1 of tFile) into tLastGenerated
-   
-   if tLastModified > tLastGenerated then
+   local tInput, tOutput
+   put revIDEGetDictionaryHTMLTemplate(pWhich) into tInput
+   put revIDEGetDictionaryUrl(pWhich) into tOutput
+
+   local tNeedUpdate, tError
+   put revIDEIsFilesetStale(revIDEGetDictionaryHTMLTemplate(pWhich), \
+         revIDEGetDictionaryUrl(pWhich), false, tError) into tNeedUpdate
+
+   if tNeedUpdate is true then
       revIDEGenerateDictionaryHTML pWhich
    end if
 end revIDEEnsureDictionaryUrl

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11107,18 +11107,23 @@ end revIDEDatabaseDriversMapping
 /**
 Summary: Compute whether derived files are up-to-date
 
-Syntax: revIDEIsFilesetStale(pInputs, pOutputs, pRecursive)
+Syntax: revIDEIsFilesetStale(pInputs, pOutputs, pRecursive, rError)
 
 Parameters:
 pInputs: A numerically-keyed array of filenames, or a filename
 pOutputs: A numerically-keyed array of filenames, or a filename
 pRecursive: True if folders should be checked recursively
+rError: Set to a string describing an error, if necessary.
 
 Description:
-Checks whether the <pOutputs> are up-to-date relative to the <pInputs>,
-by checking the modification times on the files.  Returns true if any
-of the <pInputs> are newer than any of the <pOutputs>, or if any of the
-<pOutputs> are missing.
+Checks whether the <pOutputs> are up-to-date relative to the
+<pInputs>, by checking the modification times on the files.  Returns
+true if any of the <pInputs> are newer than any of the <pOutputs>, or
+if any of the <pOutputs> are missing.  Returns false if all of the
+<pOutputs> are up-to-date.
+
+If an error occurs, returns empty and sets <rError> to a descriptive
+string.
 
 The <pInputs> and the <pOutputs> are file sets, and can either be a
 single filename as a string, or a numerically-keyed array of filenames.
@@ -11133,33 +11138,39 @@ that is a directory is scanned recursively and its files are added to
 the fileset.  If <pRecursive> is false, it is an error for either file
 set to contain directories.
 */
-function revIDEIsFilesetStale pInputs, pOutputs, pRecursive
-   if pRecursive is empty then
-      put false into pRecursive
-   end if
+function revIDEIsFilesetStale pInputs, pOutputs, pRecursive, @rError
+   local tError
+   try
+      if pRecursive is empty then
+         put false into pRecursive
+      end if
    
-   -- Make sure both filesets are non-empty arrays
-   local tInputs, tOutputs
-   put __CheckFileset(pInputs) into tInputs
-   put __CheckFileset(pOutputs) into tOutputs
-   if (tInputs is false) or (tOutputs is false) then
-      return false -- consider everything to be up-to-date
-   end if
+      -- Make sure both filesets are non-empty arrays
+      local tInputs, tOutputs
+      put __CheckFileset(pInputs) into tInputs
+      put __CheckFileset(pOutputs) into tOutputs
+      if (tInputs is false) or (tOutputs is false) then
+         return false -- consider everything to be up-to-date
+      end if
    
-   -- Gather dates from each fileset
-   local tInputTimes, tOutputTimes
-   put __ScanFilesetMTimes(tOutputs, pRecursive, true) into tOutputTimes
-   if (tOutputTimes is false) then
-      return true -- an output file is missing, so update is required
-   end if
+      -- Gather dates from each fileset
+      local tInputTimes, tOutputTimes
+      put __ScanFilesetMTimes(tOutputs, pRecursive, true) into tOutputTimes
+      if (tOutputTimes is false) then
+         return true -- an output file is missing, so update is required
+      end if
    
-   put __ScanFilesetMTimes(tInputs, pRecursive, false) into tInputTimes
+      put __ScanFilesetMTimes(tInputs, pRecursive, false) into tInputTimes
    
-   if (tInputTimes is not an array or tOutputTimes is not an array) then
-      throw "This should never happen"
-   end if
+      if (tInputTimes is not an array or tOutputTimes is not an array) then
+         throw "This should never happen"
+      end if
    
-   return tInputTimes["max"] > tOutputTimes["min"]
+      return tInputTimes["max"] > tOutputTimes["min"]
+   catch tError
+      put tError into rError
+      return empty
+   end try
 end revIDEIsFilesetStale
 
 -- Converts pFileset to an array of at least one element and returns it.

--- a/tests/core/idelibrary/isfilesetstale.livecodescript
+++ b/tests/core/idelibrary/isfilesetstale.livecodescript
@@ -1,0 +1,96 @@
+﻿script "TestIsFilesetStale"
+
+local sWorkDir, sOldDir, sOldFile, sNewDir, sNewFile
+local sEmptyDir, sMissingDir, sMissingFile
+
+on TestSetup
+   set the itemdelimiter to slash
+   set the defaultfolder to item 1 to -2 of the filename of me
+
+   put "_TestIsFilesetStale" into sWorkDir
+
+   put sWorkDir & slash & "missing" into sMissingDir
+   put sMissingDir & slash & "missing" into sMissingFile
+   put sWorkDir & slash & "empty" into sEmptyDir
+   put sWorkDir & slash & "old" into sOldDir
+   put sOldDir & slash & "old" into sOldFile
+   put sWorkDir & slash & "new" into sNewDir
+   put sNewDir & slash & "new" into sNewFile
+   
+   if there is a folder sWorkDir then
+      exit TestSetup
+   end if
+   
+   create folder sWorkDir
+   create folder sEmptyDir
+   create folder sOldDir
+   put empty into url("file:" & sOldFile)
+   wait for 2 seconds with messages
+   create folder sNewDir
+   put empty into url("file:" & sNewFile)
+   
+end TestSetup
+
+private command __TestBasicFileset pOld, pNew, pMissing, pEmpty
+   TestAssert "empty filesets are up-to-date", revIDEIsFilesetStale(pEmpty, pEmpty, false) is false
+   TestAssert "empty output fileset is up-to-date", revIdeIsFilesetStale(pNew, pEmpty, false) is false
+   TestAssert "empty input fileset is up-to-date", revIDEIsFilesetStale(pEmpty, pOld, false) is false
+   
+   TestAssert "new file is up-to-date", revIDEIsFilesetStale(pOld, pNew, false) is false
+   TestAssert "old file is stale", revIDEIsFilesetStale(pNew, pOld, false) is true
+   TestAssert "missing file is stale", revIDEIsFilesetStale(pOld, pMissing, false) is true
+end __TestBasicFileset
+
+command __TestMissingInput
+   return revIDEIsFilesetStale(sMissingFile, sNewFile, false)
+end __TestMissingInput
+
+command __TestEmptyFilename
+   local tFileset
+   put empty into tFileset[1]
+   return revIDEIsFilesetStale(sOldFile, tFileset, false)
+end __TestEmptyFilename
+
+on TestBasicFileset
+   local tOldFileset, tNewFileset, tMissingFileset, tEmptyFileset
+   put sOldFile into tOldFileset[1]
+   put sNewFile into tNewFileset[1]
+   put sMissingFile into tMissingFileset[1]
+   put empty into tEmptyFileset[1]
+   delete variable tEmptyFileset[1]
+
+   TestDiagnostic "Testing string-based single-file filesets"
+   __TestBasicFileset sOldFile, sNewFile, sMissingFile, empty
+   TestDiagnostic "Testing array-based single-file filesets"
+   __TestBasicFileset tOldFileset, tNewFileset, tMissingFileset, tEmptyFileset
+
+   put sNewFile into tNewFileset[2]
+   put sNewFile into tOldFileset[2]
+   put sNewFile into tMissingFileset[2]
+   TestDiagnostic "Testing multi-file filesets"
+   __TestBasicFileset tOldFileset, tNewFileset, tMissingFileset, tEmptyFileset
+
+   TestDiagnostic "Testing basic errors"
+   TestAssertThrow "missing inputs are an error", "__TestMissingInput", \
+      the long id of me, "Failed to check modification time: missing file"
+   TestAssertThrow "invalid filenames are an error", "__TestEmptyFilename", \
+      the long id of me, "Failed to check modification time: invalid filename"
+end TestBasicFileset
+
+command __TestUnexpectedFolder
+   return revIDEIsFilesetStale(sOldFile, sNewDir, false)
+end __TestUnexpectedFolder
+
+private command __TestRecursiveFileset pOld, pNew, pMissing, pEmpty
+   TestAssert "new dir is up-to-date", revIDEIsFilesetStale(pOld, pNew, true) is false
+   TestAssert "old dir is stale", revIDEIsFilesetStale(pNew, pOld, true) is true
+   TestAssert "missing dir is stale", revIDEIsFilesetStale(pOld, pMissing, true) is true
+end __TestRecursiveFileset
+
+on TestRecursiveFileset
+   TestAssertThrow "folders are erroneous unless recursive", \
+      "__TestUnexpectedFolder", the long id of me, \
+      "Failed to check modification time: unexpected folder"
+
+   __TestRecursiveFileset sOldDir, sNewDir, sMissingDir, sEmptyDir
+end TestRecursiveFileset

--- a/tests/core/idelibrary/isfilesetstale.livecodescript
+++ b/tests/core/idelibrary/isfilesetstale.livecodescript
@@ -25,31 +25,23 @@ on TestSetup
    create folder sEmptyDir
    create folder sOldDir
    put empty into url("file:" & sOldFile)
-   wait for 2 seconds with messages
+   wait for 2 seconds
    create folder sNewDir
    put empty into url("file:" & sNewFile)
    
 end TestSetup
 
 private command __TestBasicFileset pOld, pNew, pMissing, pEmpty
-   TestAssert "empty filesets are up-to-date", revIDEIsFilesetStale(pEmpty, pEmpty, false) is false
-   TestAssert "empty output fileset is up-to-date", revIdeIsFilesetStale(pNew, pEmpty, false) is false
-   TestAssert "empty input fileset is up-to-date", revIDEIsFilesetStale(pEmpty, pOld, false) is false
+   local tError
+
+   TestAssert "empty filesets are up-to-date", revIDEIsFilesetStale(pEmpty, pEmpty, false, tError) is false
+   TestAssert "empty output fileset is up-to-date", revIdeIsFilesetStale(pNew, pEmpty, false, tError) is false
+   TestAssert "empty input fileset is up-to-date", revIDEIsFilesetStale(pEmpty, pOld, false, tError) is false
    
-   TestAssert "new file is up-to-date", revIDEIsFilesetStale(pOld, pNew, false) is false
-   TestAssert "old file is stale", revIDEIsFilesetStale(pNew, pOld, false) is true
-   TestAssert "missing file is stale", revIDEIsFilesetStale(pOld, pMissing, false) is true
+   TestAssert "new file is up-to-date", revIDEIsFilesetStale(pOld, pNew, false, tError) is false
+   TestAssert "old file is stale", revIDEIsFilesetStale(pNew, pOld, false, tError) is true
+   TestAssert "missing file is stale", revIDEIsFilesetStale(pOld, pMissing, false, tError) is true
 end __TestBasicFileset
-
-command __TestMissingInput
-   return revIDEIsFilesetStale(sMissingFile, sNewFile, false)
-end __TestMissingInput
-
-command __TestEmptyFilename
-   local tFileset
-   put empty into tFileset[1]
-   return revIDEIsFilesetStale(sOldFile, tFileset, false)
-end __TestEmptyFilename
 
 on TestBasicFileset
    local tOldFileset, tNewFileset, tMissingFileset, tEmptyFileset
@@ -71,26 +63,31 @@ on TestBasicFileset
    __TestBasicFileset tOldFileset, tNewFileset, tMissingFileset, tEmptyFileset
 
    TestDiagnostic "Testing basic errors"
-   TestAssertThrow "missing inputs are an error", "__TestMissingInput", \
-      the long id of me, "Failed to check modification time: missing file"
-   TestAssertThrow "invalid filenames are an error", "__TestEmptyFilename", \
-      the long id of me, "Failed to check modification time: invalid filename"
+   local tStale, tError, tBadFileset
+   put revIDEIsFilesetStale(sMissingFile, sNewFile, false, tError) into tStale
+   TestAssert "missing inputs result is empty", tStale is empty
+   TestAssert "missing inputs generate an error", \
+      tError is "Failed to check modification time: missing file"
+   put empty into tBadFileset[1]
+   put revIDEIsFilesetStale(sOldFile, tBadFileset, false, tError) into tStale
+   TestAssert "invalid filename result is empty", tStale is empty
+   TestAssert "invalid filename generates an error", \
+      tError is "Failed to check modification time: invalid filename"
 end TestBasicFileset
 
-command __TestUnexpectedFolder
-   return revIDEIsFilesetStale(sOldFile, sNewDir, false)
-end __TestUnexpectedFolder
-
 private command __TestRecursiveFileset pOld, pNew, pMissing, pEmpty
-   TestAssert "new dir is up-to-date", revIDEIsFilesetStale(pOld, pNew, true) is false
-   TestAssert "old dir is stale", revIDEIsFilesetStale(pNew, pOld, true) is true
-   TestAssert "missing dir is stale", revIDEIsFilesetStale(pOld, pMissing, true) is true
+   local tError
+   TestAssert "new dir is up-to-date", revIDEIsFilesetStale(pOld, pNew, true, tError) is false
+   TestAssert "old dir is stale", revIDEIsFilesetStale(pNew, pOld, true, tError) is true
+   TestAssert "missing dir is stale", revIDEIsFilesetStale(pOld, pMissing, true, tError) is true
 end __TestRecursiveFileset
 
 on TestRecursiveFileset
-   TestAssertThrow "folders are erroneous unless recursive", \
-      "__TestUnexpectedFolder", the long id of me, \
-      "Failed to check modification time: unexpected folder"
-
    __TestRecursiveFileset sOldDir, sNewDir, sMissingDir, sEmptyDir
+
+   local tSlate, tError
+   put revIDEIsFilesetStale(sOldFile, sNewDir, false, tError) into tStale
+   TestAssert "unexpected folder result is empty", tStale is empty
+   TestAssert "unexpected folder generates an error", \
+      tError is "Failed to check modification time: unexpected folder"
 end TestRecursiveFileset


### PR DESCRIPTION
This changeset adds the `revIDEIsFilesetStale()` function to the IDE library.  This is a dependency-checking primitive for checking whether a set of derived files should be updated from a set of input files, and is intended to avoid the need to manually fetch and process file modification times.
