### PR TITLE
[Bug 18455] Start Center: display correct version of LiveCode.

### DIFF
--- a/Toolset/palettes/start center/revStartCenterBehavior.livecodescript
+++ b/Toolset/palettes/start center/revStartCenterBehavior.livecodescript
@@ -85,6 +85,12 @@ command logoInitialise
    ## Set the logo to the correct logo for the version
    set the iconPresetName of widget "logo" of me to "lc-logo"
    set the foregroundColor of widget "logo" of me to uiColor("logo")
+   
+   ## Set the title to contain the correct version string
+   local tMajorVersion
+   set the itemDelimiter to "."
+   put item 1 to 2 of the version into tMajorVersion
+   put merge("Welcome to LiveCode [[tMajorVersion]]") into field "title" of me
 end logoInitialise
 
 command socialMediaInitialise   

--- a/notes/bugfix-18455.md
+++ b/notes/bugfix-18455.md
@@ -1,0 +1,1 @@
+# Show the correct version of LiveCode in Start Center title


### PR DESCRIPTION
Use `the version` to populate the stack title on opening the stack
rather than using a hardcoded string.
