### PR TITLE
[Bug 18637] Fix searching in "Stack file and its stackfiles"

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -4359,15 +4359,11 @@ private function findListObjectsOnStackAndSubstacks pObject, pIncludeStackfiles,
                return empty
             end if
             
-            local tStackFileList
-            put empty into tStackFileList
-            get revIDEListSearchObjectTree(the name of stack tPath, false, empty, true, true, true, tStackFileList)
-            put tStackFileList after tList
+            get revIDEListSearchObjectTree(the name of stack tPath, false, empty, true, true, true, tList)
          end if
          unlock messages
          
       end repeat
-      delete the last char of tList
    end if
    
    return tList

--- a/notes/bugfix-18637.md
+++ b/notes/bugfix-18637.md
@@ -1,0 +1,1 @@
+# Fix searching in "Stack File and its stack files" from the script editor


### PR DESCRIPTION
Based on the changes in PR https://github.com/livecode/livecode-ide/pull/1349,
`tList` is no longer a `CR` separated list (it is now an array), so we should not `delete the last char of tList`. 

In the future we might want to rename all array vars to end with `A`, i.e. `tMyCollectionOfStuffA`
