### PR TITLE
[Bug 15887] Handle "selectionChanged" messsage sent by the engine to the SE

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2455,9 +2455,14 @@ command cancelPendingMessages
    end if
 end cancelPendingMessages
 
+-- This is sent by the engine
+on selectionChanged
+   handleSelectionChanged
+end selectionChanged
+
 -- PM-2016-09-22: [[ Bug 15887 ]] Distinguish between "selectionChanged" sent by the engine and \
 -- "selectionChangedByArrowKey pArrowKey"
-on selectionChanged
+on handleSelectionChanged
    if the selectedText of field "Script" of me is not empty then
       put the selectedText of field "Script" of me into sLastNonEmptySelection
    end if
@@ -2467,10 +2472,10 @@ on selectionChanged
    if the long id of the focusedObject is the long id of field "Script" of me then
       put word 2 of it & comma & word 4 of it into sLastSelectedChunk
    end if
-end selectionChanged
+end handleSelectionChanged
 
 on selectionChangedByArrowKey pArrowKey
-   send "selectionChanged" to me in 0 milliseconds
+   send "handleSelectionChanged" to me in 0 milliseconds
    get the selectedChunk
    
    local tAt

--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2475,7 +2475,7 @@ on handleSelectionChanged
 end handleSelectionChanged
 
 on selectionChangedByArrowKey pArrowKey
-   send "handleSelectionChanged" to me in 0 milliseconds
+   handleSelectionChanged
    get the selectedChunk
    
    local tAt

--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2455,30 +2455,35 @@ command cancelPendingMessages
    end if
 end cancelPendingMessages
 
-on selectionChanged pArrowKey
+-- PM-2016-09-22: [[ Bug 15887 ]] Distinguish between "selectionChanged" sent by the engine and \
+-- "selectionChangedByArrowKey pArrowKey"
+on selectionChanged
    if the selectedText of field "Script" of me is not empty then
       put the selectedText of field "Script" of me into sLastNonEmptySelection
    end if
-   
-   get the selectedChunk
    
    # OK-2008-10-22 : Bug 7343 - Must save the last selection point as its lost
    # when the user begins typing into the search field.
    if the long id of the focusedObject is the long id of field "Script" of me then
       put word 2 of it & comma & word 4 of it into sLastSelectedChunk
    end if
+end selectionChanged
+
+on selectionChangedByArrowKey pArrowKey
+   send "selectionChanged" to me in 0 milliseconds
+   get the selectedChunk
    
    local tAt
    if word 2 of it > word 4 of it then
       put word 4 of it into tAt
    else
       -- It is a multiple selection, so we need to exit this.
-      exit selectionChanged
+      exit selectionChangedByArrowKey
    end if
    
    -- Single selection in the process of making a larger selection, so exit if shift is down.
    if the shiftKey is "down" then
-      exit selectionChanged
+      exit selectionChangedByArrowKey
    end if
    
    local tLine
@@ -2527,7 +2532,7 @@ on selectionChanged pArrowKey
    textMark "Insert"
    
    selectionUpdateRequest
-end selectionChanged
+end selectionChangedByArrowKey
 
 
 private command selectionUpdateRequest
@@ -3238,14 +3243,14 @@ on rawKeyDown pKey
    
    # For Windows: Home (Windows / Linux)
    if pKey is kKeyHome and seGetPlatform() is not "macos" then
-      send "selectionChanged" to me in 0 milliseconds
+      send "selectionChangedByArrowKey" to me in 0 milliseconds
       pass rawKeyDown
    end if
    
    # For Mac: Ctrl-Left / Cmd-Left / Ctrl-A (Mac)
    if (pKey is kKeyLeftArrow and (the controlKey is "down" or the commandKey is "down") or \
          (pKey is 65 and the controlKey is "down" and the shiftKey is "up")) and seGetPlatform() is "macos" then
-      send "selectionChanged" to me in 0 milliseconds
+      send "selectionChangedByArrowKey" to me in 0 milliseconds
       pass rawKeyDown
    end if
    
@@ -3317,7 +3322,7 @@ on rawKeyUp pKey
    
    if not scriptLocked() then
       textMark "Insert"
-      send "selectionChanged tKeyName" to me in 0 milliseconds
+      send "selectionChangedByArrowKey tKeyName" to me in 0 milliseconds
    end if
    pass rawKeyUp
 end rawKeyUp

--- a/notes/bugfix-15887.md
+++ b/notes/bugfix-15887.md
@@ -1,0 +1,1 @@
+# Make sure arrowKey left in Script Editor is not stuck at begin of line


### PR DESCRIPTION
This fixes a regression caused by the fix to bug 7217.  According to that fix, the engine should send a `selectionChanged` message to the field when navigating using arrow keys, regardless of whether the Shift key is held down. That resulted in having four different `selectionChanged` messages:

1) A `selectionChanged` that is sent to the field by the engine, and has no parameters. On LC 7.1.0 DP1 (i.e before the fix to bug 7217), this was sent to the field ONLY when navigating using arrow keys AND the Shift key was down. The handler selectionChanged pArrowKey of button "Template Editor” handled this case with:

```
if the shiftKey is "down" then
   exit selectionChanged
end if
```

2) A `selectionChanged pArrowKey` that is sent by the `rawKeyUp pKey` handler:

`send "selectionChanged tKeyName" to me in 0 milliseconds`

3) A selectionChanged (with no parameters) that is sent by the rawKeyDown pKey handler, to handle the Home and End keys:

`send "selectionChanged" to me in 0 milliseconds`

The handler selectionChanged pArrowKey of button "Template Editor" handled this case with:

```
switch pArrowKey
      case "left"
         …
      case "right"
         …
      case "up"
      case "down"
         …
      case "empty"
      default
         caretUpdate tField, tScript
         break
   end switch
```

All these 3 cases were handled by the selectionChanged pArrowKey handler. Now, after the fix to bug 7217, there is another `selectionChanged` message (with no parameters) that is sent by the engine. Call this case (4). Currently, case (4) is handled as case (3), since pArrowKey==empty, but it should be handled as case (1).

So this patch addresses this problem by:

Renaming the handler `selectionChanged pArrowKey` to `selectionChangedByArrowKey pArrowKey` so as to keep its existing functionality to handle cases (2) and (3),

adding another `selectionChanged` handler that will handle cases (1) and (4).

The new handler `selectionChanged` just updates the `sLastNonEmptySelection` and `sLastSelectedChunk`, just the way it was done in the old `selectionChanged pArrowKey` handler (now renamed to `selectionChangedByArrowKey pArrowKey`).
