### PR TITLE
[[ Bug 18082 ]] Improve script only stack opening

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -288,7 +288,16 @@ on revInternal__openStack
       
       -- Now the home stack has loaded, we can allow interrupts..
       set the allowInterrupts to true
+      
+      revInternal__OpenCommandLineFiles
 end revInternal__openStack
+
+command revInternal__OpenCommandLineFiles
+   local tFile
+   repeat for each element tFile in the commandArguments
+      revTryToOpenStackFromFile tFile, true
+   end repeat
+end revInternal__OpenCommandLineFiles
 
 on revInternal__setSplashStatus pMessage
 	revInternal__Log "Message", pMessage

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -519,26 +519,28 @@ on appleEvent p1, p2, p3
       request AppleEvent data
       put it into tData
       
-      local tExists
-      local tCanonical
-      repeat for each line l in tData
-         lock messages
-         put utilityCanonicalizePath(l) into tCanonical
-         put (there is a stack tCanonical) into tExists
-         unlock messages
-         // AL-2014-10-27: [[ Bug 12558 ]] Stack opened in apple event should report correct error
-         if not tExists then 
-            answer error "Unable to open stack:" && the result
-         else 
-            go stack tCanonical
-            ideMessageSend "ideOpenStack", the long id of stack tCanonical
-         end if
+      local tFile
+      repeat for each line tFile in tData
+         revTryToOpenStackFromFile tFile, false
       end repeat
       
       exit appleEvent
    end if
    pass appleEvent
 end appleEvent
+
+command revTryToOpenStackFromFile pFile, pFailSilently
+   local tExists
+   local tCanonical
+   lock messages
+   put utilityCanonicalizePath(pFile) into tCanonical
+   put (there is a stack tCanonical) into tExists
+   unlock messages
+   if tExists or (not tExists and not pFailSilently) then
+      -- revIDEOpenStack presents appropriate failure dialogs
+      revIDEOpenStack tCanonical
+   end if
+end revTryToOpenStackFromFile
 
 # OK-2007-11-27 : Tidied up
 on revSave pWhichStack

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6182,10 +6182,19 @@ on revIDEOpenStack pFilePath
       
       # AL-2015-06-09: [[ Bug 14831 ]] If stack is script only, open in script editor
       if the scriptOnly of stack pFilePath then
-         revIDEEditScriptOfObject the long id of stack pFilePath
+         local tStack
+         put the long id of stack pFilePath into tStack
+         send "__CheckScriptOnlyStackIsVisible tStack" to me in 100 milliseconds
       end if
    end if
 end revIDEOpenStack
+
+command __CheckScriptOnlyStackIsVisible pStack
+   if the invisible of pStack then
+      revIDEEditScriptOfObject pStack
+   end if
+end __CheckScriptOnlyStackIsVisible
+      
 
 on revIDEHelpKeyPressed
    --send "menuPick" && quote & "Help Contents" & quote to btn "Help" of stack "revMenuBar"

--- a/notes/bugfix-18082.md
+++ b/notes/bugfix-18082.md
@@ -1,0 +1,8 @@
+# Improve script only stack opening
+
+Script only stacks will now be checked to determine if they are visible
+after opening before editing their script in the script editor after
+opening via the file menu and when opened via the system. This allows
+script only stacks that generate their own user interface via script
+in `preOpenStack` or `openStack` to not open into the script editor
+by setting the visible of the stack to true in `openStack`.


### PR DESCRIPTION
This patch makes the following changes:
- Script only stacks will now be checked to determine if they are visible
  after opening before editing their script in the script editor after
  opening via the file menu and when opened via the system. This allows
  script only stacks that generate their own user interface via script
  in `preOpenStack` or `openStack` to not open into the script editor
  by setting the visible of the stack to true in `openStack`.
- StackFiles are now explicitly opened at startup by the IDE rather
  than depending on the engine to open them.
- StackFiles opened via AppleEvent will now use the same code path
  as StackFiles opened via command line arguments and relaunch arguments
