### PR TITLE
[Bug 18035] Fixed issues in gradient popup stack

### DIFF
--- a/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
@@ -193,6 +193,9 @@ end editorPopup
 after editorPopup pClickLoc
    local tStackName
    put popupStackName() into tStackName
+   if tStackName is in the openstacks then
+      exit editorPopup
+   end if
    create invisible stack tStackName
    dispatch "setAsBehavior" to stack revIDEPaletteResourcePath("behaviors/revinspectorpopupstackbehavior.livecodescript", the long id of stack "revInspector") with the long id of stack tStackName
    set the frameHidden of stack tStackName to true

--- a/Toolset/palettes/inspector/behaviors/revinspectorpopupstackbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectorpopupstackbehavior.livecodescript
@@ -34,6 +34,10 @@ on openStack
    unlock screen
 end openStack
 
+on closeStack
+   send "popupDismissed" to sTarget in 0 millisecs
+end closeStack
+
 on editorValueChanged pProperty, pValue, pLockUpdates
    try
       dispatch "valueChanged" to sTarget with pProperty, pValue

--- a/notes/bugfix-18035.md
+++ b/notes/bugfix-18035.md
@@ -1,0 +1,1 @@
+# Make sure the gradient popup stack is displayed as expected


### PR DESCRIPTION
This patch fixes the following problems:

1. Closing the stack and reopening it resulted in an additional "OK" button 
2. Clicking on the stroke/fill gradient button while the stroke/fill gradient popup stack was already open, resulted in the height of the stack to be increased, as well as a mess in the layout of the stack controls.