### PR TITLE
[Bug 18452] Make sure saving a substack from the PB saves the mainstack

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2498,7 +2498,7 @@ on revMenubarContextMenuPickTarget pWhich, pTarget
          end if
          break
       case "Save"
-         revIDEActionSaveStack tTargetStack
+         revIDESaveStack tTargetStack
          break
       case "Paste Objects"
          revIDEPasteOntoStack tTargetStack

--- a/notes/bugfix-18452.md
+++ b/notes/bugfix-18452.md
@@ -1,0 +1,1 @@
+# Saving a substack from the Project Browser no longer asks for a path to save


### PR DESCRIPTION
The `revIDESaveStack` is called when you click "Save" on a stack/substack from the menubar. Use this function when saving a stack/substack from the PB, since it handles correctly the case of substacks
