### PR TITLE
Don't set IDE scripts that don't compile

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -137,7 +137,9 @@ end revSEAddTargetObject
 #   Removes the specified object from this script editor. If the removed object is the current
 #   editing object, then changes the current object to the last selected object.
 command revSERemoveTargetObject pObject, pDontWarn, pDontCloseIfLast, pDontChangeTab
-   if pDontWarn is not true and seGetObjectState(pObject) is "edited" then
+   local tState
+   put seGetObjectState(pObject) into tState
+   if pDontWarn is not true and (tState is "edited" or (tState is "error" and revIDEObjectIsOnIDEStack(pObject))) then
       revSEWarnBeforeClosing pObject
       if the result is "cancel" then
          exit revSERemoveTargetObject
@@ -743,7 +745,9 @@ command revSEGetModifiedObjects
    
    local tEditedObjects
    repeat for each line tObject in tObjects
-      if seGetObjectState(tObject) is "edited" then
+      local tState
+      put seGetObjectState(tObject) into tState
+      if tState is "edited" or (tState is "error" and revIDEObjectIsOnIDEStack(tObject)) then
          # OK-2009-01-17 : Bug 7169
          local tDirty
          send "getDirty tObject" to group "Editor" of me
@@ -1479,7 +1483,7 @@ end seResizeCardBottom
 
 # Parameters
 #   pObject : the object to apply the script of
-#   pIgnoreErrors : causes errors in setting the script not to be displayed in the errors pane
+#   pIgnoreErrors : causes errors in setting the script not to be displayed in the errors pane and IDE scripts to be set regardless of errors
 #   @rCompilationErrors : gets the list of compilation errors placed into it. Will be set to empty if none occurred.
 # Returns
 #   True if the script was applied, false otherwise. Note that compilation errors may occur but the script could 
@@ -1498,9 +1502,7 @@ private command applyScript pObject, pIgnoreErrors, @rCompilationErrors
    # MW-2011-03-11: After moving S/E scripts into behaviors, we have a problem - it makes it too easy
    #   to break everything. Thus in the case the script is in an object which has 'revNewScriptEditor' in its
    #   long id we don't set the script on compilation errors.
-   local tIsEditorScript
-   put "stack" && quote & "revNewScriptEditor" & quote is in pObject into tIsEditorScript
-   if tCompilationResult is empty or not tIsEditorScript then
+   if tCompilationResult is empty or not revIDEObjectIsOnIDEStack(pObject) or pIgnoreErrors then
       local tScript
       send "scriptGet pObject" to group "Editor" of me
       put the result into tScript

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -1748,16 +1748,32 @@ command actionApplyAndSave
    put the result into tObject
    
    local tStack
-   put revTargetStack(tObject) into tStack
+   put ideMainStackOfObject(tObject) into tStack
    
    local tTargetObjects
    revSEGetTargetObjects
    put the result into tTargetObjects
    
+   local tIgnoreErrors = false
    repeat for each line tTargetObject in tTargetObjects
-      if revTargetStack(tTargetObject) is tStack then
+      if ideMainStackOfObject(tTargetObject) is tStack then
          # OK-2009-06-23 : Bug 8124 - When saving, still display compilation errors, just apply the script anyway.
-         compileScript tTargetObject, false
+         compileScript tTargetObject, tIgnoreErrors
+         
+         local tCompilationErrors
+         put the result into tCompilationErrors
+         
+         if not tIgnoreErrors and tCompilationErrors is not empty and revIDEObjectIsOnIDEStack(tTargetObject) then
+            answer error "The following script has compilation errors. Would you like to ignore errors and apply the script before saving?" & return & the long name of tTargetObject with "Ignore Errors" or "Cancel"
+            
+            if it is "Cancel" then
+               revSESetCurrentObject tTargetObject
+               exit actionApplyAndSave
+            end if
+            
+            put true into tIgnoreErrors
+            compileScript tTargetObject, tIgnoreErrors
+         end if
       end if
    end repeat
    


### PR DESCRIPTION
Previously there was a check to ensure script editor
scripts were not set if they didn't compile. This has
been extended to all scripts when gREVDevelopment is
true.

This change makes it **much** simpler to edit
IDE scripts, however, the team needs to be aware that
scripts with compile errors will _not_ save. If necessary
set gREVDevelopment to false temporarily to work around.
