### PR TITLE
[Bug 18984] Reinstate fixedLineHeight for tableField

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TableField.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.TableField.txt
@@ -27,7 +27,7 @@ listBehavior							false
 multipleHilites							false					
 nonContiguousHilites							false					
 toggleHilites							false					
-fixedLineHeight												
+fixedLineHeight							true					
 textHeight												
 firstIndent							0					
 dontSearch							false					

--- a/notes/Bugfix-18984.md
+++ b/notes/Bugfix-18984.md
@@ -1,0 +1,1 @@
+# Reinstate fixedLineHeight = true for tableField Input field needs this to stay in sync


### PR DESCRIPTION
the input field needs fixedLineHeight for syncing to tableField