### PR TITLE
Check the target is me in revLoadLibrary and revUnloadLibrary

### DIFF
--- a/Toolset/libraries/revanimationlibrary.livecodescript
+++ b/Toolset/libraries/revanimationlibrary.livecodescript
@@ -12,240 +12,289 @@ end revUnloadLibrary
 local lOverRide
 
 on revGoToFramePaused pWhichAnimation, pWhich
-  global gREVCurrentAnimation
-  lock messages
-  if pWhichAnimation is not empty then put pWhichAnimation into tName
-  else put gREVCurrentAnimation into tName
-  if tName is empty then revAnimationError "no name"
-  if pWhich is not a number and pWhich is not empty then
-    --look it up to see if you can find the frame
-    put the cREVAnimation[tName,frameNames] of this cd & cr into tKeyFrames
-    put lineOffset(comma&pWhich&cr,tKeyFrames) into tLineNo
-    if tLineNo is 0 then revAnimationError "frame named" && pWhich && "not listed"
-    put item 1 of line tLineNo of tKeyFrames into pWhich
-  end if
-  if pWhich > the cREVAnimation[tName,calculatedTotal] of this cd then revAnimationError "frame" && pWhich && "not found"
-  if "cached" is in the cREVAnimation[tName,status] of this cd then 
-    put pWhich into tFrameNo
-    --insert cached frame lookup code here
-    --*
-     
-    exit revGoToFramePaused
-  end if
-  if lOverRide is not true then
-    put the cREVAnimation[tName,status] of this cd into tPrevStatus
-    put "paused" into line 1 of tPrevStatus
-    set the cREVAnimation[tName,status] of this cd to tPrevStatus
-  end if
-  put pWhich into tFrameNo
-  put the cREVAnimation[tName,currentFrame] of this cd into tPrevframe
-  set the cREVAnimation[tName,currentFrame] of this cd to tFrameNo
-  put tFrameNo & comma into tFrameLookUp
-  --move animation to tFrameNo
-  repeat for each line l in the cREVAnimation[tName,objectsList] of this cd
-    put empty into tFinalProps
-    --check to send any messages
-    put the cREVAnimation[tName,tFrameNo,messages] of l into tMessages
-    put the cREVAnimation[tName,tPrevframe,messages] of l into tPrevMessages
-    put the cREVAnimation[tName,tFrameNo,playState] of l into tPlayState
-    if line 3 of tPrevMessages is not empty then send (line 3 of tPrevMessages) to l
-    if line 1 of tMessages is not empty then send (line 1 of tMessages) to l
-    put the cREVAnimation[tName,keyFrames] of l into tKeyFrames
-    if lineOffset(tFrameLookUp,tKeyFrames) is not 0 then
-      --its a key frame for this object, set the properties
-      put the customProperties[(cREVAnimation&tName&tFrameNo)] of l into tTempProps
-      set the properties of l to tTempProps
-      if line 2 of tMessages is not empty then
-        send (line 2 of tMessages) to l
-      end if
-      if line 4 of tPrevMessages is not empty then
-        send (line 4 of tPrevMessages) to l
-      end if
-      if tPlayState is "play" then 
-        start playing l
-      else if tPlayState is "stop" then 
-        stop playing l
-      end if
-    else
-      --calculate tweening
-      --which frame are we between
-      repeat for each line k in tKeyFrames
-        if item 1 of k < tFrameNo then put item 1 of k into tBefore
-        if item 1 of k > tFrameNo then 
-          put item 1 of k into tAfter
-          exit repeat
-        end if
-      end repeat
-      if tAfter is empty then
-        --go as a keyframe to the last keyframe
-        put the customProperties[(cREVAnimation&tName&tBefore)] of l into tTempProps
-        set the properties of l to tTempProps
+   global gREVCurrentAnimation
+   lock messages
+   
+   local tName
+   if pWhichAnimation is not empty then put pWhichAnimation into tName
+   else put gREVCurrentAnimation into tName
+   if tName is empty then revAnimationError "no name"
+   if pWhich is not a number and pWhich is not empty then
+      --look it up to see if you can find the frame
+      
+      local tKeyFrames
+      put the cREVAnimation[tName,"frameNames"] of this cd & cr into tKeyFrames
+      
+      local tLineNo
+      put lineOffset(comma&pWhich&cr,tKeyFrames) into tLineNo
+      if tLineNo is 0 then revAnimationError "frame named" && pWhich && "not listed"
+      put item 1 of line tLineNo of tKeyFrames into pWhich
+   end if
+   if pWhich > the cREVAnimation[tName,"calculatedTotal"] of this cd then revAnimationError "frame" && pWhich && "not found"
+   
+   local tFrameNo
+   if "cached" is in the cREVAnimation[tName,"status"] of this cd then 
+      put pWhich into tFrameNo
+      --insert cached frame lookup code here
+      --*
+      
+      exit revGoToFramePaused
+   end if
+   local tPrevStatus
+   if lOverRide is not true then
+      put the cREVAnimation[tName,"status"] of this cd into tPrevStatus
+      put "paused" into line 1 of tPrevStatus
+      set the cREVAnimation[tName,"status"] of this cd to tPrevStatus
+   end if
+   put pWhich into tFrameNo
+   
+   local tPrevframe
+   put the cREVAnimation[tName,"currentFrame"] of this cd into tPrevframe
+   set the cREVAnimation[tName,"currentFrame"] of this cd to tFrameNo
+   
+   local tFrameLookUp
+   put tFrameNo & comma into tFrameLookUp
+   --move animation to tFrameNo
+   repeat for each line l in the cREVAnimation[tName,"objectsList"] of this cd
+      local tFinalProps
+      put empty into tFinalProps
+      --check to send any messages
+      
+      local tMessages
+      put the cREVAnimation[tName,tFrameNo,"messages"] of l into tMessages
+      
+      local tPrevMessages
+      put the cREVAnimation[tName,tPrevframe,"messages"] of l into tPrevMessages
+      
+      local tPlayState
+      put the cREVAnimation[tName,tFrameNo,"playState"] of l into tPlayState
+      if line 3 of tPrevMessages is not empty then send (line 3 of tPrevMessages) to l
+      if line 1 of tMessages is not empty then send (line 1 of tMessages) to l
+      put the cREVAnimation[tName,"keyFrames"] of l into tKeyFrames
+      if lineOffset(tFrameLookUp,tKeyFrames) is not 0 then
+         --its a key frame for this object, set the properties
+         local tTempProps
+         put the customProperties[("cREVAnimation"&tName&tFrameNo)] of l into tTempProps
+         set the properties of l to tTempProps
+         if line 2 of tMessages is not empty then
+            send (line 2 of tMessages) to l
+         end if
+         if line 4 of tPrevMessages is not empty then
+            send (line 4 of tPrevMessages) to l
+         end if
+         if tPlayState is "play" then 
+            start playing l
+         else if tPlayState is "stop" then 
+            stop playing l
+         end if
       else
-        put the customProperties[(cREVAnimation&tName&tBefore)] of l into tPropsBefore
-        put the customProperties[(cREVAnimation&tName&tAfter)] of l into tPropsAfter
-        put keys(tPropsBefore) into tPropertiesList
-        put the customProperties[cREVAnimation] of l into tTemplookup
-        --calculate the tweening percentage, and acceleration if any
-        -- there is a bug in the MC engine here, remember to report
-        put tName,tBefore,acceleration into tLookUp
-        put tTempLookUp[tLookUp] into tAccel
-        if tAccel is empty then
-          put tAfter - tBefore into tTotal
-          put tFrameNo - tBefore into tCurrent
-          put tCurrent/tTotal into tPercentage
-        else
-          --acceleration stuff
-          if tAccel < 1 then
-            --deccelerate
-            put tAfter - tBefore into tTotal
-            put tFrameNo - tBefore into tCurrent
-            put abs(tAccel) into tAccel
-            put (1-(1-(tCurrent/tTotal)^(tAccel/tTotal))^(tTotal/tAccel)) into tPercentage
-            --put tAccel & cr & tPercentage*100 --debug
-          else
-            --accelerate
-            put tAfter - tBefore into tTotal
-            put tFrameNo - tBefore into tCurrent
-            put (1-(1-(tCurrent/tTotal))^(tAccel/tTotal))^(tTotal/tAccel) into tPercentage
-            --put tAccel & cr & tPercentage*100 --debug
-          end if
-        end if
-        --now do the matches and build the final array for this object
-        set the caseSensitive to true
-        repeat for each line p in tPropertiesList
-          if p is among the items of "rect,colors,points,hScroll,vScroll,patterns,icon,hiliteIcon,margins,tabStops,borderWidth,lineSize,textSize,textHeight,layer" then
-            put true into tNumberTest
-          else
-            put tPropsBefore[p] into tNumberTest
-            put tPropsAfter[p] after tNumberTest
-            replace comma with 0 in tNumberTest
-            replace cr with 0 in tNumberTest
-            if tNumberTest is a number then put true into tNumberTest else put false into tNumberTest
-          end if
-          if tPropsBefore[p] is not tPropsAfter[p] and the number of items in tPropsBefore[p] is the number of items in tPropsAfter[p] and tNumberTest then
-            --tween to a percentage
-            put empty into tFinalOutput
-            put 0 into tLineNo
-            repeat for each line c in tPropsBefore[p]
-              add 1 to tLineNo
-              put line tLineNo of tPropsAfter[p] into c2
-              put empty into tFinalValue
-              repeat with i = 1 to the number of items in c
-                put item i of c into tBeforeValue
-                put item i of c2 into tAfterValue
-                put tAfterValue - tBeforeValue into tDifference
-                put round(tDifference * tPercentage) + tBeforeValue into item (the number of items in tFinalValue+1) of tFinalValue
-              end repeat
-              put tFinalValue & cr after tFinalOutput
+         --calculate tweening
+         --which frame are we between
+         local tBefore, tAfter, tPropsBefore, tPropsAfter, tPropertiesList, tTemplookup, tLookUp, tAccel, tTotal, tCurrent, tPercentage
+         repeat for each line k in tKeyFrames
+            if item 1 of k < tFrameNo then put item 1 of k into tBefore
+            if item 1 of k > tFrameNo then 
+               put item 1 of k into tAfter
+               exit repeat
+            end if
+         end repeat
+         if tAfter is empty then
+            --go as a keyframe to the last keyframe
+            put the customProperties[("cREVAnimation"&tName&tBefore)] of l into tTempProps
+            set the properties of l to tTempProps
+         else
+            put the customProperties[("cREVAnimation"&tName&tBefore)] of l into tPropsBefore
+            put the customProperties[("cREVAnimation"&tName&tAfter)] of l into tPropsAfter
+            put keys(tPropsBefore) into tPropertiesList
+            put the customProperties["cREVAnimation"] of l into tTemplookup
+            --calculate the tweening percentage, and acceleration if any
+            -- there is a bug in the MC engine here, remember to report
+            put tName,tBefore,"acceleration" into tLookUp
+            put tTempLookUp[tLookUp] into tAccel
+            if tAccel is empty then
+               put tAfter - tBefore into tTotal
+               put tFrameNo - tBefore into tCurrent
+               put tCurrent/tTotal into tPercentage
+            else
+               --acceleration stuff
+               if tAccel < 1 then
+                  --deccelerate
+                  put tAfter - tBefore into tTotal
+                  put tFrameNo - tBefore into tCurrent
+                  put abs(tAccel) into tAccel
+                  put (1-(1-(tCurrent/tTotal)^(tAccel/tTotal))^(tTotal/tAccel)) into tPercentage
+                  --put tAccel & cr & tPercentage*100 --debug
+               else
+                  --accelerate
+                  put tAfter - tBefore into tTotal
+                  put tFrameNo - tBefore into tCurrent
+                  put (1-(1-(tCurrent/tTotal))^(tAccel/tTotal))^(tTotal/tAccel) into tPercentage
+                  --put tAccel & cr & tPercentage*100 --debug
+               end if
+            end if
+            --now do the matches and build the final array for this object
+            local tNumberTest
+            set the caseSensitive to true
+            repeat for each line p in tPropertiesList
+               if p is among the items of "rect,colors,points,hScroll,vScroll,patterns,icon,hiliteIcon,margins,tabStops,borderWidth,lineSize,textSize,textHeight,layer" then
+                  put true into tNumberTest
+               else
+                  put tPropsBefore[p] into tNumberTest
+                  put tPropsAfter[p] after tNumberTest
+                  replace comma with 0 in tNumberTest
+                  replace cr with 0 in tNumberTest
+                  if tNumberTest is a number then put true into tNumberTest else put false into tNumberTest
+               end if
+               if tPropsBefore[p] is not tPropsAfter[p] and the number of items in tPropsBefore[p] is the number of items in tPropsAfter[p] and tNumberTest then
+                  --tween to a percentage
+                  local tFinalOutput, tBeforeValue, tAfterValue, tDifference
+                  put empty into tFinalOutput
+                  put 0 into tLineNo
+                  repeat for each line c in tPropsBefore[p]
+                     add 1 to tLineNo
+                     
+                     local c2
+                     put line tLineNo of tPropsAfter[p] into c2
+                     
+                     local tFinalValue
+                     put empty into tFinalValue
+                     repeat with i = 1 to the number of items in c
+                        put item i of c into tBeforeValue
+                        put item i of c2 into tAfterValue
+                        put tAfterValue - tBeforeValue into tDifference
+                        put round(tDifference * tPercentage) + tBeforeValue into item (the number of items in tFinalValue+1) of tFinalValue
+                     end repeat
+                     put tFinalValue & cr after tFinalOutput
+                  end repeat
+                  delete last char of tFinalOutput
+                  put tFinalOutput into tFinalProps[p]
+               else
+                  --set as fixed
+                  put tPropsBefore[p] into tFinalProps[p]
+               end if
             end repeat
-            delete last char of tFinalOutput
-            put tFinalOutput into tFinalProps[p]
-          else
-            --set as fixed
-            put tPropsBefore[p] into tFinalProps[p]
-          end if
-        end repeat
-        set the properties of l to tFinalProps
-        if line 2 of tMessages is not empty then send (line 2 of tMessages) to l
-        if line 4 of tPrevMessages is not empty then send (line 4 of tPrevMessages) to l
+            set the properties of l to tFinalProps
+            if line 2 of tMessages is not empty then send (line 2 of tMessages) to l
+            if line 4 of tPrevMessages is not empty then send (line 4 of tPrevMessages) to l
+         end if
       end if
-    end if
-  end repeat
-  if lOverride is not true then
-    revUpdateAnimationPalette tFrameNo
-  end if
-  unlock messages
+   end repeat
+   if lOverride is not true then
+      revUpdateAnimationPalette tFrameNo
+   end if
+   unlock messages
 end revGoToFramePaused
 
 on revUpdateAnimationPalette pWhichframe
