### PR TITLE
[Bug 18528] Find Next/Previous in the SE respects current cursor location

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2474,6 +2474,8 @@ end cancelPendingMessages
 -- This is sent by the engine
 on selectionChanged
    handleSelectionChanged
+   -- Unmark found results when clicking on the SE
+   selectionUpdateRequest
 end selectionChanged
 
 -- PM-2016-09-22: [[ Bug 15887 ]] Distinguish between "selectionChanged" sent by the engine and \
@@ -2482,6 +2484,9 @@ on handleSelectionChanged
    if the selectedText of field "Script" of me is not empty then
       put the selectedText of field "Script" of me into sLastNonEmptySelection
    end if
+   
+   -- [[ Bug 18528 ]] We need this here otherwise the "it" var in the if block below is empty
+   get the selectedChunk
    
    # OK-2008-10-22 : Bug 7343 - Must save the last selection point as its lost
    # when the user begins typing into the search field.
@@ -2492,7 +2497,6 @@ end handleSelectionChanged
 
 on selectionChangedByArrowKey pArrowKey
    handleSelectionChanged
-   get the selectedChunk
    
    local tAt
    if word 2 of it > word 4 of it then

--- a/notes/bugfix-18528.md
+++ b/notes/bugfix-18528.md
@@ -1,0 +1,1 @@
+# Find Next/Previous in the SE now respects current cursor location


### PR DESCRIPTION
Called `get the selectedChunk` in the correct place so as to properly update the `sLastSelectedChunk`, that keeps track of the starting point from which the Find Next/Previous should begin.

Setting this to blocker for 8.1.1 RC-2 since this bug was introduced in 8.1.1 RC-1
