### PR TITLE
[[ Message Box ]] Ensure compile errors and exec errors are distinguished

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11122,7 +11122,7 @@ end __publicScriptHandlers
 
 private command __tryToDoScriptInObject pObject, pToDo, @rValidScript
    if pObject is empty then
-      return "No such object"
+      return empty
    end if
    
    local tHandlerList
@@ -11175,22 +11175,22 @@ private command __tryToDoScriptInObject pObject, pToDo, @rValidScript
          exit repeat
       end if
    end repeat
-   
-   local tError
+
+   local tCompileError
    ideCompileCheck tDoScript
-   put the result into tError
-   if tError is empty then
-      try
-         send "-- execute in object context" & return & tDoScript to pObject
-      catch tError
-         
-      end try
-   end if
-   if tError is empty then
-      put tDoScript into rValidScript
+   put the result into tCompileError
+   if tCompileError is not empty then
+      return tCompileError for error
    end if
    
-   return tError
+   local tScriptError
+   try
+      send "-- execute in object context" & return & tDoScript to pObject
+   catch tScriptError
+      return tScriptError for value
+   end try
+   
+   put tDoScript into rValidScript
 end __tryToDoScriptInObject
 
 command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode, @rValidScript
@@ -11202,27 +11202,30 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
    
    if pScript is empty then exit ideExecuteScript
    
-   # Try executing as a command first
-   if word 1 of pScript is among the lines of the commandNames then
-      ideDoMessage pScript, pDebugMode
-      if the result is empty then
-         put pScript into rValidScript
-         return empty
-      end if
-   end if
+   local tCompileError
    
    -- check if word 1 of pScript is a handler in the intelligence object's script or the default stack's script
    local tValidScript
    __tryToDoScriptInObject pIntelligenceObject, pScript, tValidScript
-   if the result is not empty then
+   if tValidScript is empty then
       __tryToDoScriptInObject the long id of this card of the defaultStack, pScript, tValidScript
    end if
    
-   if the result is empty then
+   if tValidScript is not empty then
       put tValidScript into rValidScript
-      return empty
+      return it for value
    end if
    put empty into tValidScript
+   
+   # Try executing as a command
+   if word 1 of pScript is among the lines of the commandNames then
+      ideDoMessage pScript, pDebugMode
+      put the result into tCompileError
+      if tCompileError is empty then
+         put pScript into rValidScript
+         return it for value
+      end if
+   end if
    
    --deals with the put command, if the put command cannot be executed as is then:
    --the message box will attempt to auto complete the typing of a name of an object property and the contents of that property into the results area
@@ -11250,7 +11253,8 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
       # Try as an object property of the intelligence object
       if tValidScript is empty and tIsProperty and pIntelligenceObject is not empty then
          ideDoMessage tTryProperty && "of" && pIntelligenceObject, pDebugMode
-         if the result is empty then 
+         put the result into tCompileError
+         if tCompileError is empty then
             local tName
             # pIntelligence object may be a bad reference or no longer exist
             try
@@ -11268,7 +11272,8 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
       if tValidScript is empty then
          if tIsProperty or word 3 of tTryProperty is among the lines of the functionNames then
             ideDoMessage tTryProperty, pDebugMode
-            if the result is empty then
+            put the result into tCompileError
+            if tCompileError is empty then
                put tTryProperty into tValidScript
             end if
          end if
@@ -11284,7 +11289,8 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
       # Try as a boolean expression
       if tValidScript is empty then
          ideDoMessage tBooleanExpression, pDebugMode
-         if the result is empty then
+         put the result into tCompileError
+         if tCompileError is empty then
             put tBooleanExpression into tValidScript
          end if
       end if
@@ -11294,18 +11300,19 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
    # Otherwise just try as is and ensure we get the correct error
    if tValidScript is empty then
       ideDoMessage pScript, pDebugMode
