### PR TITLE
[Bug 18595] Update correctly cursor position in the SE in some use cases

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2498,6 +2498,9 @@ end handleSelectionChanged
 on selectionChangedByArrowKey pArrowKey
    handleSelectionChanged
    
+   -- [[ Bug 18595 ]] We need this here otherwise the "it" var in the if block below is empty
+   get the selectedChunk
+   
    local tAt
    if word 2 of it > word 4 of it then
       put word 4 of it into tAt


### PR DESCRIPTION
Use Case :
- User clicks in the beginning of the first word of a line and then presses arrowKey left. The cursor should jump to the end of the last word of the previous line.

This PR fixes this problem.