-  if there is a stack "revAnimation" and the mode of stack "revAnimation" is not 0 then
-    put pWhichFrame into tFrameNo
-    --updates the animation palette itself
-    put tFrameNo into fld "current frame" of stack "revAnimation"
-    lock screen
-    put the hScroll of group "frame graphics" of stack "revAnimation" into tPrev
-    set the hScroll of group "frame graphics" of stack "revAnimation" to 0
-    set the left of grc "frame1" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" + 1 + tFrameNo * 10)
-    set the left of grc "frame2" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" - 9 + tFrameNo * 10)
-    set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev
-    if the left of grc "frame1" of stack "revAnimation" < the left of fld "timeLine" of stack "revAnimation" then
-      put the left of fld "timeLine" of stack "revAnimation" - the left of grc "frame1" of stack "revAnimation" into tDistanceOff
-      add 10 to tDistanceOff
-      set the hScroll of fld "timeLine" of stack "revAnimation" to tPrev - tDistanceOff
-      set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev - tDistanceOff
-      set the hscroll of fld "frame markers" of stack "revAnimation" to tPrev - tDistanceOff
-      set the hscroll of fld "frame numbers" of stack "revAnimation" to tPrev - tDistanceOff
-    else if the left of grc "frame1" of stack "revAnimation" > the right of fld "timeLine" of stack "revAnimation" then
-      put the left of grc "frame1" of stack "revAnimation" - the right of fld "timeLine" of stack "revAnimation" into tDistanceOff
-      add 20 to tDistanceOff
-      set the hScroll of fld "timeLine" of stack "revAnimation" to tPrev + tDistanceOff
-      set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev + tDistanceOff
-      set the hscroll of fld "frame markers" of stack "revAnimation" to tPrev + tDistanceOff
-      set the hscroll of fld "frame numbers" of stack "revAnimation" to tPrev + tDistanceOff
-    end if
-    unlock screen
-    if "revCheckPalette" is not in the pendingMessages then send "revCheckPalette" to cd 1 of stack "revAnimation" in 250 milliseconds
-    send "revStartTracking" to fld "timeline" of stack "revAnimation" --don't add keyframe
-  end if
+   if there is a stack "revAnimation" and the mode of stack "revAnimation" is not 0 then
+      local tFrameNo
+      put pWhichFrame into tFrameNo
+      --updates the animation palette itself
+      put tFrameNo into fld "current frame" of stack "revAnimation"
+      lock screen
+      
+      local tPrev
+      put the hScroll of group "frame graphics" of stack "revAnimation" into tPrev
+      set the hScroll of group "frame graphics" of stack "revAnimation" to 0
+      set the left of grc "frame1" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" + 1 + tFrameNo * 10)
+      set the left of grc "frame2" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" - 9 + tFrameNo * 10)
+      set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev
+      
+      local tDistanceOff
+      if the left of grc "frame1" of stack "revAnimation" < the left of fld "timeLine" of stack "revAnimation" then
+         put the left of fld "timeLine" of stack "revAnimation" - the left of grc "frame1" of stack "revAnimation" into tDistanceOff
+         add 10 to tDistanceOff
+         set the hScroll of fld "timeLine" of stack "revAnimation" to tPrev - tDistanceOff
+         set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev - tDistanceOff
+         set the hscroll of fld "frame markers" of stack "revAnimation" to tPrev - tDistanceOff
+         set the hscroll of fld "frame numbers" of stack "revAnimation" to tPrev - tDistanceOff
+      else if the left of grc "frame1" of stack "revAnimation" > the right of fld "timeLine" of stack "revAnimation" then
+         put the left of grc "frame1" of stack "revAnimation" - the right of fld "timeLine" of stack "revAnimation" into tDistanceOff
+         add 20 to tDistanceOff
+         set the hScroll of fld "timeLine" of stack "revAnimation" to tPrev + tDistanceOff
+         set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev + tDistanceOff
+         set the hscroll of fld "frame markers" of stack "revAnimation" to tPrev + tDistanceOff
+         set the hscroll of fld "frame numbers" of stack "revAnimation" to tPrev + tDistanceOff
+      end if
+      unlock screen
+      if "revCheckPalette" is not in the pendingMessages then send "revCheckPalette" to cd 1 of stack "revAnimation" in 250 milliseconds
+      send "revStartTracking" to fld "timeline" of stack "revAnimation" --don't add keyframe
+   end if
 end revUpdateAnimationPalette
 
 on revPlayAnimation pWhichAnimation, pStart, pEnd
-  lock messages
-  if the lockScreen then unlock screen
-  if pStart is not a number and pStart is not empty then
-    --look it up to see if you can find the frame
-    put the cREVAnimation[pWhichAnimation,frameNames] of this cd & cr into tKeyFrames
-    put lineOffset(comma&pStart&cr,tKeyFrames) into tLineNo
-    if tLineNo is 0 then revAnimationError "frame named" && pStart && "not listed"
-    put item 1 of line tLineNo of tKeyFrames into pStart
-  end if
-  if pEnd is not a number and pEnd is not empty then
-    --look it up to see if you can find the frame
-    put the cREVAnimation[pWhichAnimation,frameNames] of this cd & cr into tKeyFrames
-    put lineOffset(comma&pEnd&cr,tKeyFrames) into tLineNo
-    if tLineNo is 0 then revAnimationError "frame named" && pEnd && "not listed"
-    put item 1 of line tLineNo of tKeyFrames into pEnd
-  end if
-  if pStart is empty then put 1 into pStart
-  if pEnd is empty then put the cREVAnimation[pWhichAnimation,"calculatedTotal"] of this cd into pEnd
-  put true into lOverRide
-  put pStart into tCurrent
-  put pEnd into tTotal
-  put the cREVAnimation[pWhichAnimation,"frameRate"] of this cd into tRate
-  set the cREVAnimation[pWhichAnimation,status] of this cd to "playing"
-  put 1000 / tRate into tWait
-  put 1 into tIncrement
-  put the milliseconds into tStart
-  if pStart <= pEnd then
-    repeat with i = tCurrent to tTotal
-      if i is tTotal then put false into lOverRide
-      revGoToFramePaused pWhichAnimation,i
-      if the cREVAnimation[pWhichAnimation,status] of this cd is "paused" then 
-        put false into lOverride
-        revUpdateAnimationPalette i
-        exit repeat
-      end if
-      add 1 to tIncrement
-      repeat
-        if the milliseconds >= tStart+(tIncrement*tWait) then exit repeat
+   lock messages
+   if the lockScreen then unlock screen
+   
+   local tKeyFrames
+   if pStart is not a number and pStart is not empty then
+      --look it up to see if you can find the frame
+      put the cREVAnimation[pWhichAnimation,"frameNames"] of this cd & cr into tKeyFrames
+      
+      local tLineNo
+      put lineOffset(comma&pStart&cr,tKeyFrames) into tLineNo
+      if tLineNo is 0 then revAnimationError "frame named" && pStart && "not listed"
+      put item 1 of line tLineNo of tKeyFrames into pStart
+   end if
+   if pEnd is not a number and pEnd is not empty then
+      --look it up to see if you can find the frame
+      put the cREVAnimation[pWhichAnimation,"frameNames"] of this cd & cr into tKeyFrames
+      put lineOffset(comma&pEnd&cr,tKeyFrames) into tLineNo
+      if tLineNo is 0 then revAnimationError "frame named" && pEnd && "not listed"
+      put item 1 of line tLineNo of tKeyFrames into pEnd
+   end if
+   if pStart is empty then put 1 into pStart
+   if pEnd is empty then put the cREVAnimation[pWhichAnimation,"calculatedTotal"] of this cd into pEnd
+   put true into lOverRide
+   
+   local tCurrent
+   put pStart into tCurrent
+   
+   local tTotal
+   put pEnd into tTotal
+   
+   local tRate
+   put the cREVAnimation[pWhichAnimation,"frameRate"] of this cd into tRate
+   set the cREVAnimation[pWhichAnimation,"status"] of this cd to "playing"
+   
+   local tWait
+   put 1000 / tRate into tWait
+   
+   local tIncrement
+   put 1 into tIncrement
+   
+   local tStart
+   put the milliseconds into tStart
+   if pStart <= pEnd then
+      repeat with i = tCurrent to tTotal
+         if i is tTotal then put false into lOverRide
+         revGoToFramePaused pWhichAnimation,i
+         if the cREVAnimation[pWhichAnimation,status] of this cd is "paused" then 
+            put false into lOverride
+            revUpdateAnimationPalette i
+            exit repeat
+         end if
+         add 1 to tIncrement
+         repeat
+            if the milliseconds >= tStart+(tIncrement*tWait) then exit repeat
+         end repeat
       end repeat
-    end repeat
-  else
-    repeat with i = tCurrent down to tTotal
-      if i is tTotal then put false into lOverRide
-      revGoToFramePaused pWhichAnimation,i
-      if the cREVAnimation[pWhichAnimation,status] of this cd is "paused" then
-        put false into lOverride        
-        revUpdateAnimationPalette i
-        exit repeat
-      end if
-      add 1 to tIncrement
-      repeat
-        if the milliseconds >= tStart+(tIncrement*tWait) then exit repeat
+   else
+      repeat with i = tCurrent down to tTotal
+         if i is tTotal then put false into lOverRide
+         revGoToFramePaused pWhichAnimation,i
+         if the cREVAnimation[pWhichAnimation,status] of this cd is "paused" then
+            put false into lOverride        
+            revUpdateAnimationPalette i
+            exit repeat
+         end if
+         add 1 to tIncrement
+         repeat
+            if the milliseconds >= tStart+(tIncrement*tWait) then exit repeat
+         end repeat
       end repeat
-    end repeat
-  end if
-  unlock messages
+   end if
+   unlock messages
 end revPlayAnimation
 
 on revStopAnimation pWhichAnimation
@@ -270,22 +319,25 @@ end revStopAnimation
 --end revPreLoadAnimation
 
 on revAnimationError pWhich
-  if "frame" is in pWhich and "not found" is in pWhich and there is a stack "revAnimation" and the mode of stack "revAnimation" is not 0 then
-    put the cREVAnimation[tName,calculatedTotal] of this cd into tFrameNo
-    revGoToFramePaused the cCurrentAnimation of this cd of stack "revAnimation",tFrameNo
-    put word 2 of pWhich into tFrameNo
-    put tFrameNo into fld "current frame" of stack "revAnimation"
-    lock screen
-    put the hScroll of group "frame graphics" of stack "revAnimation" into tPrev
-    set the hScroll of group "frame graphics" of stack "revAnimation" to 0
-    set the left of grc "frame1" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" + 1 + tFrameNo * 10)
-    set the left of grc "frame2" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" - 9 + tFrameNo * 10)
-    set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev
-    unlock screen
-    if "revCheckPalette" is not in the pendingMessages then send "revCheckPalette" to cd 1 of stack "revAnimation" in 250 milliseconds
-    send "revStartTracking" to fld "timeline" of stack "revAnimation" --don't add keyframe
-  else
-   -- put "Animation error" && pWhich
-    exit to top
-  end if
+   if "frame" is in pWhich and "not found" is in pWhich and there is a stack "revAnimation" and the mode of stack "revAnimation" is not 0 then
+      local tFrameNo
+      global gREVCurrentAnimation
+      put the cREVAnimation[gREVCurrentAnimation,"calculatedTotal"] of this cd into tFrameNo
+      revGoToFramePaused the cCurrentAnimation of this cd of stack "revAnimation",tFrameNo
+      put word 2 of pWhich into tFrameNo
+      put tFrameNo into fld "current frame" of stack "revAnimation"
+      lock screen
+      local tPrev
+      put the hScroll of group "frame graphics" of stack "revAnimation" into tPrev
+      set the hScroll of group "frame graphics" of stack "revAnimation" to 0
+      set the left of grc "frame1" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" + 1 + tFrameNo * 10)
+      set the left of grc "frame2" of stack "revAnimation" to (the left of fld "timeLine" of stack "revAnimation" - 9 + tFrameNo * 10)
+      set the hScroll of group "frame graphics" of stack "revAnimation" to tPrev
+      unlock screen
+      if "revCheckPalette" is not in the pendingMessages then send "revCheckPalette" to cd 1 of stack "revAnimation" in 250 milliseconds
+      send "revStartTracking" to fld "timeline" of stack "revAnimation" --don't add keyframe
+   else
+      -- put "Animation error" && pWhich
+      exit to top
+   end if
 end revAnimationError

--- a/Toolset/libraries/revanimationlibrary.livecodescript
+++ b/Toolset/libraries/revanimationlibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revanimationlibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 --------Animation Library--------

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revbackscriptlibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 global gREVSuppressMessages

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -967,7 +967,6 @@ function revLookUpPackage pPath
 end revLookUpPackage
 
 on reloadStack pStackName, pFileName
-   global gREVSuppressMessages
    if the filename of stack pStackName is pFileName then
       toplevel pStackName
    else
@@ -3472,7 +3471,7 @@ command revIDEHandleNewStack pTarget
          send "revNewStack tStack" to stack "revApplicationOverview"
       end if
    end if
-   global gREVMessageDispatch
+   
    repeat for each line l in gREVMessageDispatch["revPreOpenStack"]
       send "revPreOpenStack" to this cd of stack l
    end repeat

--- a/Toolset/libraries/revcommonlibrary.livecodescript
+++ b/Toolset/libraries/revcommonlibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revcommonlibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 function revTargetStack pWhich

--- a/Toolset/libraries/revdeploylibrary.livecodescript
+++ b/Toolset/libraries/revdeploylibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revDeployLibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Toolset/libraries/revgeometrylibrary.livecodescript
+++ b/Toolset/libraries/revgeometrylibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revgeometrylibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 # OK-2007-08-10 : Added variable declarations and quotes round literals to this script, also tidied up some code and fixed some bugs.

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -1,7 +1,15 @@
 ﻿script "revIDEDocumentationLibrary"
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
+
+on revUnloadLibrary
+   if the target is me then
+      remove script of me from back
+   end if
+end revUnloadLibrary
 
 private on ideDocsEnsureDatabase pLocation
    if there is not a file (pLocation & slash & "api.sqlite") then

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -156,7 +156,8 @@ end ideDocsFetchData
 Fetch the data for LiveCode script dictionary entries with name <pEntryName>
 
 Returns:
-A numerically keyed array, each element of which is the arrayof data 
+A numerically keyed array, each element of which is the array
+of data 
 pertaining to a  LiveCode script dictionary entry with the given name.
 */
 function ideDocsFetchLCSData pEntryName
@@ -168,7 +169,8 @@ Fetch the data for the LiveCode script dictionary entry with name <pEntryName>
 and type <pType>
 
 Returns:
-An arrayof data pertaining to the unique LiveCode script dictionary entry with the 
+An array
+of data pertaining to the unique LiveCode script dictionary entry with the 
 given name and type.
 */
 function ideDocsFetchLCSDataOfType pEntryName, pType
@@ -180,7 +182,8 @@ Fetch a specific element of the array of data for the LiveCode script dictionary
 with name <pEntryName> and type <pType>.
 
 Returns:
