### PR TITLE
[[ Tests ]] Disable player property tests on Linux

### DIFF
--- a/tests/core/objectprops/objectdefaultprops.livecodescript
+++ b/tests/core/objectprops/objectdefaultprops.livecodescript
@@ -1718,6 +1718,11 @@ end TestImageDefaultProps
 
 
 on TestPlayerDefaultProps
+   if the platform is "linux" then
+      TestSkip "player property tests", "Bug 18618"
+      exit TestPlayerDefaultProps
+   end if
+	
    local tObjectID
    revIDEActionCreateObject "com.livecode.interface.classic.Player"
    put the result into tObjectID


### PR DESCRIPTION
These appear to be causing crashes in the test system.
