### PR TITLE
[Bug 19332] Remove setting realPoints custom prop from revRotatePoly

### DIFF
--- a/Toolset/libraries/revcommonlibrary.livecodescript
+++ b/Toolset/libraries/revcommonlibrary.livecodescript
@@ -559,11 +559,7 @@ command revRotatePoly pGraphic, pAngle
     
     lock screen
     lock messages
-    if the realPoints of pGraphic is empty then
-        put the effective points of pGraphic into tPoints
-    else
-        put the realPoints of pGraphic into tPoints
-    end if
+    put the effective points of pGraphic into tPoints
     put the loc of pGraphic into tLoc
     put item 1 of tLoc into tOrigLeft
     put item 2 of tLoc into tOrigTop
@@ -582,7 +578,6 @@ command revRotatePoly pGraphic, pAngle
         set the style of pGraphic to "polygon"
     end if
     set points of pGraphic to tFinalPoints
-    set the realPoints of pGraphic to tFinalPoints
     set loc of pGraphic to tLoc
     unlock messages
     unlock screen

--- a/notes/bugfix-19332.md
+++ b/notes/bugfix-19332.md
@@ -1,0 +1,1 @@
+# Make sure revRotatePoly respects the "angle" param after resetting the points of the graphic


### PR DESCRIPTION
The `realPoints` custom prop was set when calling `revRotatePoly` on a graphic. This resulted in the following unexpected behavior:

Use-case:
1. Reset the `points` of a graphic
2. Rotate the graphic by X degrees
3. Reset the `points`
4. Rotate again by X degrees

OBSERVED RESULT: The graphic was rotated by 2*X degrees, since the `realPoints` prop was not reset, so the new rotation started from the existing `realPoints`. This patch removes this custom prop, since:
- it is not used in other places than `revRotatePoly`
- it is not documented
- the user is not expected to reset the `realPoints` too when resetting the `points`