-Either a string or an arrayof data describing the element of the array of data
+Either a string or an array
+of data describing the element of the array of data
 pertaining to the LiveCode script dictionary entry with the given name and type.
 */
 function ideDocsFetchLCSElementOfType pEntryName, pType, pElement
@@ -191,7 +194,8 @@ end ideDocsFetchLCSElementOfType
 Fetch the data for LiveCode builder dictionary entries with name <pEntryName>
 
 Returns:
-A numerically keyed array, each element of which is the arrayof data 
+A numerically keyed array, each element of which is the array
+of data 
 pertaining to a LiveCode builder dictionary entry with the given name.
 */
 function ideDocsFetchLCBData pEntryName
@@ -203,7 +207,8 @@ Fetch the data for the LiveCode builder dictionary entry with name <pEntryName>
 and type <pType>
 
 Returns:
-An arrayof data pertaining to the unique LiveCode builder dictionary entry with the 
+An array
+of data pertaining to the unique LiveCode builder dictionary entry with the 
 given name and type.
 */
 function ideDocsFetchLCBDataOfType pEntryName, pType
@@ -215,7 +220,8 @@ Fetch a specific element of the array of data for the LiveCode builder dictionar
 with name <pEntryName> and type <pType>.
 
 Returns:
-Either a string or an arrayof data describing the element of the array of data
+Either a string or an array
+of data describing the element of the array of data
 pertaining to the LiveCode builder dictionary entry with the given name and type.
 */
 function ideDocsFetchLCBElementOfType pEntryName, pType, pElement
@@ -226,7 +232,8 @@ end ideDocsFetchLCBElementOfType
 Fetch the data for entries in the API for extension <pID> with name <pEntryName>
 
 Returns:
-A numerically keyed array, each element of which is the arrayof data 
+A numerically keyed array, each element of which is the array
+of data 
 pertaining to an entry in the API for the given extension with the given name.
 */
 function ideDocsFetchExtensionData pID, pEntryName
@@ -240,7 +247,8 @@ Fetch the data for the entry in the API for extension <pID> with name <pEntryNam
 and type <pType>
 
 Returns:
-An arrayof data pertaining to the unique entry in the API for the given extension with the 
+An array
+of data pertaining to the unique entry in the API for the given extension with the 
 given name and type.
 */
 function ideDocsFetchExtensionDataOfType pID, pEntryName, pType
@@ -254,7 +262,8 @@ Fetch a specific element of the array of data for the entry in the API for exten
 with name <pEntryName> and type <pType>.
 
 Returns:
-Either a string or an arrayof data describing the element of the array of data
+Either a string or an array
+of data describing the element of the array of data
 pertaining to the entry in the API for the given extension with the given name and type.
 */
 function ideDocsFetchExtensionElementOfType pID, pEntryName, pType, pElement
@@ -307,7 +316,8 @@ end ideDocsFetchLibraryEntries
 Fetch the data for all entries in the LiveCode script dictionary
 
 Returns:
-A numerically keyed array, each element of which is the arrayof data 
+A numerically keyed array, each element of which is the array
+of data 
 pertaining to an entry in the LiveCode script dictionary.
 */
 function ideDocsFetchLCSEntries
@@ -318,7 +328,8 @@ end ideDocsFetchLCSEntries
 Fetch the data for all entries in the LiveCode builder dictionary
 
 Returns:
-A numerically keyed array, each element of which is the arrayof data 
+A numerically keyed array, each element of which is the array
+of data 
 pertaining to an entry in the LiveCode builder dictionary.
 */
 function ideDocsFetchLCBEntries
@@ -329,7 +340,8 @@ end ideDocsFetchLCBEntries
 Fetch the data for all entries in the API for extension <pID>  
 
 Returns:
-A numerically keyed array, each element of which is the arrayof data 
+A numerically keyed array, each element of which is the array
+of data 
 pertaining to an entry in the API for the given extension.
 */
 function ideDocsFetchExtensionEntries pID

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -2,11 +2,15 @@
 local sExtensions, sExtensionProperties
 
 on revLoadLibrary
-   insert script of me into back 
+   if the target is me then
+      insert script of me into back 
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove script of me from back
+   if the target is me then
+      remove script of me from back
+   end if
 end revUnloadLibrary
 
 # Called at startup. Loads all the extensions ready for use

--- a/Toolset/libraries/revidelibrary.livecodescript
+++ b/Toolset/libraries/revidelibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revoldidelibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Toolset/libraries/revmetadatalibrary.livecodescript
+++ b/Toolset/libraries/revmetadatalibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revmetadatalibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 ################################################################################

--- a/Toolset/libraries/revprintlibrary.livecodescript
+++ b/Toolset/libraries/revprintlibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revprintlibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 ----------------------printing handlers

--- a/Toolset/libraries/revprintlibrary.livecodescript
+++ b/Toolset/libraries/revprintlibrary.livecodescript
@@ -15,17 +15,17 @@ local numPages
 constant kPo = 36
 
 on revShowPrintDialog pShowPageSetup, pShowPrinter
-  --pAnswerPrinter governs whether to show number of copies / etc. box
-  --pAnswerPrinter covers page setup on Windows as these are the same dialog
-  --pMacPrinter governs whether to show Mac printer box (MacOS only)
-  put pShowPrinter into lAnswerPrinter
-  put pShowPageSetup into lPageSetup
+   --pAnswerPrinter governs whether to show number of copies / etc. box
+   --pAnswerPrinter covers page setup on Windows as these are the same dialog
+   --pMacPrinter governs whether to show Mac printer box (MacOS only)
+   put pShowPrinter into lAnswerPrinter
+   put pShowPageSetup into lPageSetup
 end revShowPrintDialog
 
 on revPrintField pFieldRef
-  --just takes a field reference and prints the field, complete with styles and no fuss
-  --if not (there is a fld pFieldRef) then do "put the short name of" && pFieldRef && "into pFieldRef"
-  revPrintText the htmlText of pFieldRef,empty,empty,the long id of pFieldRef
+   --just takes a field reference and prints the field, complete with styles and no fuss
+   --if not (there is a fld pFieldRef) then do "put the short name of" && pFieldRef && "into pFieldRef"
+   revPrintText the htmlText of pFieldRef,empty,empty,the long id of pFieldRef
 end revPrintField
 
 on revPrintText pText,pHeader,pFooter,pSourceFieldRef,pHeaderFldRef,pFooterFldRef
@@ -75,6 +75,7 @@ on revPrintText pText,pHeader,pFooter,pSourceFieldRef,pHeaderFldRef,pFooterFldRe
    -- prepare template for invisible stacks the width of the page
    set the backgroundcolor of the templateStack to "white"
    if pSourceFieldRef is not empty then
+      local tTargetStack
       put revTargetStack(pSourceFieldRef) into tTargetStack
       set the underLineLinks of the templateStack to the underLineLinks of stack tTargetStack
       set the linkColor of the templateStack to the linkColor of stack tTargetStack
@@ -178,1166 +179,1430 @@ end revPrintText
 
 
 on revPrintSetText pTheText, pFldNum
-  local tExpressionStart, tExpressionEnd
-  if pFldNum = "" then put 1 into pFldNum
-  if "<p>" is in pTheText or matchChunk(pTheText, "<(.+>.+</.+)>") is true then set the htmltext of field pFldNum to pTheText
-  else put pTheText into field pFldNum
-  repeat until matchChunk(field pFldNum, "<%(.[^<]*)%>", tExpressionStart, tExpressionEnd) is false
-    put value(char tExpressionStart to tExpressionEnd of field pFldNum) into char tExpressionStart-2 to tExpressionEnd+2 of field pFldNum
-  end repeat
+   local tExpressionStart, tExpressionEnd
+   if pFldNum = "" then put 1 into pFldNum
+   if "<p>" is in pTheText or matchChunk(pTheText, "<(.+>.+</.+)>") is true then set the htmltext of field pFldNum to pTheText
+   else put pTheText into field pFldNum
+   repeat until matchChunk(field pFldNum, "<%(.[^<]*)%>", tExpressionStart, tExpressionEnd) is false
+      put value(char tExpressionStart to tExpressionEnd of field pFldNum) into char tExpressionStart-2 to tExpressionEnd+2 of field pFldNum
+   end repeat
 end revPrintSetText
 
 -- Need to set the font after the stack is created to prevent inheritance of
 -- non-formatForPrinting fonts from Home stack
 
 on revSetPrintFont pSourceFieldRef
-  if pSourceFieldRef is not empty then
-    if the effective textFont of pSourceFieldRef is among the lines of fontNames("printer") then
-      set the textFont of this stack to the effective textFont of pSourceFieldRef
-    else
-      if "Arial" is among the lines of fontNames("Printer") then set the textFont of this stack to "Arial"
-      else if "Helvetica" is among the lines of fontNames("Printer") then set the textFont of this stack to "Helvetica" 
-      else set the textFont of this stack to line 1 of fontNames("printer")
-    end if
-    set the textSize of this stack to the effective textSize of pSourceFieldRef
-    set the textStyle of this stack to the effective textStyle of pSourceFieldRef
-  else
-    set the textSize of this stack to 12
-    if the effective textFont of this stack is not among the lines of fontNames("printer") then
-      if "Arial" is among the lines of fontNames("printer") then set the textFont of this stack to "Arial"
-      else if "Helvetica" is among the lines of fontNames("Printer") then set the textFont of this stack to "Helvetica"
-      else set the textFont of this stack to line 1 of fontNames("printer")
-    end if
-  end if
+   if pSourceFieldRef is not empty then
+      if the effective textFont of pSourceFieldRef is among the lines of fontNames("printer") then
+         set the textFont of this stack to the effective textFont of pSourceFieldRef
+      else
+         if "Arial" is among the lines of fontNames("Printer") then set the textFont of this stack to "Arial"
+         else if "Helvetica" is among the lines of fontNames("Printer") then set the textFont of this stack to "Helvetica" 
+         else set the textFont of this stack to line 1 of fontNames("printer")
+      end if
+      set the textSize of this stack to the effective textSize of pSourceFieldRef
+      set the textStyle of this stack to the effective textStyle of pSourceFieldRef
+   else
+      set the textSize of this stack to 12
+      if the effective textFont of this stack is not among the lines of fontNames("printer") then
+         if "Arial" is among the lines of fontNames("printer") then set the textFont of this stack to "Arial"
+         else if "Helvetica" is among the lines of fontNames("Printer") then set the textFont of this stack to "Helvetica"
+         else set the textFont of this stack to line 1 of fontNames("printer")
+      end if
+   end if
 end revSetPrintFont
 
 function revCreatePrintHeaderAndFooter pTheText
-  create field
-  set the itemDelimiter to tab
-  if item 1 of pTheText <> empty then
-    revPrintSetText item 1 of pTheText,1
-    put the formattedheight of field 1 into lFH1
-  else put 0 into lFH1
-  create field
-  if item 2 of pTheText <> empty then
-    revPrintSetText item 2 of pTheText,2
-    put the formattedheight of field 2 into lFH2
-  else put 0 into lFH2
-  create field
-  if item 3 of pTheText <> empty then
-    revPrintSetText item 3 of pTheText,3
-    put the formattedheight of field 3 into lFH3
-  else put 0 into lFH3
-  set the height of this stack to max(lFH1,lFH2,lFH3)
-  get rect of this card
-  set the rect of field 1 to it
-  set the rect of field 2 to it
-  set the rect of field 3 to it
-  set the textalign of field 1 to left
-  set the textalign of field 2 to "center"
-  set the textalign of field 3 to right
-  return height of this stack+kPo
+   create field
+   set the itemDelimiter to tab
+   local tFH1, tFH2, tFH3
+   if item 1 of pTheText <> empty then
+      revPrintSetText item 1 of pTheText,1
+      put the formattedheight of field 1 into tFH1
+   else put 0 into tFH1
+   create field
+   if item 2 of pTheText <> empty then
+      revPrintSetText item 2 of pTheText,2
+      put the formattedheight of field 2 into tFH2
+   else put 0 into tFH2
+   create field
+   if item 3 of pTheText <> empty then
+      revPrintSetText item 3 of pTheText,3
+      put the formattedheight of field 3 into tFH3
+   else put 0 into tFH3
+   set the height of this stack to max(tFH1,tFH2,tFH3)
+   get rect of this card
+   set the rect of field 1 to it
+   set the rect of field 2 to it
+   set the rect of field 3 to it
+   set the textalign of field 1 to left
+   set the textalign of field 2 to "center"
+   set the textalign of field 3 to right
+   return height of this stack+kPo
 end revCreatePrintHeaderAndFooter
 ----------------end of printing handlers
 
 --------report manager handlers
 on revUpdateViewerObjectList
-  put 0 into tViewerObjects
-  repeat with i = 1 to the number of controls of this card of the topStack
-    put the long id of control i of this card of the topStack into tControl
-    if (the cREVReport["viewername"] of tControl is not empty) and (the cREVReport["sourceobjectstackname"] of tControl is not empty) then
-      put tViewerObjects + 1 into tViewerObjects
-    end if 
-  end repeat
-  set the cREVReport["viewerobjects"] of this card of the topStack to tViewerObjects
-  put empty into tViewerList
-  repeat with i = 1 to tViewerObjects
-    put the long id of control i of the topStack into tObject
-    put the cREVReport["viewername"] of tObject into tViewerName
-    put the cREVReport["sourceobjectstackname"] of tObject into tSourceStackName
-    put the cREVReport["sourceobjectlongid"] of tObject into tSourceObjectlongid
-    put tViewerName & "," & tSourceStackName & "," & tSourceObjectlongid & cr after tViewerList
-  end repeat
-  if the last char of tViewerList is cr then
-    delete the last char of tViewerList
-  end if
-  set the cREVReport["sourceobjectlist"] of this card of the topStack to tViewerList
+   local tViewerObjects
+   put 0 into tViewerObjects
+   repeat with i = 1 to the number of controls of this card of the topStack
+      local tControl
+      put the long id of control i of this card of the topStack into tControl
+      if (the cREVReport["viewername"] of tControl is not empty) and (the cREVReport["sourceobjectstackname"] of tControl is not empty) then
+         put tViewerObjects + 1 into tViewerObjects
+      end if 
+   end repeat
+   set the cREVReport["viewerobjects"] of this card of the topStack to tViewerObjects
+   local tViewerList
+   put empty into tViewerList
+   repeat with i = 1 to tViewerObjects
+      local tObject
+      put the long id of control i of the topStack into tObject
+      
+      local tViewerName
+      put the cREVReport["viewername"] of tObject into tViewerName
+      
+      local tSourceStackName
+      put the cREVReport["sourceobjectstackname"] of tObject into tSourceStackName
+      
+      local tSourceObjectlongid
+      put the cREVReport["sourceobjectlongid"] of tObject into tSourceObjectlongid
+      put tViewerName & "," & tSourceStackName & "," & tSourceObjectlongid & cr after tViewerList
+   end repeat
+   if the last char of tViewerList is cr then
+      delete the last char of tViewerList
+   end if
+   set the cREVReport["sourceobjectlist"] of this card of the topStack to tViewerList
 end revUpdateViewerObjectList
 
 
 
 
 function revGetMaxNumberCards
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    put 0 into tMaxCard
-    repeat with i = 1 to the number of controls in this card of the topStack
-      put the long id of control i of the topStack into tObject
-      if the cREVGeneral["viewerobject"] of tObject is not true then
-        next repeat
-      end if
-      if the cREVReport["maxcards"] of tObject > tMaxCard then
-        put the cREVReport["maxcards"] of tObject into tMaxCard 
-      end if
-    end repeat
-  end if
-  return tMaxCard
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      local tMaxCard
+      put 0 into tMaxCard
+      repeat with i = 1 to the number of controls in this card of the topStack
+         local tObject
+         put the long id of control i of the topStack into tObject
+         if the cREVGeneral["viewerobject"] of tObject is not true then
+            next repeat
+         end if
+         if the cREVReport["maxcards"] of tObject > tMaxCard then
+            put the cREVReport["maxcards"] of tObject into tMaxCard 
+         end if
+      end repeat
+   end if
+   return tMaxCard
 end revGetMaxNumberCards
 
 function revSourceObject pViewerName, pCardNumber
