### PR TITLE
[[ Bug 19213 ]] Update database library to set driver path

### DIFF
--- a/Toolset/libraries/revdatabaselibrary.livecodescript
+++ b/Toolset/libraries/revdatabaselibrary.livecodescript
@@ -1,15 +1,19 @@
-﻿script "revdatabaselibrary"
+script "revdatabaselibrary"
 
 on revLoadLibrary
    if the target is not me then
       pass "revLoadLibrary"
    end if	
    insert the script of me into front
-    -- MW-2009-07-09: We only do this if we are in a standalone environment
-    -- ( note that 'runtime' check can be removed if you reading this :o) )
-	if the environment is not "browser" and the environment is not "player" and the environment is not "runtime" then
-   		revDBInit
-   	end if
+
+   -- If we are running in development mode, we must set the driver path
+   if the environment is "development" then
+      if revEnvironmentIsInstalled() then
+         revSetDatabaseDriverPath revEnvironmentExternalsPath() & slash & "Database Drivers"
+      else
+         revSetDatabaseDriverPath revEnvironmentBinariesPath()
+      end if
+   end if
 end revLoadLibrary
 
 on revUnloadLibrary
@@ -2383,27 +2387,3 @@ private command log pMessage
   --put pMessage & return after msg
 end log
 
-# OK-2007-09-24 : Legacy driver support. Rewrote this handler as it seemed to have deprecated code, the old handler is 
-# commented out above.
-command revDBInit
-   try
-      if the environment is "development" then
-         local tDataPath
-         if the cREVUseLegacyDrivers of stack "revPreferences" then
-            put revEnvironmentUserExternalsPath() & "/Legacy/Database Drivers" into tDataPath
-         else
-            put revEnvironmentExternalsPath() & "/Database Drivers" into tDataPath
-         end if
-         
-         local tRootPath
-         put revEnvironmentUserExternalsPath() Into tRootPath
-         if there is a folder tRootPath then 
-            put return & tRootPath & "/Database Drivers" after tDataPath
-         end if
-      else
-         put specialfolderpath("engine") & slash & "Externals/database_drivers" into tDataPath
-      end if
-      
-      revSetDatabaseDriverPath tDataPath
-   end try
-end revDBInit

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1502,9 +1502,11 @@ on revIDEInitialiseIDELibrary
    put "scriptlines" & return & "scriptstatus" & return & "short name" & return & "behavior" & return & "behavior scriptlines" & return & "long id" into sStackPropertiesToRead
    
    ## Load Extensions
+   revInternal__LoadLibrary "revideextensionlibrary"
    revIDEInitialiseExtensions
    
    ## Regenerate dictionary data
+   revInternal__LoadLibrary "revDatabaseLibrary"
    revIDERegenerateBuiltDictionaryData
    
    ## Initialise property library

--- a/tests/standalonebuilder/savingstandalone.livecodescript
+++ b/tests/standalonebuilder/savingstandalone.livecodescript
@@ -36,8 +36,11 @@ end TestTeardown
 private function _TestSavingStandaloneStackScript
 	local tScript
 	put "on startup" & return after tScript
-	put "write the cModified of me to stdout" & return after tScript
+	put "if the cModified of me then" & return after tScript
 	put "quit 0" & return after tScript
+	put "else" & return after tScript
+	put "quit 1" & return after tScript
+	put "end if" & return after tScript
 	put "end startup" & return after tScript
 	put "on savingStandalone" & return after tScript
 	put "set the cModified of me to true" & return after tScript
@@ -89,13 +92,20 @@ on TestSavingStandalone
    TestDiagnostic "location" && tStandalonePath
    TestAssert "standalone in expected location", there is a file tStandalonePath
    
-   local tOutput
-   put shell(quote & tStandalonePath & quote && "-ui") into tOutput
+   local tResult, tShellCmd
+   put quote & tStandalonePath & quote into tShellCmd
+   if the environment contains "command line" then
+      put " -ui" after tShellCmd
+   end if
+   get shell(tShellCmd)
+   put the result into tResult
    
-   TestDiagnostic "shell output" && tOutput
-   
+   if tResult is not empty then
+      TestDiagnostic "standalone quit with" && tResult & ":" && it
+   end if
+      
    TestAssert "savingStandalone side-effect present in standalone", \ 
-   		tOutput is "true"
+   		tResult is empty
    
    revDeleteFolder tDir
 end TestSavingStandalone


### PR DESCRIPTION
This patch ensures that the driver path is set on load of the
database library when loaded into the IDE. Such setup is not
needed in standalones, as they will have appropriate builtin
mappings for the driver components.