### PR TITLE
[[ Bug 2867 ]] Workaround IDE hang when tracing resizeStack & moveStack

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -2252,6 +2252,16 @@ on traceError pHandler, pLine, pPosition, pError
       pass traceError
    end if
    
+   -- We can not flush moveStack and resizeStack messages so the IDE will lock up if we try and trace
+   local tContexts
+   put the executionContexts into tContexts
+   local tLine
+   repeat for each line tLine in tContexts
+      if item -2 of tLine is among the words of "moveStack resizeStack" then
+         pass traceError
+      end if
+   end repeat
+   
    if pError is empty then
       revDebuggerStop
       exit traceError
@@ -2304,6 +2314,16 @@ on traceBreak pHandler, pLine
       revDebuggerRun
       exit traceBreak
    end if
+   
+   -- We can not flush moveStack and resizeStack messages so the IDE will lock up if we try and trace
+   local tContexts
+   put the executionContexts into tContexts
+   local tLine
+   repeat for each line tLine in tContexts
+      if item -2 of tLine is among the words of "moveStack resizeStack" then
+         pass traceBreak
+      end if
+   end repeat
    
    local tContext
    put tTarget & comma & pHandler & comma & pLine into tContext

--- a/notes/bugfix-2867.md
+++ b/notes/bugfix-2867.md
@@ -1,0 +1,5 @@
+# Ignore moveStack and resizeStack execution errors in script debug mode
+
+Previously when in script debug mode an execution error in the context
+of a moveStack or resizeStack handler would cause the IDE hang and 
+occasionally crash. 


### PR DESCRIPTION
Setting the mode of the script editor to debug
must be sent in time to give the script editor
time to update. This unfortunately allows time
for the next resizeStack or moveStack message
to be handled resulting in an IDE hang and eventual
crash. This has been an issue for a long time.

This patch ignores errors in those two handlers
as a better alternative to an IDE hang. Ideally
the script editor could be reworked in the future
to not require the send in time.
