### PR TITLE
Do not show warning about data loss when saving as latest format

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -7314,7 +7314,7 @@ on revIDESaveStack pStackID
       put tStackFileVersion into tFileVersions[1]
       put the minStackFileVersion of stack tStackName into tFileVersions[2]
       if highestVersionNumber(tStackFileVersion, tFileVersions[2]) is 2 then
-         answer revIDELocalise("The preference to preserve stack file formats is is set," && \
+         answer revIDELocalise("The preference to preserve stack file formats is set," && \
                "however, saving this stack file as version %1 will result in data loss." && \
                "The minimum stack file version for this stack is %2.", tFileVersions) \
                with revIDELocalise("Save as %1", tFileVersions) and  revIDELocalise("Save as %2", tFileVersions) and revIDELocalise("Cancel")
@@ -7605,7 +7605,7 @@ on revIDEActionSaveStackAs pStackID, pSubstackOnly
    local tFileVersions
    put tVersion into tFileVersions[1]
    put the minStackFileVersion of stack tShortName into tFileVersions[2]
-   if highestVersionNumber(tVersion, tFileVersions[2]) is 2 then
+   if tVersion is not empty and highestVersionNumber(tVersion, tFileVersions[2]) is 2 then
       answer revIDELocalise("Saving this stack file as version %1 will result in data loss." && \
             "The minimum stack file version for this stack is %2.", tFileVersions) \
             with revIDELocalise("Save as %1", tFileVersions) and  revIDELocalise("Save as %2", tFileVersions) and revIDELocalise("Cancel")


### PR DESCRIPTION
Create a stack and click cmd+S. Select latest format ("LiveCode stack") and click the Save button. This caused `tVersion` to be empty, and a warning dialog saying:

![screen shot 2016-08-22 at 14 30 27](https://cloud.githubusercontent.com/assets/5111835/17856404/4eb6ed6a-6875-11e6-8e0b-79312cae4952.png)

This patch ensures that no warning dialog is shown if the user chooses to save the stack as latest format ("LiveCode stack").