-  put the cREVReport["sourceobjectlist"] of this card of the topStack into tList
-  repeat with i = 1 to the number of lines in tList
-    if pViewerName is item 1 of line i of tList then
-      put item 3 of line i of tList into tFullPath
-      replace "of" with "," in tFullPath
-      put item 1 of tFullPath into tObject
-      if the last char of tObject is space then
-        delete the last char of tObject
+   local tList
+   put the cREVReport["sourceobjectlist"] of this card of the topStack into tList
+   repeat with i = 1 to the number of lines in tList
+      if pViewerName is item 1 of line i of tList then
+         local tFullPath
+         put item 3 of line i of tList into tFullPath
+         replace "of" with "," in tFullPath
+         
+         local tObject
+         put item 1 of tFullPath into tObject
+         if the last char of tObject is space then
+            delete the last char of tObject
+         end if
+         
+         local tSourceObjectName
+         if the paramCount is 2 then
+            put tObject && "of card" && pCardNumber && "of stack" && quote & item 2 of line i of tList & quote into tSourceObjectName
+         else
+            put tObject && "of card revSourceCardNumber of stack" && quote & item 2 of line i of tList & quote into tSourceObjectName
+         end if
+         exit repeat
       end if
-      if the paramCount is 2 then
-        put tObject && "of card" && pCardNumber && "of stack" && quote & item 2 of line i of tList & quote into tSourceObjectName
-      else
-        put tObject && "of card revSourceCardNumber of stack" && quote & item 2 of line i of tList & quote into tSourceObjectName
-      end if
-      exit repeat
-    end if
-  end repeat
-  return tSourceObjectName
+   end repeat
+   return tSourceObjectName
 end revSourceObject
 
 function revGetExpressionCards
-  local revSourceCardNumber, revSourceStackName, revSourceCardShortName, revSourceCardLongID
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-    put empty into tExpressionList
-    repeat with i = 1 to tNumber
-      put empty into tExpressionLineList
-      put the long id of control i of the topStack into tObject
-      if the cREVGeneral["viewerobject"] of tObject is not true then
-        next repeat
-      end if
-      put the cREVReport["maxcards"] of tObject into tMaxCard
-      put the cREVReport["sourceobjectstackname"] of tObject into revSourceStackName
-      repeat with j = 1 to tMaxCard
-        put empty into tResult
-        put the cREVReport["expression"] of this card of the topStack into tDoStatement
-        put j into revSourceCardNumber
-        --put the short name of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) into revSourceCardShortName
-        --put the long id of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) into revSourceCardLongID
-        --put value(tValue,tCardObject) into tResult
-        do tDoStatement
-        put the result into tResult
-        if tResult is true then
-          put j & "," after tExpressionLineList
-        end if
+   local revSourceCardNumber, revSourceStackName, revSourceCardShortName, revSourceCardLongID
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      local tNumber
+      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+      
+      local tExpressionList
+      put empty into tExpressionList
+      repeat with i = 1 to tNumber
+         local tExpressionLineList
+         put empty into tExpressionLineList
+         
+         local tObject
+         put the long id of control i of the topStack into tObject
+         if the cREVGeneral["viewerobject"] of tObject is not true then
+            next repeat
+         end if
+         
+         local tMaxCard
+         put the cREVReport["maxcards"] of tObject into tMaxCard
+         put the cREVReport["sourceobjectstackname"] of tObject into revSourceStackName
+         repeat with j = 1 to tMaxCard
+            local tResult
+            put empty into tResult
+            
+            local tDoStatement
+            put the cREVReport["expression"] of this card of the topStack into tDoStatement
+            put j into revSourceCardNumber
+            --put the short name of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) into revSourceCardShortName
+            --put the long id of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) into revSourceCardLongID
+            --put value(tValue,tCardObject) into tResult
+            do tDoStatement
+            put the result into tResult
+            if tResult is true then
+               put j & "," after tExpressionLineList
+            end if
+         end repeat
+         if the last char of tExpressionLineList is comma then
+            delete the last char of tExpressionLineList
+         end if
+         set the cREVReport["expressioncards"] of tObject to tExpressionLineList
+         put tExpressionLineList & cr after tExpressionList
       end repeat
-      if the last char of tExpressionLineList is comma then
-        delete the last char of tExpressionLineList
+      if the last char of tExpressionList is cr then
+         delete the last char of tExpressionList
       end if
-      set the cREVReport["expressioncards"] of tObject to tExpressionLineList
-      put tExpressionLineList & cr after tExpressionList
-    end repeat
-    if the last char of tExpressionList is cr then
-      delete the last char of tExpressionList
-    end if
-  end if
-  return tExpressionList
+   end if
+   return tExpressionList
 end revGetExpressionCards
 
 function revGetMarkedCards
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-    put empty into tMarkedList
-    repeat with i = 1 to tNumber
-      put empty into tMarkedLineList
-      put the long id of control i of the topStack into tObject
-      if the cREVGeneral["viewerobject"] of tObject is not true then
-        next repeat
-      end if
-      put the cREVReport["maxcards"] of tObject into tMaxCard
-      repeat with j = 1 to tMaxCard
-        if the mark of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) is true then
-          put j & "," after tMarkedLineList
-        end if
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      
+      local tNumber
+      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+      
+      local tMarkedList
+      put empty into tMarkedList
+      repeat with i = 1 to tNumber
+         
+         local tMarkedLineList
+         put empty into tMarkedLineList
+         
+         local tObject
+         put the long id of control i of the topStack into tObject
+         if the cREVGeneral["viewerobject"] of tObject is not true then
+            next repeat
+         end if
+         
+         local tMaxCard
+         put the cREVReport["maxcards"] of tObject into tMaxCard
+         repeat with j = 1 to tMaxCard
+            if the mark of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) is true then
+               put j & "," after tMarkedLineList
+            end if
+         end repeat
+         if the last char of tMarkedLineList is comma then
+            delete the last char of tMarkedLineList
+         end if
+         set the cREVReport["markedcards"] of tObject to tMarkedLineList
+         put tMarkedLineList & cr after tMarkedList
       end repeat
-      if the last char of tMarkedLineList is comma then
-        delete the last char of tMarkedLineList
+      if the last char of tMarkedList is cr then
+         delete the last char of tMarkedList
       end if
-      set the cREVReport["markedcards"] of tObject to tMarkedLineList
-      put tMarkedLineList & cr after tMarkedList
-    end repeat
-    if the last char of tMarkedList is cr then
-      delete the last char of tMarkedList
-    end if
-  end if
-  return tMarkedList
+   end if
+   return tMarkedList
 end revGetMarkedCards
 
 function revGetUnmarkedCards
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-    put empty into tUnmarkedList
-    repeat with i = 1 to tNumber
-      put empty into tUnmarkedLineList
-      put the long id of control i of the topStack into tObject
-      if the cREVGeneral["viewerobject"] of tObject is not true then
-        next repeat
-      end if
-      put the cREVReport["maxcards"] of tObject into tMaxCard
-      repeat with j = 1 to tMaxCard
-        if the mark of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) is false then
-          put j & "," after tUnmarkedLineList
-        end if
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      local tNumber
+      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+      
+      local tUnmarkedList
+      put empty into tUnmarkedList
+      repeat with i = 1 to tNumber
+         local tUnmarkedLineList
+         put empty into tUnmarkedLineList
+         
+         local tObject
+         put the long id of control i of the topStack into tObject
+         if the cREVGeneral["viewerobject"] of tObject is not true then
+            next repeat
+         end if
+         
+         local tMaxCard
+         put the cREVReport["maxcards"] of tObject into tMaxCard
+         repeat with j = 1 to tMaxCard
+            if the mark of card j of stack (the cREVReport["sourceobjectstackname"] of tObject) is false then
+               put j & "," after tUnmarkedLineList
+            end if
+         end repeat
+         if the last char of tUnmarkedLineList is comma then
+            delete the last char of tUnmarkedLineList
+         end if
+         set the cREVReport["unmarkedcards"] of tObject to tUnmarkedLineList
+         put tUnmarkedLineList & cr after tUnmarkedList
       end repeat
-      if the last char of tUnmarkedLineList is comma then
-        delete the last char of tUnmarkedLineList
+      if the last char of tUnmarkedList is cr then
+         delete the last char of tUnmarkedList
       end if
-      set the cREVReport["unmarkedcards"] of tObject to tUnmarkedLineList
-      put tUnmarkedLineList & cr after tUnmarkedList
-    end repeat
-    if the last char of tUnmarkedList is cr then
-      delete the last char of tUnmarkedList
-    end if
-  end if
-  return tUnmarkedList
+   end if
+   return tUnmarkedList
 end revGetUnmarkedCards
 
 on revPrintAllCards pCards
-  put revGetMaxNumberCards() into tMaxCards
-  if tMaxCards >= 1 then
-    put 1 & "-" & tMaxCards into tRange
-    put revReportParseRangeList(tRange) into tList
-    revPrintCards tList, pCards
-  end if
+   local tMaxCards
+   put revGetMaxNumberCards() into tMaxCards
+   if tMaxCards >= 1 then
+      local tRange
+      put 1 & "-" & tMaxCards into tRange
+      
+      local tList
+      put revReportParseRangeList(tRange) into tList
+      revPrintCards tList, pCards
+   end if
 end revPrintAllCards
 
 on revPrintMarkedCards pCards
-  put revGetMarkedCards() into tRawList
-  put revReportParseRangeList(tRawList) into tList
-  if tList is not empty then
-    revPrintCards tList, pCards
-  end if
+   local tRawList
+   put revGetMarkedCards() into tRawList
+   
+   local tList
+   put revReportParseRangeList(tRawList) into tList
+   if tList is not empty then
+      revPrintCards tList, pCards
+   end if
 end revPrintMarkedCards
 
 on revPrintUnmarkedCards pCards
-  put revGetUnmarkedCards() into tRawList
-  put revReportParseRangeList(tRawList) into tList
-  if tList is not empty then
-    revPrintCards tList, pCards
-  end if
+   local tRawList
+   put revGetUnmarkedCards() into tRawList
+   
+   local tList
+   put revReportParseRangeList(tRawList) into tList
+   if tList is not empty then
+      revPrintCards tList, pCards
+   end if
 end revPrintUnmarkedCards
 
 on revPrintRangeCards pCards
-  if the cREVReport["cardrange"] of this card of the topStack is not empty then
-    put the cREVReport["cardrange"] of this card of the topStack into tRawList
-    put revReportParseRangeList(tRawList) into tList
-    if tList is not empty then
-      revPrintCards tList, pCards
-    end if
-  end if
+   if the cREVReport["cardrange"] of this card of the topStack is not empty then
+      local tRawList
+      put the cREVReport["cardrange"] of this card of the topStack into tRawList
+      
+      local tList
+      put revReportParseRangeList(tRawList) into tList
+      if tList is not empty then
+         revPrintCards tList, pCards
+      end if
+   end if
 end revPrintRangeCards
 
 on revPrintExpressionCards pCards
-  put revGetExpressionCards() into tRawList
-  put revReportParseRangeList(tRawList) into tList
-  if tList is not empty then
-    revPrintCards tList, pCards
-  end if
+   local tRawList
+   put revGetExpressionCards() into tRawList
+   
+   local tList
+   put revReportParseRangeList(tRawList) into tList
+   if tList is not empty then
+      revPrintCards tList, pCards
+   end if
 end revPrintExpressionCards
 
 on revReturnConfirmPrint pValue
-  if pValue is true then
-    put true into lPrintConfirm
-  else
-    put false into lPrintConfirm
-  end if
+   local lPrintConfirm
+   if pValue is true then
+      put true into lPrintConfirm
+   else
+      put false into lPrintConfirm
+   end if
 end revReturnConfirmPrint
 
 function revPrintConfirmation pNumberList
-  if ("revConfirmPrint" is in the script of this card of the topStack) and (the cREVGeneral["report"] of this card of the topStack is true) then
-    put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-    put the cREVReport["sourceobjectlist"] of this card of the topStack into tInfoList
-    repeat with i = 1 to tNumber
-      set the itemDelimiter to ":"
-      put item i of pNumberList into pNumber
-      put the long id of field i of this card of the topStack into tObject
-      repeat with j = 1 to the number of lines in tInfoList
-        put the cREVReport["sourceobjectlongid"] of tObject into tLongID
-        set the itemDelimiter to comma
-        if item 3 of line j of tInfoList is tLongID then
-          put pNumber into item 4 of line j of tInfoList
-        end if
+   if ("revConfirmPrint" is in the script of this card of the topStack) and (the cREVGeneral["report"] of this card of the topStack is true) then
+      local tNumber
+      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+      
+      local tInfoList
+      put the cREVReport["sourceobjectlist"] of this card of the topStack into tInfoList
+      repeat with i = 1 to tNumber
+         set the itemDelimiter to ":"
+         
+         local tNum
+         put item i of pNumberList into tNum
+         
+         local tObject
+         put the long id of field i of this card of the topStack into tObject
+         repeat with j = 1 to the number of lines in tInfoList
+            local tLongID
+            put the cREVReport["sourceobjectlongid"] of tObject into tLongID
+            set the itemDelimiter to comma
+            if item 3 of line j of tInfoList is tLongID then
+               put tNum into item 4 of line j of tInfoList
+            end if
+         end repeat
       end repeat
