### PR TITLE
[[ FilterHandlers ]] Clear filter when viewing a different script

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsefilterfieldbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsefilterfieldbehavior.livecodescript
@@ -107,3 +107,8 @@ end returnInField
 on enterInField
    selectAll
 end enterInField
+
+command clearFilter
+   put empty into me
+   stopFiltering
+end clearFilter

--- a/Toolset/palettes/script editor/behaviors/revseleftbarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseleftbarbehavior.livecodescript
@@ -36,7 +36,7 @@ command resize
    unlock screen
 end resize
 
-command update pDontUpdateSelectedHandler
+command update pDontUpdateSelectedHandler, pClearFilter
    lock screen
    
    local tObject, tFilter
@@ -66,14 +66,18 @@ command update pDontUpdateSelectedHandler
    set the cMinHeight of tObject to (the height of me - the height of tFilter)
    
    call "initializeWithoutGrabbingFocus" to tObject
-
+   
    -- Hook up the filter field to the list of handlers, and initialise it.
    set the cCallback of tFilter to "filterChanged"
    set the cCallbackTarget of tFilter to tObject
    set the cPlaceholderText of tFilter to "Filter..."
-
-   send "update" to tFilter
-
+   
+   if pClearFilter then
+      dispatch "clearFilter" to tFilter
+   else
+      send "update" to tFilter
+   end if
+   
    unlock screen
 end update
 

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -41,6 +41,12 @@ local sLastShownExecutionPoint
 #   Sets the current object to edit to pObject. If pStartingLine is given, then seeks to that line
 #   otherwise seeks to the last selected line.
 command revSESetCurrentObject pObject, pStartingLine, pDontSendCallbacks
+   lock screen
+   
+   revSEGetCurrentObject
+   if the result is not empty and the long id of pObject is the long id of the result then
+       exit revSESetCurrentObject
+   end if
    # Check that pObject is one of the target objects, if not then just do nothing
    local tTargetObjects
    revSEGetTargetObjects
@@ -66,10 +72,11 @@ command revSESetCurrentObject pObject, pStartingLine, pDontSendCallbacks
    # After a new object has been set we need to update the toolbar, as the compile, undo and redo buttons need to be
    # updated.
    call "update" to group "Toolbar" of me
-   call "update" to group "Left Bar" of me
+   dispatch "update" to group "Left Bar" of me with false, true
    
    seUpdateWindowTitle tObject
-    set the allowInterrupts to tOldAllowInterrupts
+   set the allowInterrupts to tOldAllowInterrupts
+   unlock screen
 end revSESetCurrentObject
 
 # Description


### PR DESCRIPTION
Previously the handler filter would remain when switching scripts and
cause confustion when no handlers were listed. This patch clears the
handler filter each time the user views a different script. This
patch also ensures that the script editor isn't unnecessarily
updated when the user clicks on the active script tab.
