### PR TITLE
[Tests] Corrected default value of fixedlineheight in table field

### DIFF
--- a/tests/core/objectprops/objectdefaultprops.livecodescript
+++ b/tests/core/objectprops/objectdefaultprops.livecodescript
@@ -863,7 +863,7 @@ on TestTableFieldDefaultProps
    put "true" into tPropsA["dontWrap"]
    put empty into tPropsA["dropShadow"]
    put 0 into tPropsA["firstIndent"]
-   put "false" into tPropsA["fixedLineHeight"]
+   put "true" into tPropsA["fixedLineHeight"]
    put empty into tPropsA["focusColor"]
    put empty into tPropsA["focusPattern"]
    put empty into tPropsA["foreColor"]


### PR DESCRIPTION
The default value of `fixedlineheight` for a table field should be true (see https://github.com/livecode/livecode-ide/pull/1507). 