### PR TITLE
[[ Bug 19264 ]] Clean up message box error display

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11631,6 +11631,7 @@ function revIDEObjectIsOpen pLongID
 end revIDEObjectIsOpen
 
 constant kExtensionErrorCode = 863
+constant kExternalHandlerErrorCode = 634
 /**
 Returns the error description associated with the given 
 error code.
@@ -11654,6 +11655,8 @@ function revIDELookupError pType, pError
          put item 4 to -1 of line 3 of pError into tFile
          put item 4 to -1 of line 4 of pError into tLine
          return merge("LCB Error in file [[tFile]] at line [[tLine]]: [[tDesc]]")
+      else if tCode is kExternalHandlerErrorCode then
+         return "External handler execution error:" && item 4 to -1 of line 1 of pError
       end if
       return line tCode of the scriptExecutionErrors
    else if pType is "warning" then

--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -601,18 +601,11 @@ function ideMessageBoxFormatErrorForDisplay pErrorTrace, pErrorType
    local tError, tErrorDisplay, tLineNum
    put line 1 of pErrorTrace into tError
    if item 1 of tError is a number and item 1 of tError >= 0 then
-      if tErrorType is "compile error" then
-         --put revIDELocalisedConstructedString("Script compile error:" & cr & "Error description: [error]",revIDELookupError("compilation",tLineNum)) into tErrorDisplay
-         put "Script compile error:" & cr & "Error description:" && revIDELookupError("compilation", tError) into tErrorDisplay
+      if pErrorType is "compile error" then
+         put "Script compile error:" & cr & "Error description:" && revIDELookupError("compilation", pErrorTrace) into tErrorDisplay
       else
-         if item 1 of tError is kExternalErrorCode then
-            --put revIDELocalisedConstructedString("External execution error:" & cr & "Error description: [error]",item 4 to -1 of line 1 of tError) into tErrorDisplay
-            put "External execution error:" & cr & "Error description:" && item 4 to -1 of line 1 of tError into tErrorDisplay
-         else 
-            --put revIDELocalisedConstructedString("Message execution error:" & cr & "Error description: [error]" & cr & "Hint: [hint]",revIDELookupError("execution", (item 1 of line 1 of tError)),item 4 to -1 of line 1 of tError) into tErrorDisplay
-            put "Message execution error:" & cr & "Error description:" && revIDELookupError("execution", tError)  & cr & \
-                  "Hint:" && item 4 to -1 of line 1 of tError into tErrorDisplay
-         end if
+         put "Message execution error:" & cr & "Error description:" && revIDELookupError("execution", pErrorTrace)  & cr & \
+               "Hint:" && item 4 to -1 of line 1 of tError into tErrorDisplay
       end if
    else
       put tError into tErrorDisplay


### PR DESCRIPTION
https://github.com/livecode/livecode-ide/pull/1573 only partially fixed the display of LCB errors - this patch ensures the whole error is passed through to the IDE library to format the error correctly when it is thrown from execution in the message box.

It also fixes an issue with external handler errors from the message box, that were previously not being handled.