### PR TITLE
[Bug 17851] Add a default script to scrollbars

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1096,11 +1096,11 @@ end getFirstIndentLevel
 #   The default script that the script editor should use for objects of the specified
 #   type if they have no script set. Returns empty if no default script is to be used.
 function seDefaultScript pObjectType, pStyle
+  # AL-2015-09-21: [[ Bug 15961 ]] Add default mouseup handler to opaque button
+   local tIndent
+   put getFirstIndentLevel() into tIndent
    switch pObjectType
-      case "button"
-         # AL-2015-09-21: [[ Bug 15961 ]] Add default mouseup handler to opaque button
-         local tIndent
-         put getFirstIndentLevel() into tIndent
+    case "button"
          if pStyle is among the items of "standard,rectangle,checkbox,radiobutton,transparent,opaque" then
             return "on mouseUp" & return & tIndent & return & "end mouseUp"
          else if pStyle is "menu" then
@@ -1108,11 +1108,11 @@ function seDefaultScript pObjectType, pStyle
          end if
          break
        case "scrollbar"
-           if pStyle is among the items of "Slider,little arrows,scrollbar" then
+         if pStyle is among the items of "scale,scrollbar" then
             return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return &\
-            "  put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
+            tIndent & "put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
             "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag" 
-            end if
+          end if
           break
       case "widget"
          return revIDEWidgetDefaultScript(pStyle)

--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1109,7 +1109,7 @@ function seDefaultScript pObjectType, pStyle
          break
        case "scrollbar"
            if pStyle is among the items of "Slider,little arrows,scrollbar" then
-            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return & tIndent &\
+            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return & "  " &\
             "put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
             "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag" 
             end if

--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1103,6 +1103,8 @@ function seDefaultScript pObjectType, pStyle
          put getFirstIndentLevel() into tIndent
          if pStyle is among the items of "standard,rectangle,checkbox,radiobutton,transparent,opaque" then
             return "on mouseUp" & return & tIndent & return & "end mouseUp"
+         if pStyle is among the items of "Slider,little arrows,scrollbar" then
+            return "on mouseDown --save the initial value" & return & tIndent & return & "put the thumbPos of me into startValue" & return & "end mouseDown" & return & return & "on scrollbarDrag newValue -- "save the final value" & return & tIndent & return & "end scrollbarDrag"
          else if pStyle is "menu" then
             return "on menuPick pItemName" & return & tIndent & "switch pItemName" & return & tIndent & tIndent & return & tIndent & "end switch" & return & "end menuPick"
          end if

--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1104,7 +1104,9 @@ function seDefaultScript pObjectType, pStyle
          if pStyle is among the items of "standard,rectangle,checkbox,radiobutton,transparent,opaque" then
             return "on mouseUp" & return & tIndent & return & "end mouseUp"
          if pStyle is among the items of "Slider,little arrows,scrollbar" then
-            return "on mouseDown --save the initial value" & return & tIndent & return & "put the thumbPos of me into startValue" & return & "end mouseDown" & return & return & "on scrollbarDrag newValue -- "save the final value" & return & tIndent & return & "end scrollbarDrag"
+            return "local tStartValue" & return & return & "on mouseDown --save the initial value" & return & tIndent & return &\
+            "put the thumbPos of me into tStartValue" & return & "end mouseDown" & return & return &\
+            "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag"
          else if pStyle is "menu" then
             return "on menuPick pItemName" & return & tIndent & "switch pItemName" & return & tIndent & tIndent & return & tIndent & "end switch" & return & "end menuPick"
          end if

--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1103,13 +1103,17 @@ function seDefaultScript pObjectType, pStyle
          put getFirstIndentLevel() into tIndent
          if pStyle is among the items of "standard,rectangle,checkbox,radiobutton,transparent,opaque" then
             return "on mouseUp" & return & tIndent & return & "end mouseUp"
-         if pStyle is among the items of "Slider,little arrows,scrollbar" then
-            return "local tStartValue" & return & return & "on mouseDown --save the initial value" & return & tIndent & return &\
-            "put the thumbPos of me into tStartValue" & return & "end mouseDown" & return & return &\
-            "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag"
          else if pStyle is "menu" then
             return "on menuPick pItemName" & return & tIndent & "switch pItemName" & return & tIndent & tIndent & return & tIndent & "end switch" & return & "end menuPick"
          end if
+         break
+       case "scrollbar"
+           if pStyle is among the items of "Slider,little arrows,scrollbar" then
+            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return & tIndent & return &\
+            "put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
+            "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag"
+            end if
+          break
       case "widget"
          return revIDEWidgetDefaultScript(pStyle)
          break

--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1109,8 +1109,8 @@ function seDefaultScript pObjectType, pStyle
          break
        case "scrollbar"
            if pStyle is among the items of "Slider,little arrows,scrollbar" then
-            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return & "  " &\
-            "put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
+            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return &\
+            "  put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
             "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag" 
             end if
           break

--- a/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -1109,9 +1109,9 @@ function seDefaultScript pObjectType, pStyle
          break
        case "scrollbar"
            if pStyle is among the items of "Slider,little arrows,scrollbar" then
-            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return & tIndent & return &\
+            return "local sStartValue" & return & return & "on mouseDown --save the initial value" & return & tIndent &\
             "put the thumbPos of me into sStartValue" & return & "end mouseDown" & return & return &\
-            "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag"
+            "on scrollbarDrag newValue -- save the final value" & return & tIndent & return & "end scrollbarDrag" 
             end if
           break
       case "widget"

--- a/notes/bugfix-17851.md
+++ b/notes/bugfix-17851.md
@@ -1,0 +1,1 @@
+# Add default script to scrollbar


### PR DESCRIPTION
Broke long line into multiple shorter ones with line continuation char. Lose spurious quote. Declare local variable "tStartValue" to support strict compilation.