### PR TITLE
[Bug 17826] Don't lock screen when executing commands from the msg box

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10765,7 +10765,6 @@ command ideDoMessage pScript, pDebugMode
    
    do "global" && the globals
    
-   lock screen
    local tScriptError
    try
       if pDebugMode then
@@ -10790,7 +10789,6 @@ command ideDoMessage pScript, pDebugMode
       end if
    catch tScriptError
    end try
-   unlock screen
    
    if tScriptError is not empty then
       put "execution error" & return before tScriptError

--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -546,13 +546,11 @@ command ideMessageBoxExecuteScript pScript
    local tDebugMode
    put revIDEGetPreference("IDEDebugMode") into tDebugMode
    
-   lock screen
    local tValidScript
    ideExecuteScript pScript, tDefaultStack, tIntelligenceObject, tDebugMode, tValidScript
    if the result is not empty then
       put ideMessageBoxFormatErrorForDisplay(the result) into field "results" of card lSelectedCard of me
    end if
-   unlock screen
    
    return tValidScript
 end ideMessageBoxExecuteScript 

--- a/notes/bugfix-17826.md
+++ b/notes/bugfix-17826.md
@@ -1,0 +1,1 @@
+# Make sure "move" command results in smooth movement when executed from the msg box


### PR DESCRIPTION
This ensures that commands such as `move grc X to the topleft of this card` will result in smooth movement of the object
