### PR TITLE
[Bug 17448] Don't lock messages when going to objects from PB

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -746,7 +746,6 @@ on goToObject pObjectID
       exit goToObject
    end if
    
-   lock messages
    if word 1 of pObjectID is "stack"  then
       if not the visible of pObjectID then show pObjectID
       go pObjectID 
@@ -757,7 +756,6 @@ on goToObject pObjectID
       go ideStackOfObject(pObjectID)
       revIDESelectObjects pObjectID
    end if
-   unlock messages
 end goToObject
 
 ########### Footer actions ############

--- a/notes/bugfix-17448.md
+++ b/notes/bugfix-17448.md
@@ -1,0 +1,1 @@
+# Make sure messages are sent when going to stacks/cards from the Project Browser 


### PR DESCRIPTION
This patch restores the pre-LC8 behavior, where going to a stack/card from the Project Browser caused messages (`openstack` etc) to be sent.