### PR TITLE
[[ Bug 18475 ]] Fix close combobox bug in font PI

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.font.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.font.behavior.livecodescript
@@ -46,3 +46,7 @@ on valueChanged
    set the editorValue of me to the label of button 1 of me
    updateProperty
 end valueChanged
+
+on closeField
+   valueChanged
+end closeField

--- a/bugfix-18475
+++ b/bugfix-18475
@@ -1,0 +1,1 @@
+# textFont of control does not get set when tabbing out of textFont comboBox in P.I.


### PR DESCRIPTION
Font was not being updated when closing combobox by pressing tab key.
