### PR TITLE
[[ PI ]] Fix some surprising UX features of the custom props editor

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -10,7 +10,10 @@ on editorInitialize
    set the editorMaxWidth of me to 0
 end editorInitialize
 
-local sDontUpdate
+on updateHilitePath pPath
+   set the hilitedElement of widget 1 of me to pPath
+end updateHilitePath
+
 on editorUpdate
    lock screen
    local tValue, tEffective, tEnabled
@@ -48,10 +51,8 @@ on editorUpdate
    # Hilite a newly created key
    if sHilitePath is not empty and sHilitePath is not tPath then
       # Signals are posted from the widget after the handler has 
-      # executed, so lock messages here doesn't prevent hiliteChanged -
-      # use a script local to prevent second update.
-      put true into sDontUpdate
-      set the hilitedElement of widget 1 of me to sHilitePath
+      # executed, so we need to delay rehiliting the old path
+      send "updateHilitePath sHilitePath" to me in 10 millisecs
       put sHilitePath into tPath
    end if
    put empty into sHilitePath
@@ -320,11 +321,6 @@ end revValidSetName
 
 on hiliteChanged
    put empty into sHilitePath
-   # Prevent setting hilite in update causing additional call to editorUpdate
-   if not sDontUpdate then
-      editorUpdate
-   end if
-   put false into sDontUpdate
 end hiliteChanged
 
 

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -218,15 +218,34 @@ end dataChanged
 on valueChanged
    local tPath
    put the hilitedElement of widget 1 of me into tPath
-   if tPath is empty then
-      # Don't update anthing
-   else
-      local tArray
-      put the arrayData of widget 1 of me into tArray
-      setArrayDataOnPath field "value" of me, tPath, tArray
-      setPropSet tArray
-   end if
+   valueChangedOnPath tPath
 end valueChanged
+
+private command valueChangedOnPath pPath
+   if pPath is empty then
+      # Don't update anthing
+      exit valueChangedOnPath
+   end if
+   local tArray
+   put the arrayData of widget 1 of me into tArray
+   
+   local tValue, tExisting
+   put field "value" of me into tValue
+   fetchArrayDataOnPath pPath, tArray, tExisting
+   
+   local tChanged
+   if tExisting is an array then
+      put tValue is not empty into tChanged
+   else
+      put tExisting is not tValue into tChanged
+   end if
+   
+   if not tChanged then
+      exit valueChangedOnPath
+   end if
+   setArrayDataOnPath field "value" of me, pPath, tArray
+   setPropSet tArray
+end valueChangedOnPath
 
 on keyChanged
    lock screen

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -212,6 +212,7 @@ on fetchArrayDataOnPath pPath, pArray, @rData
 end fetchArrayDataOnPath
 
 on dataChanged
+   checkRehilite
    setPropSet the arrayData of widget 1 of me
 end dataChanged
 

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -248,17 +248,31 @@ private command valueChangedOnPath pPath
 end valueChangedOnPath
 
 on keyChanged
-   lock screen
    local tPath
    put the hilitedElement of widget 1 of me into tPath
+   keyChangedOnPath tPath
+end keyChanged
+
+local sLastHilite
+private command keyChangedOnPath pPath
+   if pPath is empty then
+      # Don't update anthing
+      exit keyChangedOnPath
+   end if
    
-   local tArray, tNewKey
+   local tNewKey
    put field "key" of me into tNewKey
+   if tNewKey is item -1 of pPath then
+      exit  keyChangedOnPath
+   end if
+   
+   local tArray
    put the arrayData of widget 1 of me into tArray
    
-   if tPath is not empty then
+   lock screen
+   if pPath is not empty then
       # If there is a hilited element then change it
-      setArrayKeyOnPath tNewKey, tPath, tArray
+      setArrayKeyOnPath tNewKey, pPath, tArray
    else
       # otherwise add a new key to the current set
       addArrayKeyOnPath tNewKey, tArray
@@ -266,10 +280,14 @@ on keyChanged
    
    # Set the new property and hilite the new/changed key
    setPropSet tArray
-   put tNewKey into item -1 of tPath
-   put tPath into sHilitePath
+   
+   # Since the key changed, invalidate the last hilite path
+   put empty into sLastHilite
+   
+   put tNewKey into item -1 of pPath
+   put pPath into sHilitePath
    unlock screen
-end keyChanged
+end keyChangedOnPath
 
 on propSetRenamed pFrom, pTo
    local tArray

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -357,9 +357,24 @@ function revValidSetName pWhich
 end revValidSetName
 
 on hiliteChanged
+   checkRehilite
+   editorUpdate
    put empty into sHilitePath
 end hiliteChanged
 
+on checkRehilite
+   # Check to see if the key or value has changed
+   keyChangedOnPath sLastHilite
+   valueChangedOnPath sLastHilite
+   
+   # Store the existing hilited path
+   put the hilitedElement of widget "array" of me into sLastHilite
+   if sLastHilite is not empty then
+      # If a click caused a new path to be hilited, don't trigger 
+      # a rehilite of the old path
+      put empty into sHilitePath
+   end if
+end checkRehilite
 
 function arrayKeysAreNumeric pArrayA
    local tKey

--- a/notes/bugfix-18302.md
+++ b/notes/bugfix-18302.md
@@ -1,0 +1,1 @@
+# Retain custom prop changes when clicking on tree view in editor


### PR DESCRIPTION
The key / value fields should be updated when the user clicks on a new array element in the tree view.