### PR TITLE
[[ Preferences ]] Start documenting preferences

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2412,6 +2412,39 @@ function revIDELocalisedString
 end revIDELocalisedString
 
 /*
+pPreferenceName (enum):
+
+- cImageFileRelative (boolean): If false set image paths to absolute 
+paths rather than relative to
+the stack
+- cREVExtension (boolean): If false force extensions to be added during 
+save
+- cDestroyStack (boolean): The default value for destroyStack on new 
+stacks
+- cAskDestroy (enum): What to do when a stack with destroyStack true 
+is closed
+
+   - "don't remove": Don't remove from memory
+   - "remove": remove from memory
+   - "ask": ask the user
+
+- cNumRecent (integer): The number of recent files to show in the menu 
+and start center
+- cRecentSort (enum): The sort order of recent files
+
+    - "alphabetically": Sort by file name
+    - "modification date": Sort by date
+    
+- cRecentStackPaths (string): A list of recent stack file paths
+- cPreserveStackCreator (boolean): *LEGACY* If true preserve the MacOS 
+file creator     
+- cPreserveStackVersion (boolean): If true save the file with the 
+original stack file version
+- cCustomizationPath (string): The path to the user customization 
+directory
+*/
+
+/*
 Sets a preference.
 
 pPreferenceName (String): The name of the preference to set


### PR DESCRIPTION
A start on documenting preferences used by the IDE with the intention that these are moved to the API docs once complete and in the meantime added to as we work with various preferences.
