### PR TITLE
[Bug 18037] Use property defaults from metadata for testing widgets

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -513,7 +513,8 @@ on __revIDEDeveloperExtensionDoCreateTestStack pPath, tRectsA, pDetailsA
       set the title of it to pDetailsA["name"]
       set the script of it to __testStackScript()
       go stack "LiveCode Extension Test Window"
-      create widget as pDetailsA["id"]
+      revIDECreateObject pDetailsA["id"], the long id of the defaultStack, \
+            (the width of the defaultStack / 2) & comma & (the height of the defaultStack / 2)
       unlock messages
    end if
    

--- a/notes/bugfix-18037.md
+++ b/notes/bugfix-18037.md
@@ -1,0 +1,1 @@
+# Apply property defaults from metadata when testing widgets


### PR DESCRIPTION
Up until now, the 'Test' button in the 'Extension Builder' stack used
a raw `create widget` command to instantiate the test widget.  This
produced a "raw" widget, with its properties exactly as initialised by
its `OnCreate()` handler.

By contrast, when created from the tools palette, the default values
specified in the metadata for each property are applied.  These values
are intended to ensure a pretty and/or accessible state for the widget
when constructing a user interface interactively.

Although this behaviour wasn't necessarily wrong, because it helped to
verify that `OnCreate()` initialised the widget to a sensible empty
state, it required some contortions to check what the widget would
look like when dragged out of the tools palette.

This patch modifies the 'Test' button so that it creates a test widget
exactly as if it had been dragged out from the tools palette.