### PR TITLE
[Bug 4695] Make sure no runtime error occurs when saving as legacy

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7401,7 +7401,7 @@ on revIDESaveStackAs pStackID, pFileName, pVersion
    end if
    
    local tShortName, tResult
-   put the short name of stack pStackID into tShortName
+   put the short name of pStackID into tShortName
    put the result into tResult
    if tResult is not empty then
       local tLocaliseSubstitutions

--- a/notes/bugfix-4695.md
+++ b/notes/bugfix-4695.md
@@ -1,0 +1,1 @@
+# Fixed runtime error when saving as legacy


### PR DESCRIPTION
When `revIDESaveStackAs pStackID, pFileName, pVersion` is called `pStackID` is of the form "stack /Users/panos/myStack.livecode", i.e. it contains the word "stack" already
