### PR TITLE
[[ Bug ]] ensure iconGravity is empty when creating buttons in IDE

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -321,6 +321,8 @@ on generateMenubarUI
       delete group "toolbar" of me
    end if
    
+   reset the templatebutton
+   
    create group "icons"
    create group "toolbar"
    
@@ -332,7 +334,6 @@ on generateMenubarUI
    set the borderwidth of the templatebutton to 0
    set the blendlevel of the templatebutton to 0
    set the margins of the templatebutton to "4,0,4,1"
-   set the icongravity of the templatebutton to "top"
    set the traversalOn of the templatebutton to false
    set the autoHilite of the templatebutton to false
    

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -200,7 +200,6 @@ on generatePalette
    set the showname of the templatebutton to false
    set the style of the templatebutton to "transparent"
    
-   set the icongravity of the templatebutton to "top"
    set the threed of the templatebutton to false
    set the borderwidth of the templatebutton to 0
    set the blendlevel of the templatebutton to 0


### PR DESCRIPTION
Previously the iconGravity was not being copied
during button creation which had the effect of
iconGravity always being empty on new buttons.

When generating the UI for revTools and revMenubar
the iconGravity of the templateButton was being
set to top but as the iconGravity from the
templateButton wasn't being copied by the engine
the UIs were designed with iconGravity empty.

This patch also ensures the templateButton is reset
before generating revMenubar
