### PR TITLE
[[ Tests ]] Fix sqlite standalone inclusion test

### DIFF
--- a/tests/standalonebuilder/externals/sqlite.livecodescript
+++ b/tests/standalonebuilder/externals/sqlite.livecodescript
@@ -1,7 +1,7 @@
 ﻿script "TestRevSqlite"
 on _testInclusion
   get revOpenDatabase("sqlite","test.db")
-  if not (it begins with "dberr") then
+  if not (it begins with "revdberr") then
 	 quit 0
   else
 	 write "error - " & it to stderr


### PR DESCRIPTION
This patch corrects the string to check for in the event of the
database driver not being found - it should be 'revdberr' and not
'dberr'.