-    end repeat
-    put tInfoList into gREVReportInfo
-    put "revConfirmPrint()" into tFunction
-    return value(tFunction,this card of the topStack)
---    put empty into lPrintConfirm
---    send "revConfirmPrint tInfoList" to this card of the topStack
---    wait until lPrintConfirm is not empty
---    if lPrintConfirm is false then
---      return false
---    else if lPrintConfirm is true then
---      return true
---    end if
-  else
-    return true
-  end if
+      
+      global gREVReportInfo
+      put tInfoList into gREVReportInfo
+      
+      local tFunction
+      put "revConfirmPrint()" into tFunction
+      return value(tFunction,this card of the topStack)
+      --    put empty into lPrintConfirm
+      --    send "revConfirmPrint tInfoList" to this card of the topStack
+      --    wait until lPrintConfirm is not empty
+      --    if lPrintConfirm is false then
+      --      return false
+      --    else if lPrintConfirm is true then
+      --      return true
+      --    end if
+   else
+      return true
+   end if
 end revPrintConfirmation
 
 on revPrintCards pList, pCards
-  put the cREVReport["header"] of this card of the topStack into tHeader
-  put the cREVReport["footer"] of this card of the topStack into tFooter
-  
-  if (the cREVReport["onetoone"] of this card of the topStack is true) then
-    repeat for each item i in pList
-      revMoveToCard i
-      if revPrintConfirmation(i) is true then
-        open printing
-        if (tHeader is not empty) and (there is a stack tHeader) then
-          print stack tHeader
-        end if
-        
-        if revStackBiggerThanPaper() is true then
-          revPrintMultiplePageCard
-        else
-          print this card of the topStack
-        end if
-        
-        if (tFooter is not empty) and (there is a stack tFooter) then
-          print stack tFooter
-        end if
-        close printing
-      end if
-    end repeat
-  else if (the cREVReport["onetoone"] of this card of the topStack is false) then
-    if the cREVReport["multiplecards"] of this card of the topStack is true then
+   local tHeader
+   put the cREVReport["header"] of this card of the topStack into tHeader
+   
+   local tFooter
+   put the cREVReport["footer"] of this card of the topStack into tFooter
+   
+   if (the cREVReport["onetoone"] of this card of the topStack is true) then
       repeat for each item i in pList
-        revMoveToCard i
-        if revPrintConfirmation(i) is true then
-          open printing
-          if (tHeader is not empty) and (there is a stack tHeader) then
-            print stack tHeader
-          end if
-          repeat with j = 1 to pCards
-            if revStackBiggerThanPaper() is true then
-              revPrintMultiplePageCard
-            else
-              print this card of the topStack
-            end if
-          end repeat
-          if (tFooter is not empty) and (there is a stack tFooter) then
-            print stack tFooter
-          end if
-          close printing
-        end if
-      end repeat
-    else
-       
-      --open printing
-      put 0 into tCardNumber
-      repeat for each item i in pList
-        revMoveToCard i
-        if revPrintConfirmation(i) is true then
-          if tCardNumber = 0 then
+         revMoveToCard i
+         if revPrintConfirmation(i) is true then
             open printing
             if (tHeader is not empty) and (there is a stack tHeader) then
-              print stack tHeader
+               print stack tHeader
             end if
-          end if
-           
-          if revStackBiggerThanPaper() is true then
-            revPrintMultiplePageCard
-          else
-            print this card of the topStack 
-          end if
-           
-          put tCardNumber + 1 into tCardNumber
-          if (tCardNumber is pCards) or (i is the last item in pList) then
+            
+            if revStackBiggerThanPaper() is true then
+               revPrintMultiplePageCard
+            else
+               print this card of the topStack
+            end if
+            
             if (tFooter is not empty) and (there is a stack tFooter) then
-              print stack tFooter
+               print stack tFooter
             end if
             close printing
-            put 0 into tCardNumber
-          end if
-        end if
+         end if
       end repeat
-      --close printing
-       
-    end if
-  end if
-  put empty into gREVReportInfo
+   else if (the cREVReport["onetoone"] of this card of the topStack is false) then
+      if the cREVReport["multiplecards"] of this card of the topStack is true then
+         repeat for each item i in pList
+            revMoveToCard i
+            if revPrintConfirmation(i) is true then
+               open printing
+               if (tHeader is not empty) and (there is a stack tHeader) then
+                  print stack tHeader
+               end if
+               repeat with j = 1 to pCards
+                  if revStackBiggerThanPaper() is true then
+                     revPrintMultiplePageCard
+                  else
+                     print this card of the topStack
+                  end if
+               end repeat
+               if (tFooter is not empty) and (there is a stack tFooter) then
+                  print stack tFooter
+               end if
+               close printing
+            end if
+         end repeat
+      else
+         
+         --open printing
+         local tCardNumber
+         put 0 into tCardNumber
+         repeat for each item i in pList
+            revMoveToCard i
+            if revPrintConfirmation(i) is true then
+               if tCardNumber = 0 then
+                  open printing
+                  if (tHeader is not empty) and (there is a stack tHeader) then
+                     print stack tHeader
+                  end if
+               end if
+               
+               if revStackBiggerThanPaper() is true then
+                  revPrintMultiplePageCard
+               else
+                  print this card of the topStack 
+               end if
+               
+               put tCardNumber + 1 into tCardNumber
+               if (tCardNumber is pCards) or (i is the last item in pList) then
+                  if (tFooter is not empty) and (there is a stack tFooter) then
+                     print stack tFooter
+                  end if
+                  close printing
+                  put 0 into tCardNumber
+               end if
+            end if
+         end repeat
+         --close printing
+         
+      end if
+   end if
+   global gREVReportInfo
+   put empty into gREVReportInfo
 end revPrintCards
 
 function revStackBiggerThanPaper
-  put revCalculateEffectivePrintArea() into tPaperSize
-  put item 1 of tPaperSize into tPaperWidth
-  put item 2 of tPaperSize into tPaperHeight
-  put the width of this card of the topStack into tStackWidthPixel
-  put the height of this card of the topStack into tStackHeightPixel
-  put revPixelToPt(tStackWidthPixel) into tStackWidth
-  put revPixelToPt(tStackHeightPixel) into tStackHeight
-  if (tStackWidth > tPaperWidth) or (tStackHeight > tPaperHeight) then
-    return true
-  else
-    return false
-  end if
+   local tPaperSize
+   put revCalculateEffectivePrintArea() into tPaperSize
+   
+   local tPaperWidth
+   put item 1 of tPaperSize into tPaperWidth
+   
+   local tPaperHeight
+   put item 2 of tPaperSize into tPaperHeight
+   
+   local tStackWidthPixel
+   put the width of this card of the topStack into tStackWidthPixel
+   
+   local tStackHeightPixel
+   put the height of this card of the topStack into tStackHeightPixel
+   
+   local tStackWidth
+   put revPixelToPt(tStackWidthPixel) into tStackWidth
+   
+   local tStackHeight
+   put revPixelToPt(tStackHeightPixel) into tStackHeight
+   if (tStackWidth > tPaperWidth) or (tStackHeight > tPaperHeight) then
+      return true
+   else
+      return false
+   end if
 end revStackBiggerThanPaper
 
 on revPrintMultiplePageCard
-  put revCalculateNumberPages() into tRectList
-  open printing
-  repeat with i = 1 to the number of lines in tRectList
-    set the itemDelimiter to space
-    print this card of the topStack from item 1 of line i of tRectList to item 2 of line i of tRectList
-    print break
-  end repeat
-  close printing
+   local tRectList
+   put revCalculateNumberPages() into tRectList
+   open printing
+   repeat with i = 1 to the number of lines in tRectList
+      set the itemDelimiter to space
+      print this card of the topStack from item 1 of line i of tRectList to item 2 of line i of tRectList
+      print break
+   end repeat
+   close printing
 end revPrintMultiplePageCard
 
 
 function revReportParseRangeList pRawList
-  put the cREVReport["viewerobjects"] of this card of the topStack into tViewerNumber
-  set the itemDelimiter to comma
-  put empty into tRangeList
-  put empty into tParseRangeList
-  put 0 into tMaxItems
-  repeat with i = 1 to the number of lines in pRawList
-    put line i of pRawList into tRawLineList
-    repeat with j = 1 to the number of items in tRawLineList
-      put item j of tRawLineList into tRawRange
-      set the itemDelimiter to "-"
-      if the number of items in tRawRange = 1 then
-        put tRawRange & "," after tRangeList
-      else
-        put item 1 of tRawRange into tstart
-        put item 2 of tRawRange into tfinish
-        repeat with k = tstart to tfinish
-          put k & "," after tRangeList
-        end repeat
+   local tViewerNumber
+   put the cREVReport["viewerobjects"] of this card of the topStack into tViewerNumber
+   set the itemDelimiter to comma
+   
+   local tRangeList
+   put empty into tRangeList
+   
+   local tParseRangeList
+   put empty into tParseRangeList
+   
+   local tMaxItems
+   put 0 into tMaxItems
+   repeat with i = 1 to the number of lines in pRawList
+      local tRawLineList
+      put line i of pRawList into tRawLineList
+      repeat with j = 1 to the number of items in tRawLineList
+         local tRawRange
+         put item j of tRawLineList into tRawRange
+         set the itemDelimiter to "-"
+         if the number of items in tRawRange = 1 then
+            put tRawRange & "," after tRangeList
+         else
+            local tStart
+            put item 1 of tRawRange into tstart
+            
+            local tFinish
+            put item 2 of tRawRange into tfinish
+            repeat with k = tstart to tfinish
+               put k & "," after tRangeList
+            end repeat
+         end if
+         set the itemDelimiter to comma
+      end repeat
+      if the last char of tRangeList is comma then
+         delete the last char of tRangeList
       end if
-      set the itemDelimiter to comma
-    end repeat
-    if the last char of tRangeList is comma then
+      put cr after tRangeList
+   end repeat
+   if the last char of tRangeList is cr then
       delete the last char of tRangeList
-    end if
-    put cr after tRangeList
-  end repeat
-  if the last char of tRangeList is cr then
-    delete the last char of tRangeList
-  end if
+   end if
    
-  repeat with i = 1 to the number of lines in tRangeList
-    if the number of items of line i of tRangeList > tMaxItems then
-      put the number of items of line i of tRangeList into tMaxItems
-    end if
-  end repeat
-   
-  repeat with i = 1 to tMaxItems
-    repeat with j = 1 to tViewerNumber
-      if the number of lines in tRangeList = 1 then
-        put item i of line 1 of tRangeList & ":" after tParseRangeList
-      else
-        if item i of line j of tRangeList is empty then
-          put "0:" after tParseRangeList
-        else
-          put item i of line j of tRangeList & ":" after tParseRangeList
-        end if
+   repeat with i = 1 to the number of lines in tRangeList
+      if the number of items of line i of tRangeList > tMaxItems then
+         put the number of items of line i of tRangeList into tMaxItems
       end if
-    end repeat
-    if the last char of tParseRangeList is ":" then
+   end repeat
+   
+   repeat with i = 1 to tMaxItems
+      repeat with j = 1 to tViewerNumber
+         if the number of lines in tRangeList = 1 then
+            put item i of line 1 of tRangeList & ":" after tParseRangeList
+         else
+            if item i of line j of tRangeList is empty then
+               put "0:" after tParseRangeList
+            else
+               put item i of line j of tRangeList & ":" after tParseRangeList
+            end if
+         end if
+      end repeat
+      if the last char of tParseRangeList is ":" then
+         delete the last char of tParseRangeList
+      end if
+      put "," after tParseRangeList
+   end repeat
+   if the last char of tParseRangeList is "," then
       delete the last char of tParseRangeList
-    end if
-    put "," after tParseRangeList
-  end repeat
-  if the last char of tParseRangeList is "," then
-    delete the last char of tParseRangeList
-  end if
-  return tParseRangeList
+   end if
+   return tParseRangeList
 end revReportParseRangeList
 
 on revMoveToCard pNumberList
-  --answer pNumberList
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
-      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-      repeat with i = 1 to tNumber
-        set the itemDelimiter to ":"
-        put item i of pNumberList into pNumber
-        put the long id of control i of this card of the topStack into tObject
-        if the cREVGeneral["viewerobject"] of tObject is not true then
-          next repeat
-        end if
-        put the cREVReport["maxcards"] of tObject into tMaxCard
-        if (pNumber <= tMaxCard) and (pNumber > 0) then
-          if not revIsPageLocked(tObject) then
-            put the cREVReport["currentcard"] of tObject into tOldNumber
-            set the cREVReport["currentcard"] of tObject to pNumber
-            --send "revChangePage tOldNumber,pNumber" to revSourceObject(the cREVReport["viewername"] of tObject,pNumber)
-            --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
-            revDoReportFormatting tObject
-            send "revChangePage tOldNumber,pNumber" to revSourceObject(the cREVReport["viewername"] of tObject,pNumber)
-          end if
-        else
-          set the text of tObject to empty
-        end if
-      end repeat
-    else
-      -- Do scrolling of field
-    end if
-  end if
+   --answer pNumberList
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
+         local tNumber
+         put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+         repeat with i = 1 to tNumber
+            set the itemDelimiter to ":"
+            local tNum
+            put item i of pNumberList into tNum
+            
+            local tObject
+            put the long id of control i of this card of the topStack into tObject
+            if the cREVGeneral["viewerobject"] of tObject is not true then
+               next repeat
+            end if
+            
+            local tMaxCard
+            put the cREVReport["maxcards"] of tObject into tMaxCard
+            if (tNum <= tMaxCard) and (tNum > 0) then
+               if not revIsPageLocked(tObject) then
+                  local tOldNumber
+                  put the cREVReport["currentcard"] of tObject into tOldNumber
+                  set the cREVReport["currentcard"] of tObject to tNum
+                  --send "revChangePage tOldNumber,pNumber" to revSourceObject(the cREVReport["viewername"] of tObject,pNumber)
+                  --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
+                  revDoReportFormatting tObject
+                  send "revChangePage tOldNumber,tNum" to revSourceObject(the cREVReport["viewername"] of tObject,tNum)
+               end if
+            else
+               set the text of tObject to empty
+            end if
+         end repeat
+      else
+         -- Do scrolling of field
+      end if
+   end if
 end revMoveToCard
 
 function revIsPageLocked tObject
-  if the cREVReport["pagelock"] of tObject is true then
-    return true
-  else
-    return false
-  end if
+   if the cREVReport["pagelock"] of tObject is true then
+      return true
+   else
+      return false
+   end if
 end revIsPageLocked
 
 on revSetPaperMargins
