### PR TITLE
[[ Bugfix 18300 ]] Property inspector custom property list is not sorted

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -37,6 +37,11 @@ on editorUpdate
       set the label of button "customPropertySet" of group "Set buttons" of me to sPropSet
    end if
    
+   if arrayKeysAreNumeric(tValue[sPropSet]) then
+      set the sorttype of of widget 1 of me to "numeric"
+   else
+      set the sorttype of of widget 1 of me to "text"
+   end if
    set the arrayData of widget 1 of me to tValue[sPropSet]
    local tPath
    put the hilitedElement of widget 1 of me into tPath
@@ -321,3 +326,13 @@ on hiliteChanged
    end if
    put false into sDontUpdate
 end hiliteChanged
+
+
+function arrayKeysAreNumeric pArrayA
+   local tKey
+   
+   repeat for each key tKey in pArrayA
+      if tKey is not an integer then return false
+   end repeat
+   return true
+end arrayKeysAreNumeric

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -38,9 +38,9 @@ on editorUpdate
    end if
    
    if arrayKeysAreNumeric(tValue[sPropSet]) then
-      set the sorttype of of widget 1 of me to "numeric"
+      set the sorttype of widget 1 of me to "numeric"
    else
-      set the sorttype of of widget 1 of me to "text"
+      set the sorttype of widget 1 of me to "text"
    end if
    set the arrayData of widget 1 of me to tValue[sPropSet]
    local tPath

--- a/notes/bugfix-18300.md
+++ b/notes/bugfix-18300.md
@@ -1,0 +1,1 @@
+# property inspector custom property list is not sorted


### PR DESCRIPTION
The custom property UI in the property inspector was always sorting keys numerically.
This update changes the sort order based on the keys being displayed. If they are
numeric then the sorttype is set to numeric. Otherwise it is set to text.
