### PR TITLE
[Bug 18549] Make sure 'lock cursor' works in the IDE

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -3469,7 +3469,7 @@ resize cursor when the mouse is over a selection handle.
 constant kHandleSize = 5
 
 on ideMouseMove pX, pY, pTarget
-   if the tool is "browse tool" then exit ideMouseMove
+   if the tool is not "pointer tool" then exit ideMouseMove
    
    if pTarget is among the lines of the selectedObjects then
       local tRect

--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -3469,6 +3469,8 @@ resize cursor when the mouse is over a selection handle.
 constant kHandleSize = 5
 
 on ideMouseMove pX, pY, pTarget
+   if the tool is "browse tool" then exit ideMouseMove
+   
    if pTarget is among the lines of the selectedObjects then
       local tRect
       put the rect of pTarget into tRect

--- a/notes/bugfix-18549.md
+++ b/notes/bugfix-18549.md
@@ -1,0 +1,1 @@
+# Make sure `lock cursor` works in the IDE


### PR DESCRIPTION
The `ideMouseMove` is used for setting the cursor to the appropriate 
 resize cursor when the mouse is over a selection handle, so it makes sense only in *edit mode*. It includes an `unlock cursor` command, which prevents any `lock cursor` command to work in a stack script.

This patch fixes this problem by exiting `ideMouseMove` if the tool is not `pointer tool`.