-      if the result is empty then 
+      put the result into tCompileError
+      if tCompileError is empty then 
          put pScript into tValidScript
       end if
    end if
    
    if tValidScript is empty then
-      return the result
+      return tCompileError for error
    end if
    unlock screen
    
    put tValidScript into rValidScript
-   return empty
+   return it for value
 end ideExecuteScript
 
 /** 
@@ -11361,7 +11368,7 @@ end __removeMessageBoxFromDebugContexts
 command ideDoMessage pScript, pDebugMode
    ideCompileCheck pScript
    if the result is not empty then
-      return "compile error" & return & the result
+      return the result for error
    end if
    
    do "global" && the globals
@@ -11397,10 +11404,7 @@ command ideDoMessage pScript, pDebugMode
    catch tScriptError
    end try
    
-   if tScriptError is not empty then
-      put "execution error" & return before tScriptError
-   end if
-   return tScriptError
+   return tScriptError for value
 end ideDoMessage
 
 private function menuitemEscape pItem, pFirst

--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -587,20 +587,21 @@ command ideMessageBoxExecuteScript pScript
    local tValidScript
    ideExecuteScript pScript, tDefaultStack, tIntelligenceObject, ideIsDebugging(), tValidScript
    if the result is not empty then
-      put ideMessageBoxFormatErrorForDisplay(the result) into field "results" of card lSelectedCard of me
+      put ideMessageBoxFormatErrorForDisplay(the result, "compile error") into field "results" of card lSelectedCard of me
+   else if it is not empty then
+      put ideMessageBoxFormatErrorForDisplay(it, "execution error") into field "results" of card lSelectedCard of me
    end if
    
    return tValidScript
 end ideMessageBoxExecuteScript 
    
-function ideMessageBoxFormatErrorForDisplay pErrorTrace
+function ideMessageBoxFormatErrorForDisplay pErrorTrace, pErrorType
    --if there is an error, then this will be formatted and then displayed in the results field
    ##GH : will need localising
-   local tError, tErrorDisplay, tLineNum, tErrorType
-   put line 1 of pErrorTrace into tErrorType
-   put line 2 of pErrorTrace into tError
+   local tError, tErrorDisplay, tLineNum
+   put line 1 of pErrorTrace into tError
    if item 1 of tError is a number and item 1 of tError >= 0 then
-      if tErrorType is "compile error" then
+      if pErrorType is "compile error" then
          put item 1 of line 1 of tError into tLineNum
          --put revIDELocalisedConstructedString("Script compile error:" & cr & "Error description: [error]",revIDELookupError("compilation",tLineNum)) into tErrorDisplay
          put "Script compile error:" & cr & "Error description:" && revIDELookupError("compilation", tLineNum) into tErrorDisplay

--- a/notes/bugfix-19480.md
+++ b/notes/bugfix-19480.md
@@ -1,0 +1,1 @@
+# Ensure message box execution succeeds first time if no compile error

--- a/tests/messagebox/errors.livecodescript
+++ b/tests/messagebox/errors.livecodescript
@@ -34,11 +34,68 @@ on TestTeardown
 end TestTeardown
 
 on TestBug17380
-   // An error is thrown when running this test due to bug 17465
-   /*
    revIDELaunchResource("sample stacks")
    MessageBoxIsEmpty
    
    TestAssert "message box is empty after opening revOnline stack", the result
-   */
 end TestBug17380