-  put the cREVReport["paperleftmargin"] of this card of the topStack into tleft
-  put the cREVReport["papertopmargin"] of this card of the topStack into ttop
-  put the cREVReport["paperrightmargin"] of this card of the topStack into tright
-  put the cREVReport["paperbottommargin"] of this card of the topStack into tbottom
-  put tleft & "," & ttop & "," & tright & "," & tbottom into tMargins
-  set the printMargins to tMargins
-  put the cREVReport["paperverticalmargin"] of this card of the topStack into tvertical
-  put the cREVReport["paperhorizontalmargin"] of this card of the topStack into thorizontal
-  put thorizontal & "," & tvertical into tGutter
-  set the printGutters to tGutter
+   local tLeft, tTop, tRight, tBottom
+   put the cREVReport["paperleftmargin"] of this card of the topStack into tleft
+   put the cREVReport["papertopmargin"] of this card of the topStack into ttop
+   put the cREVReport["paperrightmargin"] of this card of the topStack into tright
+   put the cREVReport["paperbottommargin"] of this card of the topStack into tbottom
+   
+   local tMargins
+   put tleft & "," & ttop & "," & tright & "," & tbottom into tMargins
+   set the printMargins to tMargins
+   
+   local tVertical
+   put the cREVReport["paperverticalmargin"] of this card of the topStack into tvertical
+   
+   local tHorizontal
+   put the cREVReport["paperhorizontalmargin"] of this card of the topStack into thorizontal
+   
+   local tGutter
+   put thorizontal & "," & tvertical into tGutter
+   set the printGutters to tGutter
 end revSetPaperMargins
 
 on revPrintReport
-  revUpdateViewerObjectList
-  if (the cREVGeneral["report"] of this card of the topStack is true) and (the cREVReport["viewerobjects"] of this card of the topStack > 0) then
-    revSetPaperMargins
-    put the cREVReport["printrange"] of this card of the topStack into tPrintRange
-    put revCalculateNumberPrintCards() into tCards
-    set the formatForPrinting of the topStack to true
-    switch tPrintRange
-    case "All Cards"
-      revPrintAllCards tCards
-      break
-    case "Marked Cards"
-      revPrintMarkedCards tCards
-      break
-    case "Unmarked Cards"
-      revPrintUnmarkedCards tCards
-      break
-    case "A Specific Range of Cards"
-      revPrintRangeCards tCards
-      break
-    case "Cards Fitting an Expression"
-      revPrintExpressionCards tCards
-      break
-    end switch
-  end if
+   revUpdateViewerObjectList
+   if (the cREVGeneral["report"] of this card of the topStack is true) and (the cREVReport["viewerobjects"] of this card of the topStack > 0) then
+      revSetPaperMargins
+      
+      local tPrintRange
+      put the cREVReport["printrange"] of this card of the topStack into tPrintRange
+      
+      local tCards
+      put revCalculateNumberPrintCards() into tCards
+      set the formatForPrinting of the topStack to true
+      switch tPrintRange
+         case "All Cards"
+            revPrintAllCards tCards
+            break
+         case "Marked Cards"
+            revPrintMarkedCards tCards
+            break
+         case "Unmarked Cards"
+            revPrintUnmarkedCards tCards
+            break
+         case "A Specific Range of Cards"
+            revPrintRangeCards tCards
+            break
+         case "Cards Fitting an Expression"
+            revPrintExpressionCards tCards
+            break
+      end switch
+   end if
 end revPrintReport
 
 on revMoveFirstCard
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
-      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-      repeat with i = 1 to tNumber
-        put the long id of control i of the topStack into tObject
-        if the cREVGeneral["viewerobject"] of tObject is not true then
-          next repeat
-        end if
-        if not revIsPageLocked(tObject) then
-          if the cREVReport["currentcard"] of tObject is not empty then
-            put the cREVReport["currentcard"] of tObject into tOldNumber
-            set the cREVReport["currentcard"] of tObject to 1
-            --send "revChangePage tOldNumber,1" to revSourceObject(the cREVReport["viewername"] of tObject,1)
-            --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
-            revDoReportFormatting tObject
-            send "revChangePage tOldNumber,1" to revSourceObject(the cREVReport["viewername"] of tObject,1)
-          end if
-        end if
-      end repeat
-    else
-      -- Do scrolling of field
-    end if
-  end if
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
+         
+         local tNumber
+         put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+         repeat with i = 1 to tNumber
+            local tObject
+            put the long id of control i of the topStack into tObject
+            if the cREVGeneral["viewerobject"] of tObject is not true then
+               next repeat
+            end if
+            if not revIsPageLocked(tObject) then
+               if the cREVReport["currentcard"] of tObject is not empty then
+                  local tOldNumber
+                  put the cREVReport["currentcard"] of tObject into tOldNumber
+                  set the cREVReport["currentcard"] of tObject to 1
+                  --send "revChangePage tOldNumber,1" to revSourceObject(the cREVReport["viewername"] of tObject,1)
+                  --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
+                  revDoReportFormatting tObject
+                  send "revChangePage tOldNumber,1" to revSourceObject(the cREVReport["viewername"] of tObject,1)
+               end if
+            end if
+         end repeat
+      else
+         -- Do scrolling of field
+      end if
+   end if
 end revMoveFirstCard
 
 on revMoveNextCard
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
-      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-      repeat with i = 1 to tNumber
-        put the long id of control i of the topStack into tObject
-        if the cREVGeneral["viewerobject"] of tObject is not true then
-          next repeat
-        end if
-        put the cREVReport["currentcard"] of tObject into tCard
-        put the cREVReport["maxcards"] of tObject into tMaxCard
-        if tCard < tMaxCard then
-          if not revIsPageLocked(tObject) then
-            put tCard + 1 into tCard
-            put the cREVReport["currentcard"] of tObject into tOldNumber
-            set the cREVReport["currentcard"] of tObject to tCard
-            --send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
-            --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
-            revDoReportFormatting tObject
-            send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
-          end if
-        end if
-      end repeat
-    else
-      -- Do scrolling of field
-    end if
-  end if
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
+         local tNumber
+         put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+         repeat with i = 1 to tNumber
+            local tObject
+            put the long id of control i of the topStack into tObject
+            if the cREVGeneral["viewerobject"] of tObject is not true then
+               next repeat
+            end if
+            
+            local tCard
+            put the cREVReport["currentcard"] of tObject into tCard
+            
+            local tMaxCard
+            put the cREVReport["maxcards"] of tObject into tMaxCard
+            if tCard < tMaxCard then
+               if not revIsPageLocked(tObject) then
+                  put tCard + 1 into tCard
+                  
+                  local tOldNumber
+                  put the cREVReport["currentcard"] of tObject into tOldNumber
+                  set the cREVReport["currentcard"] of tObject to tCard
+                  --send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
+                  --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
+                  revDoReportFormatting tObject
+                  send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
+               end if
+            end if
+         end repeat
+      else
+         -- Do scrolling of field
+      end if
+   end if
 end revMoveNextCard
 
 on revMovePreviousCard
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
-      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-      repeat with i = 1 to tNumber
-        put the long id of control i of the topStack into tObject
-        if the cREVGeneral["viewerobject"] of tObject is not true then
-          next repeat
-        end if
-        put the cREVReport["currentcard"] of tObject into tCard
-        put the cREVReport["maxcards"] of tObject into tMaxCard
-        if tCard > 1 then
-          if not revIsPageLocked(tObject) then
-            put tCard - 1 into tCard
-            put the cREVReport["currentcard"] of tObject into tOldNumber
-            set the cREVReport["currentcard"] of tObject to tCard
-            --send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
-            --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
-            revDoReportFormatting tObject
-            send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
-          end if
-        end if
-      end repeat
-    else
-      --Do scrolling
-    end if
-  end if
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
+         local tNumber
+         put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+         repeat with i = 1 to tNumber
+            local tObject
+            put the long id of control i of the topStack into tObject
+            if the cREVGeneral["viewerobject"] of tObject is not true then
+               next repeat
+            end if
+            
+            local tCard
+            put the cREVReport["currentcard"] of tObject into tCard
+            
+            local tMaxCard
+            put the cREVReport["maxcards"] of tObject into tMaxCard
+            if tCard > 1 then
+               if not revIsPageLocked(tObject) then
+                  put tCard - 1 into tCard
+                  local tOldNumber
+                  put the cREVReport["currentcard"] of tObject into tOldNumber
+                  set the cREVReport["currentcard"] of tObject to tCard
+                  --send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
+                  --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
+                  revDoReportFormatting tObject
+                  send "revChangePage tOldNumber,tCard" to revSourceObject(the cREVReport["viewername"] of tObject,tCard)
+               end if
+            end if
+         end repeat
+      else
+         --Do scrolling
+      end if
+   end if
 end revMovePreviousCard
 
 on revMoveLastCard
-  if the cREVGeneral["report"] of this card of the topStack is true then
-    if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
-      put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
-      repeat with i = 1 to tNumber
-        put the long id of control i of the topStack into tObject
-        if the cREVGeneral["viewerobject"] of tObject is not true then
-          next repeat
-        end if
-        if not revIsPageLocked(tObject) then
-          if the cREVReport["currentcard"] of tObject is not empty then
-            put the cREVReport["maxcards"] of tObject into tMaxCard
-            put the cREVReport["currentcard"] of tObject into tOldNumber
-            set the cREVReport["currentcard"] of tObject to tMaxCard
-            --send "revChangePage tOldNumber,tMaxCard" to revSourceObject(the cREVReport["viewername"] of tObject,tMaxCard)
-            --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
-            revDoReportFormatting tObject
-            send "revChangePage tOldNumber,tMaxCard" to revSourceObject(the cREVReport["viewername"] of tObject,tMaxCard)
-          end if
-        end if
-      end repeat
-    else
-      --Do scrolling
-    end if
-  end if
+   if the cREVGeneral["report"] of this card of the topStack is true then
+      if (the cREVReport["virtualcard"] of this card of the topStack is false) or (the cREVReport["virtualcard"] of this card of the topStack is empty) then
+         local tNumber
+         put the cREVReport["viewerobjects"] of this card of the topStack into tNumber
+         repeat with i = 1 to tNumber
+            local tObject
+            put the long id of control i of the topStack into tObject
+            if the cREVGeneral["viewerobject"] of tObject is not true then
+               next repeat
+            end if
+            if not revIsPageLocked(tObject) then
+               if the cREVReport["currentcard"] of tObject is not empty then
+                  local tMaxCard
+                  put the cREVReport["maxcards"] of tObject into tMaxCard
+                  
+                  local tOldNumber
+                  put the cREVReport["currentcard"] of tObject into tOldNumber
+                  set the cREVReport["currentcard"] of tObject to tMaxCard
+                  --send "revChangePage tOldNumber,tMaxCard" to revSourceObject(the cREVReport["viewername"] of tObject,tMaxCard)
+                  --set the text of tObject to the text of control id (the cREVReport["sourceobjectshortid"] of tObject) of card (the cREVReport["currentcard"] of tObject) of stack (the cREVReport["sourceobjectstackname"] of tObject)
+                  revDoReportFormatting tObject
+                  send "revChangePage tOldNumber,tMaxCard" to revSourceObject(the cREVReport["viewername"] of tObject,tMaxCard)
+               end if
+            end if
+         end repeat
+      else
+         --Do scrolling
+      end if
+   end if
 end revMoveLastCard
 
 on revDoReportFormatting pObject
-  put the cREVReport["formatlist"] of pObject into tFormatList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  set the cREVReport["currentview"] of pObject to the text of control id tShortID of card tCard of stack tStackName
-  set the cREVReport["originalview"] of pObject to the cREVReport["currentview"] of pObject
-  if tFormatList is not empty then
-    set the itemDelimiter to tab
-    repeat with i = 1 to the number of lines in tFormatList
-      if line i of tFormatList is not empty then
-        put item 1 of line i of tFormatList into tCellList
-        put item 2 of line i of tFormatList into tTypeList
-        set the itemDelimiter to ":"
-        put item 1 of tTypeList into tType
-        put item 2 of tTypeList into tPrefixList
-        switch tType
-        case "Date"
-          revReportDateFormat pObject,tCellList,tPrefixList
-          break
-        case "Prefix"
-          revReportPrefixFormat pObject,tCellList,tPrefixList
-          break
-        case "Suffix"
-          revReportSuffixFormat pObject,tCellList,tPrefixList
-          break
-          --        case "Generic"
-          --          revGenericFormat pObject,tCellList,tPrefixList
-          --          break
-        case "Scientific"
-          revReportScientificFormat pObject,tCellList,tPrefixList
-          break
-        case "Percentage"
-          revReportPercentageFormat pObject,tCellList,tPrefixList
-          break
-        case "Decimal"
-          revReportDecimalFormat pObject,tCellList,tPrefixList
-          break
-        end switch
-      end if
+   local tFormatList
+   put the cREVReport["formatlist"] of pObject into tFormatList
+   
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   set the cREVReport["currentview"] of pObject to the text of control id tShortID of card tCard of stack tStackName
+   set the cREVReport["originalview"] of pObject to the cREVReport["currentview"] of pObject
+   if tFormatList is not empty then
       set the itemDelimiter to tab
-      set the cREVReport["currentview"] of pObject to the cREVReport["formattedview"] of pObject
-    end repeat
-  else
-    set the cREVReport["formattedview"] of pObject to the cREVReport["currentview"] of pObject
-  end if
-  set the text of pObject to the cREVReport["formattedview"] of pObject
+      repeat with i = 1 to the number of lines in tFormatList
+         if line i of tFormatList is not empty then
+            local tCellList
+            put item 1 of line i of tFormatList into tCellList
+            
+            local tTypeList
+            put item 2 of line i of tFormatList into tTypeList
+            set the itemDelimiter to ":"
+            
+            local tType
+            put item 1 of tTypeList into tType
+            
+            local tPrefixList
+            put item 2 of tTypeList into tPrefixList
+            switch tType
+               case "Date"
+                  revReportDateFormat pObject,tCellList,tPrefixList
+                  break
+               case "Prefix"
+                  revReportPrefixFormat pObject,tCellList,tPrefixList
+                  break
+               case "Suffix"
+                  revReportSuffixFormat pObject,tCellList,tPrefixList
+                  break
+                  --        case "Generic"
+                  --          revGenericFormat pObject,tCellList,tPrefixList
+                  --          break
+               case "Scientific"
+                  revReportScientificFormat pObject,tCellList,tPrefixList
+                  break
+               case "Percentage"
+                  revReportPercentageFormat pObject,tCellList,tPrefixList
+                  break
+               case "Decimal"
+                  revReportDecimalFormat pObject,tCellList,tPrefixList
+                  break
+            end switch
+         end if
+         set the itemDelimiter to tab
+         set the cREVReport["currentview"] of pObject to the cREVReport["formattedview"] of pObject
+      end repeat
+   else
+      set the cREVReport["formattedview"] of pObject to the cREVReport["currentview"] of pObject
+   end if
+   set the text of pObject to the cREVReport["formattedview"] of pObject
 end revDoReportFormatting
 
 on revReportDecimalFormat pObject,pCellList,pPrefixList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  put the cREVReport["currentview"] of pObject into tView
