### PR TITLE
[Bug 17889] Fix fillGradient entry in propertyInfo.txt

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.txt
@@ -56,7 +56,7 @@ endTime	End	Basic	com.livecode.pi.integer	true	false					0		1
 endValue	End value	Basic	com.livecode.pi.number	true	false		100					1			
 externals	External references	externalRefs	com.livecode.pi.text	true	false			
 filename	Source	Basic	com.livecode.pi.file	true	false			
-fillGradient::revIDESetGradientProperty	Fill gradient	Colors	com.livecode.pi.gradient	true	false	Background fill		popup:gradientType,gradientRamp,gradientQuality,gradientRepeat,gradientMirror,gradientWrap
+fillGradient::revIDESetGradientProperty	Fill gradient	Colors	com.livecode.pi.gradient	true	false			popup:gradientType,gradientRamp,gradientQuality,gradientRepeat,gradientMirror,gradientWrap
 firstIndent	First indent	Basic	com.livecode.pi.integer	true	false		0					1	
 fixedLineHeight	Fixed line height	Text	com.livecode.pi.boolean	true	false		false	
 focusBorder	Focus border	Basic	com.livecode.pi.boolean	true	false			

--- a/notes/bugfix-17889.md
+++ b/notes/bugfix-17889.md
@@ -1,0 +1,1 @@
+# Repaired confusing layout of fill gradient control in Property Inspector 


### PR DESCRIPTION
The property definition for fillGradient had a group entry of "Background fill", which caused it to be grouped with color and pattern background fill in the property inspector. Removing that entry allows this property to be rendered separately with the proper label.