+
+on TestMessageBoxCompileError
+   local tValidScript, tScript
+   // Should be "if true then..."
+   put "if true ten go home" into tScript
+   
+   ideExecuteScript tScript, empty, empty, false, tValidScript
+   TestAssert "execute script with compile error result", line 1 of the result is "189,2,4,ten"
+   TestAssert "execute script with compile error script invalid", tValidScript is empty
+end TestMessageBoxCompileError
+
+on TestMessageBoxExecutionError
+   local tValidScript, tScript
+   put "edit the script of stack nonexistent" into tScript
+   
+   ideExecuteScript tScript, empty, empty, false, tValidScript
+   TestAssert "execute script with script error result", line 1 of it is "91,11401,1"
+   TestAssert "execute script with script error script invalid", tValidScript is tScript
+end TestMessageBoxExecutionError
+
+on TestMessageBoxExecuteMultipleWithError
+   local tValidScript, tScript
+   put "put foo; throw bar" into tScript
+   
+   ideExecuteScript tScript, empty, empty, false, tValidScript
+   TestAssert "execute multiline script with script error result", msg is "foo"
+   TestAssert "execute multiline script with compile error script invalid", tValidScript is tScript
+end TestMessageBoxExecuteMultipleWithError
+
+-- Bug 17863
+on TestIntelligenceObjectGetNonExistentFunction
+   local tStack
+	create stack
+	put it into tStack
+	
+   local tToExecute, tValidScript
+	put "get aNonExistentFunction()" into tToExecute
+	
+	ideExecuteScript tToExecute, empty, tStack, false, tValidScript
+	
+	TestAssert "intelligence object non-existent function result", line 1 of it is "219,11400,4,aNonExistentFunction"
+	TestAssert "intelligence object non-existent function executed", tValidScript is tToExecute
+end TestIntelligenceObjectGetNonExistentFunction
+
+-- Bug 17241
+on TestIntelligenceObjectPutFunctionWithParamError
+	local tScript
+	put "function valueFunction pParam; return pParam; end valueFunction" into tScript
+
+	local tStack
+	create stack
+	put it into tStack
+	set the script of tStack to tScript
+
+	local tValidScript
+
+	ideExecuteScript "put valueFunction(hello world)", empty, tStack, false, tValidScript
+	TestAssert "intelligence object put function with multi-segment param error", the result is "126,2,19,world"
+	TestAssert "intelligence object put function with multi-segment param invalid", tValidScript is empty
+end TestIntelligenceObjectPutFunctionWithParamError

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -248,23 +248,6 @@ on TestIntelligenceObjectPutFunctionWithParam
 	TestAssert "intelligence object put function with single segment param with spaces", msg is "hello world"
 end TestIntelligenceObjectPutFunctionWithParam
 
--- Bug 17241
-on TestIntelligenceObjectPutFunctionWithParamError
-	local tScript
-	put "function valueFunction pParam; return pParam; end valueFunction" into tScript
-
-	local tStack
-	create stack
-	put it into tStack
-	set the script of tStack to tScript
-
-	local tValidScript
-
-	ideExecuteScript "put valueFunction(hello world)", empty, tStack, false, tValidScript
-	TestAssert "intelligence object put function with multi-segment param error", the result contains "error"
-	TestAssert "intelligence object put function with multi-segment param invalid", tValidScript is empty
-end TestIntelligenceObjectPutFunctionWithParamError
-
 on TestIntelligenceObjectPropertyCompleted
 	local tButton, tButtonName
 	create button
@@ -315,18 +298,3 @@ on TestIntelligenceObjectCommandWithTwoParams
 	TestAssert "intelligence object command two params result", msg is 2
 	TestAssert "intelligence object command two params executed", tValidScript is tToExecute
 end TestIntelligenceObjectCommandWithTwoParams
-
--- Bug 17863
-on TestIntelligenceObjectGetNonExistantFunction
-   local tStack
-	create stack
-	put it into tStack
-	
-   local tToExecute, tValidScript
-	put "get aNonExistantFunction()" into tToExecute
-	
-	ideExecuteScript tToExecute, empty, tStack, false, tValidScript
-	
-	TestAssert "intelligence object non-existant function result", the result contains "error"
-	TestAssert "intelligence object non-existant function executed", tValidScript is empty
-end TestIntelligenceObjectGetNonExistantFunction


### PR DESCRIPTION
In particular, once a script in the message box has been modified such
that it compiles correctly, it should execute that script and return
regardless of script execution error.