### PR TITLE
[[ Bug 11834 ]] Remove deprecated syntax from iOS card of standalone settings

### DIFF
--- a/Toolset/palettes/standalone settings/revstandalonesettingsiosbehavior.livecodescript
+++ b/Toolset/palettes/standalone settings/revstandalonesettingsiosbehavior.livecodescript
@@ -62,7 +62,7 @@ on updateSettings
    local tSettings
    put getSettings() into tSettings
    
-   set the unicodeText of field "Display Name" to uniEncode(computeDefault(tSettings["ios,display name"], tSettings["name"]), "UTF8")
+   put computeDefault(tSettings["ios,display name"], tSettings["name"]) into field "Display Name"
    put computeDefault(tSettings["ios,bundle id"], "com.yourcompany.yourapp") into field "Bundle Id"
    put computeDefault(tSettings["ios,bundle version"], "1.0.0") into field "Bundle Version"
    

--- a/notes/bugfix-11834.md
+++ b/notes/bugfix-11834.md
@@ -1,0 +1,1 @@
+# Don't encode/decode iOS app name in standalone settings


### PR DESCRIPTION
It is not needed and causes information loss
