### PR TITLE
[Bug 18644] Use long ID to compare to breakpoints list

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -1947,7 +1947,7 @@ private function __ResolveId pId, pStack
          put the long id of control id pId of pStack into tID
       end if
    end if
-   return revRuggedID(tID)
+   return tID
 end __ResolveId
 
 # Parameters

--- a/notes/bugfix-18644.md
+++ b/notes/bugfix-18644.md
@@ -1,0 +1,1 @@
+# Deactivate breakpoints correctly


### PR DESCRIPTION
(cherry picked from commit 53f75980969efe0b6a78c5ff334f6633704eb5ee)