-  put tView into tFormattedView
-  if pCellList is not empty then
-    switch pCellList
-    case "To items"
-      repeat with i = 1 to the number of items in tView
-        put item i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace item i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To words"
-      repeat with i = 1 to the number of words in tView
-        put word i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace word i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To lines"
-      repeat with i = 1 to the number of lines in tView
-        put line i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace line i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To whole label"
-      put tView into tValue
-      if (tValue is not empty) and (tValue is a number) then
-        put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
-        put tFormattedValue into tFormattedView
-      end if
-      break
-    end switch
-  end if
-  set the cREVReport["formattedview"] of pObject to tFormattedView
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   
+   local tView
+   put the cREVReport["currentview"] of pObject into tView
+   
+   local tFormattedView
+   put tView into tFormattedView
+   if pCellList is not empty then
+      switch pCellList
+         case "To items"
+            repeat with i = 1 to the number of items in tView
+               local tValue
+               put item i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  local tFormattedValue
+                  put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace item i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To words"
+            repeat with i = 1 to the number of words in tView
+               put word i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace word i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To lines"
+            repeat with i = 1 to the number of lines in tView
+               put line i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace line i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To whole label"
+            put tView into tValue
+            if (tValue is not empty) and (tValue is a number) then
+               put revDecimalDisplay(pPrefixList,tValue,1) into tFormattedValue
+               put tFormattedValue into tFormattedView
+            end if
+            break
+      end switch
+   end if
+   set the cREVReport["formattedview"] of pObject to tFormattedView
 end revReportDecimalFormat
 
 on revReportScientificFormat pObject,pCellList,pPrefixList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  put the cREVReport["currentview"] of pObject into tView
-  put tView into tFormattedView
-  if pCellList is not empty then
-    switch pCellList
-    case "To items"
-      repeat with i = 1 to the number of items in tView
-        put item i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace item i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To words"
-      repeat with i = 1 to the number of words in tView
-        put word i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace word i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To lines"
-      repeat with i = 1 to the number of lines in tView
-        put line i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace line i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To whole label"
-      put tView into tValue
-      if (tValue is not empty) and (tValue is a number) then
-        put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
-        put tFormattedValue into tFormattedView
-      end if
-      break
-    end switch
-  end if
-  set the cREVReport["formattedview"] of pObject to tFormattedView
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   
+   local tView
+   put the cREVReport["currentview"] of pObject into tView
+   
+   local tFormattedView
+   put tView into tFormattedView
+   if pCellList is not empty then
+      switch pCellList
+         case "To items"
+            repeat with i = 1 to the number of items in tView
+               local tValue
+               put item i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  local tFormattedValue
+                  put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace item i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To words"
+            repeat with i = 1 to the number of words in tView
+               put word i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace word i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To lines"
+            repeat with i = 1 to the number of lines in tView
+               put line i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace line i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To whole label"
+            put tView into tValue
+            if (tValue is not empty) and (tValue is a number) then
+               put revScientificDisplay(pPrefixList,tValue,1) into tFormattedValue
+               put tFormattedValue into tFormattedView
+            end if
+            break
+      end switch
+   end if
+   set the cREVReport["formattedview"] of pObject to tFormattedView
 end revReportScientificFormat
 
 on revReportDateFormat pObject,pCellList,pPrefixList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  put the cREVReport["currentview"] of pObject into tView
-  put tView into tFormattedView
-  if pCellList is not empty then
-    switch pCellList
-    case "To items"
-      repeat with i = 1 to the number of items in tView
-        put item i of tView into tValue
-        if (tValue is not empty) and (tValue is a date) then
-          put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace item i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To words"
-      repeat with i = 1 to the number of words in tView
-        put word i of tView into tValue
-        if (tValue is not empty) and (tValue is a date) then
-          put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace word i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To lines"
-      repeat with i = 1 to the number of lines in tView
-        put line i of tView into tValue
-        if (tValue is not empty) and (tValue is a date) then
-          put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace line i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To whole label"
-      put tView into tValue
-      if (tValue is not empty) and (tValue is a date) then
-        put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
-        put tFormattedValue into tFormattedView
-      end if
-      break
-    end switch
-  end if
-  set the cREVReport["formattedview"] of pObject to tFormattedView
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   
+   local tView
+   put the cREVReport["currentview"] of pObject into tView
+   
+   local tFormattedView, tFormattedValue
+   put tView into tFormattedView
+   if pCellList is not empty then
+      switch pCellList
+         case "To items"
+            repeat with i = 1 to the number of items in tView
+               local tValue
+               put item i of tView into tValue
+               if (tValue is not empty) and (tValue is a date) then
+                  put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace item i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To words"
+            repeat with i = 1 to the number of words in tView
+               put word i of tView into tValue
+               if (tValue is not empty) and (tValue is a date) then
+                  put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace word i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To lines"
+            repeat with i = 1 to the number of lines in tView
+               put line i of tView into tValue
+               if (tValue is not empty) and (tValue is a date) then
+                  put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace line i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To whole label"
+            put tView into tValue
+            if (tValue is not empty) and (tValue is a date) then
+               put revDateDisplay(pPrefixList,tValue,1) into tFormattedValue
+               put tFormattedValue into tFormattedView
+            end if
+            break
+      end switch
+   end if
+   set the cREVReport["formattedview"] of pObject to tFormattedView
 end revReportDateFormat
 
 on revReportPercentageFormat pObject,pCellList,pPrefixList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  put the cREVReport["currentview"] of pObject into tView
-  put tView into tFormattedView
-  if pCellList is not empty then
-    switch pCellList
-    case "To items"
-      repeat with i = 1 to the number of items in tView
-        put item i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace item i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To words"
-      repeat with i = 1 to the number of words in tView
-        put word i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace word i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To lines"
-      repeat with i = 1 to the number of lines in tView
-        put line i of tView into tValue
-        if (tValue is not empty) and (tValue is a number) then
-          put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace line i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To whole label"
-      put tView into tValue
-      if (tValue is not empty) and (tValue is a number) then
-        put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
-        put tFormattedValue into tFormattedView
-      end if
-      break
-    end switch
-  end if
-  set the cREVReport["formattedview"] of pObject to tFormattedView
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   
+   local tView
+   put the cREVReport["currentview"] of pObject into tView
+   
+   local tFormattedView, tFormattedValue, tValue
+   put tView into tFormattedView
+   if pCellList is not empty then
+      switch pCellList
+         case "To items"
+            repeat with i = 1 to the number of items in tView
+               put item i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace item i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To words"
+            repeat with i = 1 to the number of words in tView
+               put word i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace word i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To lines"
+            repeat with i = 1 to the number of lines in tView
+               put line i of tView into tValue
+               if (tValue is not empty) and (tValue is a number) then
+                  put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace line i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To whole label"
+            put tView into tValue
+            if (tValue is not empty) and (tValue is a number) then
+               put revPercentageDisplay(pPrefixList,tValue,1) into tFormattedValue
+               put tFormattedValue into tFormattedView
+            end if
+            break
+      end switch
+   end if
+   set the cREVReport["formattedview"] of pObject to tFormattedView
 end revReportPercentageFormat
 
 on revReportPrefixFormat pObject,pCellList,pPrefixList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  put the cREVReport["currentview"] of pObject into tView
-  put tView into tFormattedView
-  if pCellList is not empty then
-    switch pCellList
-    case "To items"
-      repeat with i = 1 to the number of items in tView
-        put item i of tView into tValue
-        if (tValue is not empty) then
-          put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace item i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To words"
-      repeat with i = 1 to the number of words in tView
-        put word i of tView into tValue
-        if (tValue is not empty) then
-          put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace word i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To lines"
-      repeat with i = 1 to the number of lines in tView
-        put line i of tView into tValue
-        if (tValue is not empty) then
-          put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace line i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To whole label"
-      put tView into tValue
-      if (tValue is not empty) then
-        put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
-        put tFormattedValue into tFormattedView
-      end if
-      break
-    end switch
-  end if
-  set the cREVReport["formattedview"] of pObject to tFormattedView
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   
+   local tView
+   put the cREVReport["currentview"] of pObject into tView
+   
+   local tFormattedView, tFormattedValue, tValue
+   put tView into tFormattedView
+   if pCellList is not empty then
+      switch pCellList
+         case "To items"
+            repeat with i = 1 to the number of items in tView
+               put item i of tView into tValue
+               if (tValue is not empty) then
+                  put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace item i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To words"
+            repeat with i = 1 to the number of words in tView
+               put word i of tView into tValue
+               if (tValue is not empty) then
+                  put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace word i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To lines"
+            repeat with i = 1 to the number of lines in tView
+               put line i of tView into tValue
+               if (tValue is not empty) then
+                  put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace line i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To whole label"
+            put tView into tValue
+            if (tValue is not empty) then
+               put revPrefixDisplay(pPrefixList,tValue,1) into tFormattedValue
+               put tFormattedValue into tFormattedView
+            end if
+            break
+      end switch
+   end if
+   set the cREVReport["formattedview"] of pObject to tFormattedView
 end revReportPrefixFormat
 
 on revReportSuffixFormat pObject,pCellList,pPrefixList
-  put the cREVReport["sourceobjectshortid"] of pObject into tShortID
-  put the cREVReport["currentcard"] of pObject into tCard
-  put the cREVReport["sourceobjectstackname"] of pObject into tStackName
-  put the cREVReport["currentview"] of pObject into tView
-  put tView into tFormattedView
-  if pCellList is not empty then
-    switch pCellList
-    case "To items"
-      repeat with i = 1 to the number of items in tView
-        put item i of tView into tValue
-        if (tValue is not empty) then
-          put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace item i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To words"
-      repeat with i = 1 to the number of words in tView
-        put word i of tView into tValue
-        if (tValue is not empty) then
-          put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace word i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To lines"
-      repeat with i = 1 to the number of lines in tView
-        put line i of tView into tValue
-        if (tValue is not empty) then
-          put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
-          replace line i of tFormattedView with tFormattedValue in tFormattedView
-        end if
-      end repeat
-      break
-    case "To whole label"
-      put tView into tValue
-      if (tValue is not empty) then
-        put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
-        put tFormattedValue into tFormattedView
-      end if
-      break
-    end switch
-  end if
-  set the cREVReport["formattedview"] of pObject to tFormattedView
+   local tShortID
+   put the cREVReport["sourceobjectshortid"] of pObject into tShortID
+   
+   local tCard
+   put the cREVReport["currentcard"] of pObject into tCard
+   
+   local tStackName
+   put the cREVReport["sourceobjectstackname"] of pObject into tStackName
+   
+   local tView
+   put the cREVReport["currentview"] of pObject into tView
+   
+   local tFormattedView, tFormattedValue, tValue
+   put tView into tFormattedView
+   if pCellList is not empty then
+      switch pCellList
+         case "To items"
+            repeat with i = 1 to the number of items in tView
+               put item i of tView into tValue
+               if (tValue is not empty) then
+                  put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace item i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To words"
+            repeat with i = 1 to the number of words in tView
+               put word i of tView into tValue
+               if (tValue is not empty) then
+                  put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace word i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To lines"
+            repeat with i = 1 to the number of lines in tView
+               put line i of tView into tValue
+               if (tValue is not empty) then
+                  put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
+                  replace line i of tFormattedView with tFormattedValue in tFormattedView
+               end if
+            end repeat
+            break
+         case "To whole label"
+            put tView into tValue
+            if (tValue is not empty) then
+               put revSuffixDisplay(pPrefixList,tValue,1) into tFormattedValue
+               put tFormattedValue into tFormattedView
+            end if
+            break
+      end switch
+   end if
+   set the cREVReport["formattedview"] of pObject to tFormattedView
 end revReportSuffixFormat
 
 
 function revPixelToPt pPixel
-  put pPixel * (105/300) * (2.8346457) into tPt
-  return tPt
+   local tPt
+   put pPixel * (105/300) * (2.8346457) into tPt
+   return tPt
 end revPixelToPt
 
 function revPtToPixel pPt
-  put pPt * (300/(105 * 2.8346457)) into tPixel
-  return tPixel
+   local tPixel
+   put pPt * (300/(105 * 2.8346457)) into tPixel
+   return tPixel
 end revPtToPixel
 
 function revCalculateNumberPages
-  put revCalculateEffectivePrintArea() into tPaperSize
-  put item 1 of tPaperSize into tPaperWidth
-  put item 2 of tPaperSize into tPaperHeight
-  put revPtToPixel(tPaperWidth) into tPaperWidthPixel
-  put revPtToPixel(tPaperHeight) into tPaperHeightPixel
-  put the width of this card of the topStack into tStackWidthPixel
-  put the height of this card of the topStack into tStackHeightPixel
-  put revPixelToPt(tStackWidthPixel) into tStackWidth
-  put revPixelToPt(tStackHeightPixel) into tStackHeight
-  
-  put tStackWidth div tPaperWidth into tHorizontalPages
-  if tStackWidth mod tPaperWidth is not 0 then
-    put tHorizontalPages + 1 into tHorizontalPages
-  end if
-  put tStackHeight div tPaperHeight into tVerticalPages
-  if tStackHeight mod tPaperHeight is not 0 then
-    put tVerticalPages + 1 into tVerticalPages
-  end if
-  put empty into tRectList
-  repeat with i = 1 to tVerticalPages
-    repeat with j = 1 to tHorizontalPages
-      put (j-1) * tPaperWidthPixel into x1
-      put (i-1) * tPaperHeightPixel into y1
-      put j * tPaperWidthPixel into x2
-      put i * tPaperHeightPixel into y2
-      if x2 > tStackWidth then
-        put tStackWidth into x2
-      end if
-      if y2 > tStackHeight then
-        put tStackHeight into y2
-      end if
-      put x1 & "," & y1 & " " & x2 & "," & y2 & cr after tRectList
-    end repeat
-  end repeat
-  if the last char of tRectList is cr then
-    delete the last char of tRectList
-  end if
-  return tRectList
+   local tPaperSize
+   put revCalculateEffectivePrintArea() into tPaperSize
+   
+   local tPaperWidth, tPaperHeight
+   put item 1 of tPaperSize into tPaperWidth
+   put item 2 of tPaperSize into tPaperHeight
+   
+   local tPaperWidthPixel, tPaperHeightPixel
+   put revPtToPixel(tPaperWidth) into tPaperWidthPixel
+   put revPtToPixel(tPaperHeight) into tPaperHeightPixel
+   
+   local tStackWidthPixel, tStackHeightPixel
+   put the width of this card of the topStack into tStackWidthPixel
+   put the height of this card of the topStack into tStackHeightPixel
+   
+   local tStackWidth, tStackHeight
+   put revPixelToPt(tStackWidthPixel) into tStackWidth
+   put revPixelToPt(tStackHeightPixel) into tStackHeight
+   
+   local tHorizontalPages
+   put tStackWidth div tPaperWidth into tHorizontalPages
+   if tStackWidth mod tPaperWidth is not 0 then
+      put tHorizontalPages + 1 into tHorizontalPages
+   end if
+   
+   local tVerticalPages
+   put tStackHeight div tPaperHeight into tVerticalPages
+   if tStackHeight mod tPaperHeight is not 0 then
+      put tVerticalPages + 1 into tVerticalPages
+   end if
+   
+   local tRectList, x1, y1, x2, y2
+   put empty into tRectList
+   repeat with i = 1 to tVerticalPages
+      repeat with j = 1 to tHorizontalPages
+         put (j-1) * tPaperWidthPixel into x1
+         put (i-1) * tPaperHeightPixel into y1
+         put j * tPaperWidthPixel into x2
+         put i * tPaperHeightPixel into y2
+         if x2 > tStackWidth then
+            put tStackWidth into x2
+         end if
+         if y2 > tStackHeight then
+            put tStackHeight into y2
+         end if
+         put x1 & "," & y1 & " " & x2 & "," & y2 & cr after tRectList
+      end repeat
+   end repeat
+   if the last char of tRectList is cr then
+      delete the last char of tRectList
+   end if
+   return tRectList
 end revCalculateNumberPages
 
 function revCalculateNumberPrintCards
