### PR TITLE
[[ Bug 19564 ]] Defer deletion of script tab

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsescripttabsbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsescripttabsbehavior.livecodescript
@@ -759,7 +759,7 @@ private command contextMenuPick pItemName
    
    switch pItemName
       case "Close tab"
-         revSERemoveTargetObject sTabMap[tTabNumber]
+         deleteTab tTabNumber
          break
          
       case "Close other tabs"
@@ -807,7 +807,7 @@ private command contextMenuPick pItemName
          lock screen
          local tObjectToMove
          put sTabMap[tTabNumber] into tObjectToMove
-         revSERemoveTargetObject tObjectToMove
+         deleteTab tTabNumber
          revEditScriptInNewWindow tObjectToMove
          break
          

--- a/Toolset/palettes/script editor/behaviors/revsescripttabsbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsescripttabsbehavior.livecodescript
@@ -882,7 +882,7 @@ on mouseUp pButtonNumber
    
    if the long id of the target is the long id of button "Close" of me then
       lock screen
-      revSERemoveTargetObject sTabMap[sSelectedTab]
+      deleteTab sSelectedTab
       unlock screen
       exit mouseUp
    end if
@@ -915,7 +915,7 @@ on mouseUp pButtonNumber
       
       # The icon on the left of the tabs is a close button
       if the short name of the target is "Tab Icon" then
-         revSERemoveTargetObject sTabMap[tClickedTabNumber]
+         deleteTab tClickedTabNumber
       else
          # Clicking anywhere else in the tab selects it
 
@@ -931,6 +931,10 @@ on mouseUp pButtonNumber
    end if
    unlock screen
 end mouseUp
+
+private command deleteTab pWhich
+   send "revSERemoveTargetObject sTabMap[pWhich]" to me in 0 millisecs
+end deleteTab
 
 private command updateToggleIcon
    local tMode

--- a/notes/bugfix-19564.md
+++ b/notes/bugfix-19564.md
@@ -1,0 +1,1 @@
+# Prevent error when deleting script editor tab


### PR DESCRIPTION
The script tab group gets deleted in a mouseUp handler of one of
its children, which causes an exec error. This patch defers the
deletion to after the mouseUp has been handled, using `send ...
in 0 millisecs`