### PR TITLE
[[ Bug 19181 ]] Ensure tutorial has location set when being skipped

### DIFF
--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -3141,6 +3141,7 @@ on revTutorialRunTutorial pCourse, pTutorial, pLesson, pLocation, pFromStep, pUn
    put pCourse into sRunningInfo["course"]
    put pTutorial into sRunningInfo["tutorial"]
    put pLesson into sRunningInfo["lesson"]
+   put pLocation into sRunningInfo["location"]
    
    if pFromStep is empty then
       put tData["first step"] into pFromStep

--- a/notes/bugfix-19181.md
+++ b/notes/bugfix-19181.md
@@ -1,0 +1,1 @@
+# Ensure tutorial has location set when being skipped


### PR DESCRIPTION
Backport (cherry picked from commit 2bdaf546f705dd74a4073b0a118a2933abe136db)