-  put item 1 of the printGutters into tRowGutter
-  put item 2 of the printGutters into tColumnGutter
-  put revCalculateEffectivePrintArea() into tPaperSize
-  put item 1 of tPaperSize into tPaperWidth
-  put item 2 of tPaperSize into tPaperHeight
-  put the width of this card of the topStack into tStackWidthPixel
-  put the height of this card of the topStack into tStackHeightPixel
-  put revPixelToPt(tStackWidthPixel) into tStackWidth
-  put revPixelToPt(tStackHeightPixel) into tStackHeight
-  
-  put 0 into tColumnPt
-  put 0 into tRowPt
-  put 1 into tColumnCount
-  put 1 into tRowCount
-  put tStackWidth into tColumnPt
-  repeat until tColumnPt > tPaperWidth
-    put tColumnGutter + tStackWidth + tColumnPt into tColumnPt
-    put tColumnCount + 1 into tColumnCount
-  end repeat
-  put tStackHeight into tRowPt
-  repeat until tRowPt > tPaperHeight
-    put tRowGutter + tStackHeight + tRowPt into tRowPt
-    put tRowCount + 1 into tRowCount
-  end repeat
-  if tRowCount > 1 then
-    put tRowCount - 1 into tRowCount
-  end if
-  if tColumnCount > 1 then
-    put tColumnCount - 1 into tColumnCount
-  end if
-  put tRowCount * tColumnCount into tResult
-  return tResult
+   local tRowGutter, tColumnGutter
+   put item 1 of the printGutters into tRowGutter
+   put item 2 of the printGutters into tColumnGutter
+   
+   local tPaperSize, tPaperWidth, tPaperHeight
+   put revCalculateEffectivePrintArea() into tPaperSize
+   put item 1 of tPaperSize into tPaperWidth
+   put item 2 of tPaperSize into tPaperHeight
+   
+   local tStackWidthPixel, tStackHeightPixel
+   put the width of this card of the topStack into tStackWidthPixel
+   put the height of this card of the topStack into tStackHeightPixel
+   
+   local tStackWidth, tStackHeight
+   put revPixelToPt(tStackWidthPixel) into tStackWidth
+   put revPixelToPt(tStackHeightPixel) into tStackHeight
+   
+   local tColumnPt, tRowPt, tColumnCount, tRowCount
+   put 0 into tColumnPt
+   put 0 into tRowPt
+   put 1 into tColumnCount
+   put 1 into tRowCount
+   put tStackWidth into tColumnPt
+   repeat until tColumnPt > tPaperWidth
+      put tColumnGutter + tStackWidth + tColumnPt into tColumnPt
+      put tColumnCount + 1 into tColumnCount
+   end repeat
+   put tStackHeight into tRowPt
+   repeat until tRowPt > tPaperHeight
+      put tRowGutter + tStackHeight + tRowPt into tRowPt
+      put tRowCount + 1 into tRowCount
+   end repeat
+   if tRowCount > 1 then
+      put tRowCount - 1 into tRowCount
+   end if
+   if tColumnCount > 1 then
+      put tColumnCount - 1 into tColumnCount
+   end if
+   
+   local tResult
+   put tRowCount * tColumnCount into tResult
+   return tResult
 end revCalculateNumberPrintCards
 
 function revCalculateEffectivePrintArea
-  put item 1 of the printMargins into tLeft
-  put item 2 of the printMargins into tTop
-  put item 3 of the printMargins into tRight
-  put item 4 of the printMargins into tBottom
-  put item 1 of the printPaperSize into tWidth
-  put item 2 of the printPaperSize into tHeight
-  put 0 into tHeaderHeight
-  put 0 into tFooterHeight
-  put the cREVReport["header"] of this card of the topStack into tHeader
-  put the cREVReport["footer"] of this card of the topStack into tFooter
-  if (tHeader is not empty) and (there is a stack tHeader) then
-    put the height of stack tHeader into tHeaderHeight
-  end if
-  if (tFooter is not empty) and (there is a stack tFooter) then
-    put the height of stack tFooter into tFooterHeight
-  end if
-
-  put tHeight - tTop - tBottom - tHeaderHeight - tFooterHeight into tEffectiveHeight
-  put tWidth - tLeft - tRight into tEffectiveWidth
-  put tEffectiveWidth & "," & tEffectiveHeight into tResult
-  return tResult
+   local tLeft, tTop, tRight, tBottom, tWidth, tHeight
+   put item 1 of the printMargins into tLeft
+   put item 2 of the printMargins into tTop
+   put item 3 of the printMargins into tRight
+   put item 4 of the printMargins into tBottom
+   put item 1 of the printPaperSize into tWidth
+   put item 2 of the printPaperSize into tHeight
+   
+   local tHeaderHeight, tFooterHeight
+   put 0 into tHeaderHeight
+   put 0 into tFooterHeight
+   
+   local tHeader, tFooter
+   put the cREVReport["header"] of this card of the topStack into tHeader
+   put the cREVReport["footer"] of this card of the topStack into tFooter
+   if (tHeader is not empty) and (there is a stack tHeader) then
+      put the height of stack tHeader into tHeaderHeight
+   end if
+   if (tFooter is not empty) and (there is a stack tFooter) then
+      put the height of stack tFooter into tFooterHeight
+   end if
+   
+   local tEffectiveHeight, tEffectiveWidth, tResult
+   put tHeight - tTop - tBottom - tHeaderHeight - tFooterHeight into tEffectiveHeight
+   put tWidth - tLeft - tRight into tEffectiveWidth
+   put tEffectiveWidth & "," & tEffectiveHeight into tResult
+   return tResult
 end revCalculateEffectivePrintArea
 
 
 on revMenuNavigation pCardNumber
-  put revReportParseRangeList(pCardNumber) into tCard
-  revMoveToCard tCard
+   local tCard
+   put revReportParseRangeList(pCardNumber) into tCard
+   revMoveToCard tCard
 end revMenuNavigation
 
 on revInitialReportUpdate
-  put item 1 of the printMargins into tLeft
-  put item 2 of the printMargins into tTop
-  put item 3 of the printMargins into tRight
-  put item 4 of the printMargins into tBottom
-  put item 1 of the printGutters into tVertical
-  put item 2 of the printGutters into tHorizontal
-  
-  if the cREVReport["papertopmargin"] of this card of the topStack is empty then
-    set the cREVReport["papertopmargin"] of this card of the topStack to tTop
-  end if
-  if the cREVReport["paperbottommargin"] of this card of the topStack is empty then
-    set the cREVReport["paperbottommargin"] of this card of the topStack to tBottom
-  end if
-  if the cREVReport["paperrightmargin"] of this card of the topStack is empty then
-    set the cREVReport["paperrightmargin"] of this card of the topStack to tRight
-  end if
-  if the cREVReport["paperleftmargin"] of this card of the topStack is empty then
-    set the cREVReport["paperleftmargin"] of this card of the topStack to tLeft
-  end if
-  if the cREVReport["paperhorizontalmargin"] of this card of the topStack is empty then
-    set the cREVReport["paperhorizontalmargin"] of this card of the topStack to tHorizontal
-  end if
-  if the cREVReport["paperverticalmargin"] of this card of the topStack is empty then
-    set the cREVReport["paperverticalmargin"] of this card of the topStack to tVertical
-  end if
-  if the cREVReport["printrange"] of this card of the topStack is empty then
-    set the cREVReport["printrange"] of this card of the topStack to "All Cards"
-  end if
-  
-  if the cREVReport["onetoone"] of this card of the topStack is empty then
-    set the cREVReport["onetoone"] of this card of the topStack to true
-  end if
-  revUpdateViewerObjectList
+   local tLeft, tTop, tRight, tBottom
+   put item 1 of the printMargins into tLeft
+   put item 2 of the printMargins into tTop
+   put item 3 of the printMargins into tRight
+   put item 4 of the printMargins into tBottom
+   
+   local tVertical, tHorizontal
+   put item 1 of the printGutters into tVertical
+   put item 2 of the printGutters into tHorizontal
+   
+   if the cREVReport["papertopmargin"] of this card of the topStack is empty then
+      set the cREVReport["papertopmargin"] of this card of the topStack to tTop
+   end if
+   if the cREVReport["paperbottommargin"] of this card of the topStack is empty then
+      set the cREVReport["paperbottommargin"] of this card of the topStack to tBottom
+   end if
+   if the cREVReport["paperrightmargin"] of this card of the topStack is empty then
+      set the cREVReport["paperrightmargin"] of this card of the topStack to tRight
+   end if
+   if the cREVReport["paperleftmargin"] of this card of the topStack is empty then
+      set the cREVReport["paperleftmargin"] of this card of the topStack to tLeft
+   end if
+   if the cREVReport["paperhorizontalmargin"] of this card of the topStack is empty then
+      set the cREVReport["paperhorizontalmargin"] of this card of the topStack to tHorizontal
+   end if
+   if the cREVReport["paperverticalmargin"] of this card of the topStack is empty then
+      set the cREVReport["paperverticalmargin"] of this card of the topStack to tVertical
+   end if
+   if the cREVReport["printrange"] of this card of the topStack is empty then
+      set the cREVReport["printrange"] of this card of the topStack to "All Cards"
+   end if
+   
+   if the cREVReport["onetoone"] of this card of the topStack is empty then
+      set the cREVReport["onetoone"] of this card of the topStack to true
+   end if
+   revUpdateViewerObjectList
 end revInitialReportUpdate
 
 function revQueryReports pStack
-  if pStack is empty then put short name of the topStack into pStack
-  put the number of controls of this card of stack pStack into tNumControls
-  repeat with i = 1 to tNumControls
-    put the cREVReport["viewername"] of control i of this card of stack pStack into tReport
-    if tReport is not empty then put tReport & cr after tReports
-  end repeat
-  delete last char of tReports
-  sort tReports
-  return tReports
+   if pStack is empty then put short name of the topStack into pStack
+   
+   local tNumControls, tReports
+   put the number of controls of this card of stack pStack into tNumControls
+   repeat with i = 1 to tNumControls
+      local tReport
+      put the cREVReport["viewername"] of control i of this card of stack pStack into tReport
+      if tReport is not empty then put tReport & cr after tReports
+   end repeat
+   delete last char of tReports
+   sort tReports
+   return tReports
 end revQueryReports

--- a/Toolset/libraries/revprofileslibrary.livecodescript
+++ b/Toolset/libraries/revprofileslibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revprofileslibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 # OK-2008-04-14 : Added variable declarations when investigating a bug

--- a/Toolset/libraries/revxmlrpclibrary.livecodescript
+++ b/Toolset/libraries/revxmlrpclibrary.livecodescript
@@ -166,6 +166,8 @@ function revXMLRPC_GetParam pXMLRPCDocID, pParamNumber, pType
   put "/" & revXMLRootNode(pXMLRPCDocID) & "/params/param[" & pParamNumber & "]/value" into tValueNode
   put revXMLChildNames(pXMLRPCDocID,tValueNode,return,,false) into tValueType
   put tValueNode & "/" & tValueType into tDataNode
+  
+  local tParamData
   if pType is "xml" or pType is empty then
     put revXMLText(pXMLRPCDocID,tDataNode) into tParamData
   else if pType is not tValueType then
@@ -278,7 +280,7 @@ function revXMLRPC_Execute pXMLRPCDocID
   if sXMLRPC_Data[pXMLRPCDocID,"id"] is empty then return "xmlrpcerr : bad document id" && pXMLRPCDocID
   if sXMLRPC_Data[pXMLRPCDocID,"request"] is not empty then return "xmlrpcerr : document id" && pXMLRPCDocID && "is a response"
   ## if it is a valid doc ID, proceed
-  local tPath, tSocket, tHost, tPort, tURL
+  local tPath, tSocket, tHost, tPort, tURL, tProtocol
   local tPayload, tHTTPHeaders, tResponseData, tResponseID
   -- collect the host, port, path and protocol information
   put sXMLRPC_Data[pXMLRPCDocID,"host"] into tHost
@@ -309,6 +311,7 @@ function revXMLRPC_Execute pXMLRPCDocID
         tHTTPHeaders & CRLF & CRLF & tPayload to socket tSocket
     read from socket tSocket until CRLF
     -- save the response and check the server status code
+    local tServerResponse
     put it into tServerResponse
     if word 2 of line 1 of tServerResponse is not "200" then
       -- make sure to read all the data, even if we ignore it
@@ -318,6 +321,7 @@ function revXMLRPC_Execute pXMLRPCDocID
     end if
     -- read the headers
     read from socket tSocket until (CRLF & CRLF)
+    local tSRHTTPHeaders
     put it into tSRHTTPHeaders
     replace CRLF with return in tSRHTTPHeaders
     if line -1 of tSRHTTPHeaders is empty then delete line -1 of tSRHTTPHeaders
@@ -328,6 +332,7 @@ function revXMLRPC_Execute pXMLRPCDocID
     -- use POST command from libURL
     put toLower(tProtocol) & "://" & tHost & ":" & tPort & "/" & tPath into tURL
     -- now post the payload to the URL
+    local tSaveHTTPHeaders
     put the httpHeaders into tSaveHTTPHeaders #mf 03/08/2005 Bug 2444
     set the httpHeaders to tHTTPHeaders
     post tPayload to URL tURL

--- a/Toolset/libraries/revxmlrpclibrary.livecodescript
+++ b/Toolset/libraries/revxmlrpclibrary.livecodescript
@@ -1,11 +1,15 @@
 ﻿script "revxmlrpclibrary"
 
 on revLoadLibrary
-   insert the script of me into back
+   if the target is me then
+      insert the script of me into back
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
-   remove the script of me from back
+   if the target is me then
+      remove the script of me from back
+   end if
 end revUnloadLibrary
 
 ----- LiveCode XML-RPC library ------


### PR DESCRIPTION
There is no specific bug related for this but it does reduce the potential for:
- setup code in `revLoadLibrary` to be run multiple times if some back script didn't load correctly
- teardown code to be run on the wrong library in the event a library was not loaded correctly and then `revUnloadLibrary` was sent to it.
