### PR TITLE
[[ Bug ]] Ensure lowercase display name is used for associations check

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -453,7 +453,7 @@
 		// Everything associated with the object. A cross between a overview and userguide
 		
 		if(tEntryObject.type == "object" || tEntryObject.type == "widget" || tEntryObject.type == "library"){
-			var object_name = tEntryObject.name;
+			var object_name = tEntryObject["display name"].toLowerCase();
 			var object_data = {};
 			
 			$.each(dataGet(),function(entry_index, entry_data){


### PR DESCRIPTION
This happened to work with object types as the name of an object in
all cases where associations are present were identical to the lowercase
display name.
