### PR TITLE
Fix revIDEGroupObjects dependency on object selection

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3548,37 +3548,66 @@ on revIDEActionGroupObjects
    
    revIDEGroupObjects tSelobj
    
-   local tNewGroup
-   put the result into tNewGroup
-   if exists(tNewGroup) then
-      select tNewGroup
+   if the result is empty and exists(it) then
+      select it
+   else
+      beep
    end if
 end revIDEActionGroupObjects
 
+/**
+
+Name: revIDEGroupObjects
+
+Type: command
+
+Syntax: revIDEGroupObjects <objectList>
+
+Summary: Group a list of objects in their layer order
+
+Description:
+Group a list of objects in the order they are layered in
+
+Parameters:
+objectList (string): A return delimited list of long object IDs
+
+The result:
+An error string
+
+It:
+The new group long ID or empty in the case the group could not be created
+
+**/
 on revIDEGroupObjects pObjectIDs
+   filter lines of pObjectIDs without empty
+   
    if pObjectIDs is empty then
-      exit revIDEGroupObjects
+      return "No objects" for error
    end if
    
-   local tLayer, tGroupID, tList, tObj
+   local tObject
+   repeat for each line tObject in pObjectIDs
+      if not exists(tObject) then
+         return "Object does not exist" for error
+      end if
+   end repeat
    
-   put the long id of (line 1 of pObjectIDs) into tObj
-   put 1000000 into tLayer
+   sort lines of pObjectIDs numeric by the layer of each
    
    lock screen
    
-   repeat for each line tControl in pObjectIDs
-      if the layer of tControl < tLayer then put the layer of tControl into tLayer
-   end repeat
+   replace return with " and " in pObjectIDs
    
-   // PM-2016-04-07: [[ Bug 17301 ]] Use the "group" command (without an objectList)
-   // so as to group the selection in layer order
-   group
+   local tError
+   try
+      do "group " & pObjectIDs
+   catch tError
+      return "Could not group objects" for error
+   end try
    
-   put the long id of the owner of tObj into tGroupID
-   set the layer of tGroupID to tLayer
    unlock screen
-   return tGroupID
+   
+   return it for value
 end revIDEGroupObjects
 
 on revIDEActionUngroup

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2539,6 +2539,11 @@ on revMenubarContextMenuPickTarget pWhich, pTarget
          break
       case "Group"
          revIDEGroupObjects pTarget
+         if the result is empty and exists(it) then
+            select it
+         else
+            beep
+         end if
          break
          ######### SUBMENUS ########
       case "Card"

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -867,8 +867,12 @@ on groupControls
    
    put pbSelectedObjects() into tControlList
    revIDEGroupObjects tControlList
-   put the result into tGroupID
-   select tGroupID
+   
+   if the result is empty and exists(it) then
+      select it
+   else
+      beep
+   end if
    unlock screen
 end groupControls
 
@@ -2501,4 +2505,3 @@ command setConnectorIcon pControl, pState
          break
    end switch
 end setConnectorIcon
-

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -3208,9 +3208,11 @@ on revTutorialCreateAndCaptureObjects pWaitData, pCaptureData, pHighlightData
          local tChildren
          put revTutorialResolveObjectToLongID(pWaitData["object"]) into tChildren
          revIDEGroupObjects tChildren
-         put the result into sTaggedObjects["group"][tCapture["tag"]]
-         -- force recompute the children long ids
-         get revTutorialResolveObjectToLongID(pWaitData["object"], true)
+         if the result is empty and exists(it) then
+            put it into sTaggedObjects["group"][tCapture["tag"]]
+            -- force recompute the children long ids
+            get revTutorialResolveObjectToLongID(pWaitData["object"], true)
+         end if
       else
          if pHighlightData["tool"] is not empty then
             dispatch function "toolObjectName" to stack "revTools" with pHighlightData["tool"]
@@ -3309,9 +3311,11 @@ on revTutorialCreateAndCaptureObjectsStandalone pWaitData, pCaptureData, pHighli
             local tChildren
             put revTutorialResolveObjectToLongID(pWaitData["object"]) into tChildren
             revIDEGroupObjects tChildren
-            put the result into sTaggedObjects["group"][tCapture["tag"]]
-            -- force recompute the children long ids
-            get revTutorialResolveObjectToLongID(pWaitData["object"], true)
+            if the result is empty and exists(it) then
+               put it into sTaggedObjects["group"][tCapture["tag"]]
+               -- force recompute the children long ids
+               get revTutorialResolveObjectToLongID(pWaitData["object"], true)
+            end if
          else
             if pHighlightData["item"][1] contains "Import" then
                # Deal with 'import'


### PR DESCRIPTION
This is a PR I had against develop-8.0 that I have now refactored to take advantage of the new `return` and `group` command features in 8.1. It also adds some user feedback (beep) where appropriate if grouping was not possible (most likely when selecting some grouped objects and some ungrouped objects and trying to group them).
