### PR TITLE
[Bug 18485] Prevent relayering grouped controls unless in Edit Group mode

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9062,7 +9062,7 @@ on revIDERelayerControls pObjectList, pMode
    local tRelayerGrouped
    put the relayerGroupedControls into tRelayerGrouped
    
-   set the relayerGroupedControls to true
+   set the relayerGroupedControls to false
    switch pMode
       case "send to back"
          sort lines of tLayers numeric descending

--- a/notes/bugfix-18485.md
+++ b/notes/bugfix-18485.md
@@ -1,0 +1,1 @@
+# Prevent relayering of grouped controls if we are not on Edit Group mode


### PR DESCRIPTION
This is achieved by setting the `relayerGroupedControls` to false in the appropriate place, which matches the LC 7.x behavior.
