### PR TITLE
[[ Bug 19188 ]] Ensure correct debug context is used when executing in message box

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -1460,14 +1460,22 @@ end revListScriptEditors
 
 # Returns
 #   The long id of the topmost script editor, or empty if there is no script editor open.
-function revTopMostScriptEditor
+function revTopMostScriptEditor pMode
    local tEditors
    put revListScriptEditors() into tEditors
-   if the number of lines of tEditors = 0 then
-      return empty
-   else
+   
+   if pMode is empty then
       return line 1 of tEditors
    end if
+   
+   repeat for each line tEditor in tEditors
+      dispatch "revSEGetMode" to tEditor
+      if the result is pMode then
+         return tEditor
+      end if
+   end repeat
+   
+   return empty
 end revTopMostScriptEditor
 
 function revScriptEditorTemplate

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11316,6 +11316,10 @@ on ideCompileCheck pScript
    return empty
 end ideCompileCheck
 
+function ideIsDebugging
+   return revTopMostScriptEditor("debug") is not empty
+end ideIsDebugging
+
 private command __removeMessageBoxFromDebugContexts @xContexts
    local tTarget
    put the long id of the target into tTarget
@@ -11350,7 +11354,7 @@ command ideDoMessage pScript, pDebugMode
    try
       if pDebugMode then
          local tContext, tScriptEditor
-         put revTopMostScriptEditor() into tScriptEditor
+         put revTopMostScriptEditor("debug") into tScriptEditor
          -- Ensure a user-selected debug context in the script editor is the first
          -- option for execution context in the message box
          if tScriptEditor is not empty then

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11316,6 +11316,28 @@ on ideCompileCheck pScript
    return empty
 end ideCompileCheck
 
+private command __removeMessageBoxFromDebugContexts @xContexts
+   local tTarget
+   put the long id of the target into tTarget
+   local tFirst, tLast, tCount, tObject
+   put 1 into tFirst
+   put 0 into tLast
+   repeat for each line tLine in xContexts
+      add 1 to tCount
+      put item 2 of tLine into tObject
+      if tObject is not empty then
+         put the long id of tObject into tObject
+      end if
+      -- Message box execution always begins with 'returnInField' from the target
+      if item 3 of tLine is "returnInField" and \ 
+            tObject is tTarget then
+         put tCount into tLast
+      end if
+   end repeat
+   
+   delete line tFirst to tLast of xContexts
+end __removeMessageBoxFromDebugContexts
+
 command ideDoMessage pScript, pDebugMode
    ideCompileCheck pScript
    if the result is not empty then
@@ -11327,22 +11349,28 @@ command ideDoMessage pScript, pDebugMode
    local tScriptError
    try
       if pDebugMode then
-         # OK-2010-01-02: Remove the message box itself from the debug context. 
-         # Line 1 will be revDebugDoMessage
-         # Line 2 is revExecuteMessage (message box field)
-         # Line 3 is returnInField (message box field)
-         # Line 4 will hopefully be the user code (assuming of course the message box isnt' changed).
-         # Note that this code is called from both the single and multi-line fields, but luckily they both 
-         # have the same number of calls.
-         local tContext, tContextNumber
-         get revDebuggerContexts()
-         put line 4 of it into tContext
-         
+         local tContext, tScriptEditor
+         put revTopMostScriptEditor() into tScriptEditor
+         -- Ensure a user-selected debug context in the script editor is the first
+         -- option for execution context in the message box
+         if tScriptEditor is not empty then
+            dispatch function "seGetSelectedDebugContext" to tScriptEditor
+            put the result into tContext
+         end if
+         -- Otherwise, remove the chain of message box execution contexts
+         -- from the list, and take the next one.
+         if tContext is empty then
+            local tContexts
+            put revDebuggerContexts() into tContexts
+            __removeMessageBoxFromDebugContexts tContexts
+            put line 1 of tContexts into tContext
+         end if
          local tResult
          revDebuggerDo pScript, tContext
-         get the result
-         put line 1 of it into tResult
-         put line 2 to -1 of it into tScriptError
+         put the result into tResult
+         put line 2 to -1 of tResult into tScriptError
+         put line 1 of tResult into tResult
+         
       else
          do pScript
       end if

--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -71,9 +71,6 @@ on openStack
    unlock messages
    
    --if there is a stack currently being debugged then the debug mode is true, if no stack is currently being debugged then the debug mode is false
-   if the traceStack is not empty 
-   then revIDESetPreference "IDEDebugMode",true
-   else revIDESetPreference "IDEDebugMode",false
    revIDESetActiveStack
    
    revIDESubscribe "idePreferenceChanged:cShowRevolutionStacks"
@@ -586,11 +583,9 @@ command ideMessageBoxExecuteScript pScript
    catch tError
       put empty into tIntelligenceObject
    end try
-   local tDebugMode
-   put the traceStack is not empty into tDebugMode
    
    local tValidScript
-   ideExecuteScript pScript, tDefaultStack, tIntelligenceObject, tDebugMode, tValidScript
+   ideExecuteScript pScript, tDefaultStack, tIntelligenceObject, ideIsDebugging(), tValidScript
    if the result is not empty then
       put ideMessageBoxFormatErrorForDisplay(the result) into field "results" of card lSelectedCard of me
    end if
@@ -628,13 +623,6 @@ end ideMessageBoxFormatErrorForDisplay
 command revIDEUpdateIntelligenceObject
    set the cREVIntelligenceObject of me to revIDEGetPreference("ideMessageBox_intelligenceobject")
 end revIDEUpdateIntelligenceObject
-
-#   Updates the message box mode to reflect whether or not we are debugging something.
-command revMessageBoxUpdateMode
-   if the traceStack is not empty 
-   then revIDESetPreference "IDEDebugMode", true
-   else revIDESetPreference "IDEDebugMode", false
-end revMessageBoxUpdateMode
 
 on ideActiveStacksChanged
    local tCard

--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -587,7 +587,7 @@ command ideMessageBoxExecuteScript pScript
       put empty into tIntelligenceObject
    end try
    local tDebugMode
-   put revIDEGetPreference("IDEDebugMode") into tDebugMode
+   put the traceStack is not empty into tDebugMode
    
    local tValidScript
    ideExecuteScript pScript, tDefaultStack, tIntelligenceObject, tDebugMode, tValidScript

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -716,6 +716,10 @@ function seDebugContexts
 end seDebugContexts
 
 local sDebugContext
+function seGetSelectedDebugContext
+   return sDebugContext
+end seGetSelectedDebugContext
+
 function seGetDebugContext
    local tMode
    revSEGetMode

--- a/notes/bugfix-19188.md
+++ b/notes/bugfix-19188.md
@@ -1,0 +1,1 @@
+# Make outputting debug vars from message box work in all contexts


### PR DESCRIPTION
- If the user has selected a debug context from the dropdown menu in the script editor, this should be the context of message box execution 
- otherwise, use the debug contexts with the chain of contexts leading up to message box execution removed. This chain can vary in length depending on how it was triggered, so replace the magic number of lines with a calculation using 'returnInField' and 'the target'. This means the filtering will work whatever extra handlers are introduced between the returnInField to one of the message box fields.