### PR TITLE
[Bug 18791] Fix PI "list editor" not updating when it should

### DIFF
--- a/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
@@ -97,12 +97,10 @@ getProp editorEnabled
 end editorEnabled
 
 local sAllowUpdate
-local sLastValue
 local sValue
 setProp editorValue[pKey] pValue
    set the casesensitive to true
-   if sLastValue is empty or pValue is not sLastValue or sEditorEffective then 
-      put sValue into sLastValue
+   if sValue is empty or pValue is not sValue or sEditorEffective then
       if pKey is not empty then
          put pValue into sValue[pKey]
       else

--- a/notes/bugfix-18791.md
+++ b/notes/bugfix-18791.md
@@ -1,0 +1,1 @@
+# Fix PI list editors not updating when value changed


### PR DESCRIPTION
The PI editor behaviour had some not-quite-correct code for ensuring
that PI rows didn't get rebuilt/refreshed correctly.  When deciding
whether the Nth value should cause an update, the Nth value was being
compared against the (N-2)th value rather than the (N-1)th value.  As
a result, some property modification patterns were causing the PI to
show stale property values.