### PR TITLE
[Bug 18201] Make sure rulers can be hidden

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -8659,7 +8659,7 @@ on revIDEToggle pProperty
       case "Rulers"
          put "rulers" into tToggleMessage
          if the mode of stack "revRulersH" is not 0 then
-            revInternal__UnloadLibrary "revRulersScript"
+            revInternal__UnloadLibrary "revRulersScriptLibrary"
             lock messages
             close stack "revRulersH"
             close stack "revRulersV"

--- a/notes/bugfix-18201.md
+++ b/notes/bugfix-18201.md
@@ -1,0 +1,1 @@
+# Make sure rulers can be hidden


### PR DESCRIPTION
An incorrect library name was preventing the rulers library to be unloaded, thus the rulers could not be hidden.