### PR TITLE
Merge develop 8.1-09.02.2017

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5236,6 +5236,14 @@ on revIDEPropertySet pObjectList, pProperty, pValue, pLockUpdates
          
          # If stack name is changed, use new name when setting edited
          if tStack is tObject and pProperty is "name" then
+            if char 1 to 3 of pValue is "rev" then
+               answer warning "Using rev in the first three characters of a stack name is reserved for use by the LiveCode development environment and advanced users creating Plug-ins. If you use these characters, your stack may not behave as expected."
+            end if
+            if pValue is a number then 
+               beep
+               answer error "You cannot set the name of a stack to a number."
+               exit revIDEPropertySet
+            end if
             put pValue into tStackName
          else
             put the short name of tStack into tStackName

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5236,12 +5236,19 @@ on revIDEPropertySet pObjectList, pProperty, pValue, pLockUpdates
          
          # If stack name is changed, use new name when setting edited
          if tStack is tObject and pProperty is "name" then
+            local tOldName
+            put the short name of tStack into tOldName
             if char 1 to 3 of pValue is "rev" then
-               answer warning "Using rev in the first three characters of a stack name is reserved for use by the LiveCode development environment and advanced users creating Plug-ins. If you use these characters, your stack may not behave as expected."
+               answer warning revIDELocalise("Using rev in the first three characters of a stack name is reserved for use by the LiveCode development environment and advanced users creating Plug-ins. If you use these characters, your stack may not behave as expected.") with revIDELocalise("OK") and revIDELocalise("Cancel")
+               if it is revIDELocalise("Cancel") then
+                  set the name of tStack to tOldName
+                  exit revIDEPropertySet
+               end if
             end if
             if pValue is a number then 
                beep
-               answer error "You cannot set the name of a stack to a number."
+               answer error revIDELocalise("You cannot set the name of a stack to a number.")
+               set the name of tStack to tOldName
                exit revIDEPropertySet
             end if
             put pValue into tStackName

--- a/notes/bugfix-19152.md
+++ b/notes/bugfix-19152.md
@@ -1,0 +1,1 @@
+# Show warning if the new stack name begins with "rev"


### PR DESCRIPTION
Conflict in `revidelibrary.8.livecodescript`, resolved by keeping the `develop` version of this file