### PR TITLE
[[ Bug 19480 ]] Overhaul message box execution

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11354,10 +11354,22 @@ private command __removeMessageBoxFromDebugContexts @xContexts
    delete line tFirst to tLast of xContexts
 end __removeMessageBoxFromDebugContexts
 
+function ideDeclaredGlobalVariables
+   -- Return globals without 'each' or any of the env vars
+   local tGlobals
+   put the globals into tGlobals
+   replace comma with return in tGlobals
+   filter tGlobals without "$*"
+   filter tGlobals without "each"
+   return tGlobals
+end ideDeclaredGlobalVariables
+
 command ideDoMessage pScript, pDebugMode, pObject
-   do "global" && the globals
+   local tScriptError, tGlobals
+   put ideDeclaredGlobalVariables() into tGlobals
+   replace return with comma in tGlobals
+   put "global" && tGlobals & return before pScript
    
-   local tScriptError
    try
       if pDebugMode then
          local tContext, tScriptEditor
@@ -11386,7 +11398,8 @@ command ideDoMessage pScript, pDebugMode, pObject
          if pObject is empty then
             put the long id of this card of this stack into pObject
          end if
-         send "-- execute in object context" & return & pScript to pObject
+         send "-- execute in object context" & return & \
+               pScript to pObject
       end if
    catch tScriptError
    end try

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11104,11 +11104,18 @@ end revIDEGetGeometry
 
 private function __publicScriptHandlers pObject
    local tScript, tHandlers
+   repeat while pObject is not empty
    try
-      put the script of pObject into tScript
+         put the script of pObject & return after tScript
+         put the owner of pObject into pObject
    catch tError
-      return empty
+         exit repeat
    end try
+   end repeat
+   
+   if tScript is empty then
+      return empty
+   end if
    
    repeat for each line tLine in tScript
       if token 1 of tLine is among the items of "on,command" then
@@ -11121,7 +11128,7 @@ private function __publicScriptHandlers pObject
    return tHandlers
 end __publicScriptHandlers
 
-private command __tryToDoScriptInObject pObject, pToDo, @rValidScript
+private command __TryToAutocompleteScript pObject, pScript, @rNewScript
    if pObject is empty then
       return empty
    end if
@@ -11138,20 +11145,20 @@ private command __tryToDoScriptInObject pObject, pToDo, @rValidScript
    -- Check to see if any handler in the message path matches the executed script
    
    local tTargetHandler, tIsPutOrGet
-   put token 1 of pToDo into tTargetHandler
+   put token 1 of pScript into tTargetHandler
    put false into tIsPutOrGet
    if tTargetHandler is among the items of "put,get" then
       put true into tIsPutOrGet
-      if token 2 of pToDo is "the" then
-         put token 3 of pToDo into tTargetHandler
+      if token 2 of pScript is "the" then
+         put token 3 of pScript into tTargetHandler
       else
-         put token 2 of pToDo into tTargetHandler
+         put token 2 of pScript into tTargetHandler
       end if
    end if
    
-   local tDoScript
-   put pToDo into tDoScript
-   set the itemdelimiter to ";"
+   local tDoScript, tFound
+   put false into tFound
+   put pScript into tDoScript
    repeat for each line tLine in tHandlerList
       local tHandlerName, tHandlerType
       put segment 1 of tLine into tHandlerType
@@ -11163,68 +11170,61 @@ private command __tryToDoScriptInObject pObject, pToDo, @rValidScript
       local tParams
       if not tIsPutOrGet and tHandlerType is "M" then
          -- If this is a command that matches, just send the message
-         put pToDo into tDoScript
+         put pScript into tDoScript
+         put true into tFound
          exit repeat
       else if tHandlerType is "F" then
          -- otherwise this is a function that matches
          if tIsPutOrGet then
-            put pToDo into tDoScript
+            put pScript into tDoScript
          else
             -- autocomplete the 'put' if necessary
-            put "put" && pToDo into tDoScript
+            put "put" && pScript into tDoScript
          end if
+         put true into tFound
          exit repeat
       end if
    end repeat
 
-   local tCompileError
-   ideCompileCheck tDoScript
-   put the result into tCompileError
-   if tCompileError is not empty then
-      return tCompileError for error
-   end if
-   
-   local tScriptError
-   try
-      send "-- execute in object context" & return & tDoScript to pObject
-   catch tScriptError
-      return tScriptError for value
-   end try
-   
-   put tDoScript into rValidScript
-end __tryToDoScriptInObject
+   put tDoScript into rNewScript
+   return tFound
+end __TryToAutocompleteScript
 
-command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode, @rValidScript
-   local tOldDefault
-   put the defaultStack into tOldDefault
-   if pDefaultStack is not empty then
-      set the defaultStack to pDefaultStack
-   end if
+command ideExecuteScript pScript, pObject, pDebugMode, @rValidScript
+   local tDefaultStack
+   put the defaultStack into tDefaultStack
    
    if pScript is empty then exit ideExecuteScript
    
-   local tCompileError
+   if pObject is empty then
+      put the long id of this card of the defaultStack into pObject
+   else if word 1 of pObject is "stack" then
+      set the defaultStack to the short name of pObject
+      put the long id of this card of pObject into pObject
+   end if
    
    -- check if word 1 of pScript is a handler in the intelligence object's script or the default stack's script
-   local tValidScript
-   __tryToDoScriptInObject pIntelligenceObject, pScript, tValidScript
-   if tValidScript is empty then
-      __tryToDoScriptInObject the long id of this card of the defaultStack, pScript, tValidScript
-   end if
+   local tScript, tValidScript, tCompileError, tOriginalCompileError
+   ideCompileCheck pScript
+   put the result into tOriginalCompileError
    
-   if tValidScript is not empty then
-      put tValidScript into rValidScript
-      return it for value
-   end if
-   put empty into tValidScript
-   
-   # Try executing as a command
-   if word 1 of pScript is among the lines of the commandNames then
-      ideDoMessage pScript, pDebugMode
+   __TryToAutocompleteScript pObject, pScript, tScript
+   -- If we found a handler already, just execute the script
+   if the result is true then
+      ideCompileCheck tScript
       put the result into tCompileError
       if tCompileError is empty then
-         put pScript into rValidScript
-         return it for value
+         put tScript into tValidScript
+      end if
+   end if
+   
+   # Try executing as a command
+   if tValidScript is empty and \ 
+         word 1 of tScript is among the lines of the commandNames then
+      ideCompileCheck tScript
+      put the result into tCompileError
+      if tCompileError is empty then
+         put tScript into tValidScript
       end if
    end if
    
@@ -11233,33 +11233,44 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
    --where the intelligence object has been set in the preferences (currently selected object or the object directly underneath the mouse) ;s
    lock screen
    
-   if not (token 1 of pScript is "get") then
+   if tValidScript is empty and not (token 1 of tScript is "get") then
       # Try executing as a function or property
       local tTryProperty
       
       # Build the string so that it starts with "put the"
-      if not (token 1 of pScript is "the") then
-         put "the" && pScript into tTryProperty 
+      if not (token 1 of tScript is "the") then
+         put "the" && tScript into tTryProperty 
       else
-         put pScript into tTryProperty
+         put tScript into tTryProperty
       end if
       if not (token 1 of tTryProperty is "put ") then
          put "put " before tTryProperty 
       end if
       
       set the wholeMatches to true
-      local tIsProperty
-      put word 3 of tTryProperty is among the lines of the propertyNames into tIsProperty
+      local tIsProperty, tToken
+      put word 3 of tTryProperty into tToken
+      put tToken is among the lines of the propertyNames into tIsProperty
       
-      # Try as an object property of the intelligence object
-      if tValidScript is empty and tIsProperty and pIntelligenceObject is not empty then
-         ideDoMessage tTryProperty && "of" && pIntelligenceObject, pDebugMode
+      # Try as a function or global property
+      if tIsProperty or tToken is among the lines of the functionNames then
+         ideCompileCheck tTryProperty
+         put the result into tCompileError
+         if tCompileError is empty then
+            put tTryProperty into tValidScript
+         end if
+      end if
+      
+      # If it wasn't valid as an object property of the intelligence object
+      # then try as an object property of the intelligence object
+      if tValidScript is empty and tIsProperty and pObject is not empty then
+         ideCompileCheck tTryProperty && "of" && pObject
          put the result into tCompileError
          if tCompileError is empty then
             local tName
             # pIntelligence object may be a bad reference or no longer exist
             try
-               put the name of pIntelligenceObject into tName
+               put the name of pObject into tName
             catch tError
             end try
             if tError is empty then
@@ -11268,52 +11279,29 @@ command ideExecuteScript pScript, pDefaultStack, pIntelligenceObject, pDebugMode
          end if
       end if
       
-      # If it wasn't valid as an object property of the intelligence object
-      # then try as a function or global property
-      if tValidScript is empty then
-         if tIsProperty or word 3 of tTryProperty is among the lines of the functionNames then
-            ideDoMessage tTryProperty, pDebugMode
-            put the result into tCompileError
-            if tCompileError is empty then
-               put tTryProperty into tValidScript
-            end if
-         end if
-      end if
-      
       ## If not a function, global property or object property then
       ## try as a boolean expression
+      if tValidScript is empty then     
       local tBooleanExpression
-      
       # Build the string so that it starts with "put"
-      put "put" && pScript into tBooleanExpression 
-      
-      # Try as a boolean expression
-      if tValidScript is empty then
-         ideDoMessage tBooleanExpression, pDebugMode
+         put "put" && tScript into tBooleanExpression 
+         ideCompileCheck tBooleanExpression
          put the result into tCompileError
          if tCompileError is empty then
             put tBooleanExpression into tValidScript
          end if
       end if
-      
-   end if
-   
-   # Otherwise just try as is and ensure we get the correct error
-   if tValidScript is empty then
-      ideDoMessage pScript, pDebugMode
-      put the result into tCompileError
-      if tCompileError is empty then 
-         put pScript into tValidScript
-      end if
    end if
    
    if tValidScript is empty then
-      return tCompileError for error
+      return tOriginalCompileError for error
    end if
    unlock screen
+   set the defaultStack to tDefaultStack
    
    put tValidScript into rValidScript
-   return it for value
+   ideDoMessage tValidScript, pDebugMode, pObject
+   return the result for value
 end ideExecuteScript
 
 /** 
@@ -11366,12 +11354,7 @@ private command __removeMessageBoxFromDebugContexts @xContexts
    delete line tFirst to tLast of xContexts
 end __removeMessageBoxFromDebugContexts
 
-command ideDoMessage pScript, pDebugMode
-   ideCompileCheck pScript
-   if the result is not empty then
-      return the result for error
-   end if
-   
+command ideDoMessage pScript, pDebugMode, pObject
    do "global" && the globals
    
    local tScriptError
@@ -11400,12 +11383,15 @@ command ideDoMessage pScript, pDebugMode
          put line 1 of tResult into tResult
          
       else
-         do pScript
+         if pObject is empty then
+            put the long id of this card of this stack into pObject
+         end if
+         send "-- execute in object context" & return & pScript to pObject
       end if
    catch tScriptError
    end try
    
-   return tScriptError for value
+   return tScriptError
 end ideDoMessage
 
 private function menuitemEscape pItem, pFirst

--- a/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -70,8 +70,13 @@ on openStack
    set the revMessageBoxRedirect to the long id of me
    unlock messages
    
-   --if there is a stack currently being debugged then the debug mode is true, if no stack is currently being debugged then the debug mode is false
-   revIDESetActiveStack
+   local tIntelligence
+   put revIDEGetPreference("ideMessageBox_intelligenceobject") into tIntelligence
+   if tIntelligence is empty then
+      put "selectedObject" into tIntelligence
+   end if
+   revIDESetPreference "ideMessageBox_intelligenceobject", "selectedObject"
+   revIDEUpdateIntelligenceObject
    
    revIDESubscribe "idePreferenceChanged:cShowRevolutionStacks"
    revIDESubscribe "idePreferenceChanged:revPaletteFrameSize"
@@ -438,6 +443,8 @@ on idePreferenceChanged pPreference, pValue
       case "cScriptEditor,editor,fontSize"
          __UpdateMessageFont
          break
+      default
+         break
    end switch
    unlock screen
 end idePreferenceChanged
@@ -581,11 +588,11 @@ command ideMessageBoxExecuteScript pScript
    try
       do "put the long id of the" && tIntelligencePref && "into tIntelligenceObject"
    catch tError
-      put empty into tIntelligenceObject
+      put the long id of stack tDefaultStack into tIntelligenceObject
    end try
    
    local tValidScript
-   ideExecuteScript pScript, tDefaultStack, tIntelligenceObject, ideIsDebugging(), tValidScript
+   ideExecuteScript pScript, tIntelligenceObject, ideIsDebugging(), tValidScript
    if the result is not empty then
       put ideMessageBoxFormatErrorForDisplay(the result, "compile error") into field "results" of card lSelectedCard of me
    else if it is not empty then
@@ -613,16 +620,60 @@ function ideMessageBoxFormatErrorForDisplay pErrorTrace, pErrorType
    return tErrorDisplay
 end ideMessageBoxFormatErrorForDisplay
 
+private command __UpdateIntelligenceDisplay
+   lock screen
+   local tIntelligence
+   put revIDEGetPreference("ideMessageBox_intelligenceobject") into tIntelligence
+   lock messages
+   try
+      do "get the long id of the" && tIntelligence
+   catch tError
+   end try
+   global gRevDevelopment
+   if it is empty or it begins with "stack" or \
+         (not gRevDevelopment and revIDEObjectIsOnIDEStack(it)) then
+      local tCard
+      put the short name of this card of me into tCard
+      if tCard is "Single Line" or tCard is "Multiple Lines" then
+         revIDESetActiveStack
+      end if
+   else
+      local tControl
+      put the name of it into tControl
+      set the label of button "Open Stacks" of group "Stacks" of me to tIntelligence & ": " & tControl
+      enable button "Open Stacks" of group "Stacks" of me
+   end if
+   positionOpenStacksButton
+   unlock messages
+   unlock screen
+end __UpdateIntelligenceDisplay
+
+on ideSelectedObjectChanged
+   __UpdateIntelligenceDisplay
+end ideSelectedObjectChanged
+
+on ideMouseMove
+   __UpdateIntelligenceDisplay
+end ideMouseMove
+
 command revIDEUpdateIntelligenceObject
-   set the cREVIntelligenceObject of me to revIDEGetPreference("ideMessageBox_intelligenceobject")
+   local tIntelligence
+   put revIDEGetPreference("ideMessageBox_intelligenceobject") into tIntelligence
+   
+   if tIntelligence is "selectedObject" then 
+      revIDESubscribe "ideSelectedObjectChanged"
+      revIDEUnsubscribe "ideMouseMove"
+   else if tIntelligence is "mouseControl" then
+      revIDESubscribe "ideMouseMove"
+      revIDEUnsubscribe "ideSelectedObjectChanged"
+   end if
+   
+   set the cREVIntelligenceObject of me to tIntelligence
+   __UpdateIntelligenceDisplay
 end revIDEUpdateIntelligenceObject
 
 on ideActiveStacksChanged
-   local tCard
-   put the short name of this card of me into tCard
-   if tCard is "Single Line" or tCard is "Multiple Lines" then
-      revIDESetActiveStack
-   end if
+   __UpdateIntelligenceDisplay
 end ideActiveStacksChanged
 
 command revIDESetActiveStack

--- a/notes/bugfix-19589.md
+++ b/notes/bugfix-19589.md
@@ -1,0 +1,1 @@
+# Fix 'put globalVar' in msg box

--- a/tests/messagebox/errors.livecodescript
+++ b/tests/messagebox/errors.livecodescript
@@ -45,7 +45,7 @@ on TestMessageBoxCompileError
    // Should be "if true then..."
    put "if true ten go home" into tScript
    
-   ideExecuteScript tScript, empty, empty, false, tValidScript
+   ideExecuteScript tScript, empty, false, tValidScript
    TestAssert "execute script with compile error result", line 1 of the result is "189,2,4,ten"
    TestAssert "execute script with compile error script invalid", tValidScript is empty
 end TestMessageBoxCompileError
@@ -54,7 +54,7 @@ on TestMessageBoxExecutionError
    local tValidScript, tScript
    put "edit the script of stack nonexistent" into tScript
    
-   ideExecuteScript tScript, empty, empty, false, tValidScript
+   ideExecuteScript tScript, empty, false, tValidScript
    TestAssert "execute script with script error result", \
          matchText(line 1 of it, "^91,\d+,1$")
    TestAssert "execute script with script error script invalid", tValidScript is tScript
@@ -64,7 +64,7 @@ on TestMessageBoxExecuteMultipleWithError
    local tValidScript, tScript
    put "put foo; throw bar" into tScript
    
-   ideExecuteScript tScript, empty, empty, false, tValidScript
+   ideExecuteScript tScript, empty, false, tValidScript
    TestAssert "execute multiline script with script error result", msg is "foo"
    TestAssert "execute multiline script with compile error script invalid", tValidScript is tScript
 end TestMessageBoxExecuteMultipleWithError
@@ -78,10 +78,10 @@ on TestIntelligenceObjectGetNonExistentFunction
    local tToExecute, tValidScript
 	put "get aNonExistentFunction()" into tToExecute
 	
-	ideExecuteScript tToExecute, empty, tStack, false, tValidScript
+	ideExecuteScript tToExecute, tStack, false, tValidScript
 	
 	TestAssert "intelligence object non-existent function result", \
-         matchText(line 1 of it, "^219,\d+,4,aNonExistentFunction$")
+         matchText(line 1 of it, "^219,\d+,\d+,aNonExistentFunction$")
 	TestAssert "intelligence object non-existent function executed", tValidScript is tToExecute
 end TestIntelligenceObjectGetNonExistentFunction
 
@@ -97,7 +97,7 @@ on TestIntelligenceObjectPutFunctionWithParamError
 
 	local tValidScript
 
-	ideExecuteScript "put valueFunction(hello world)", empty, tStack, false, tValidScript
+	ideExecuteScript "put valueFunction(hello world)", tStack, false, tValidScript
 	TestAssert "intelligence object put function with multi-segment param error", the result is "126,2,19,world"
 	TestAssert "intelligence object put function with multi-segment param invalid", tValidScript is empty
 end TestIntelligenceObjectPutFunctionWithParamError

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -38,7 +38,7 @@ on TestBug16281
 	create button
 	put the long id of it into tButton
 	
-	ideExecuteScript "hilite" && tButton, empty, empty, false, tValidScript
+	ideExecuteScript "hilite" && tButton, empty, false, tValidScript
 	
 	TestAssert "hilite command in msg box", the hilite of tButton
 end TestBug16281
@@ -58,7 +58,7 @@ on TestBug15832
 	set the defaultStack to the short name of it
 	
 	local tValidScript
-	ideExecuteScript "put the name of button 1; put the name of control 2;", tStack, empty, false, tValidScript
+	ideExecuteScript "put the name of button 1; put the name of control 2;", tStack, false, tValidScript
 
 	TestAssert "; in single line message box", word 1 of msg is "field"
 end TestBug15832
@@ -76,21 +76,21 @@ on TestBug16863
    local tValidScript, tScript
    put "there is a button" && quote & "test" & quote into tScript
    
-   ideExecuteScript tScript, tStack, empty, false, tValidScript
+   ideExecuteScript tScript, tStack, false, tValidScript
    TestAssert "boolean expression value with 'put' prepended", msg is "true"
    TestAssert "boolean expression executed with 'put' prepended", tValidScript is ("put" && tScript)
 end TestBug16863
 
 on TestGlobalPropertyCompleted
 	local tValidScript
-	ideExecuteScript "backdrop", empty, empty, false, tValidScript
+	ideExecuteScript "backdrop", empty, false, tValidScript
 
 	TestAssert "global prop value with 'put the' prepended", msg is "none"
 	TestAssert "global prop executed with 'put the' prepended", tValidScript is "put the backdrop"
 
 	put empty into msg
 
-	ideExecuteScript "the backdrop", empty, empty, false, tValidScript
+	ideExecuteScript "the backdrop", empty, false, tValidScript
 
 	TestAssert "global prop value with 'put' prepended", msg is "none"
 	TestAssert "global prop executed with 'put' prepended", tValidScript is "put the backdrop"
@@ -106,7 +106,10 @@ on TestIntelligenceObjectMultilineCommand
 	set the script of tStack to tScript
 	
 	local tValidScript
-	ideExecuteScript "valueCommand; put the result", empty, tStack, false, tValidScript
+	ideExecuteScript "valueCommand; put the result", tStack, false, tValidScript
+	
+	TestDiagnostic "msg" && msg
+	TestDiagnostic "valid script:" && tValidScript
 	
 	TestAssert "intelligence object multiple command result", msg is "value"
 	TestAssert "intelligence object multiple command executed", tValidScript is "valueCommand; put the result"
@@ -122,7 +125,7 @@ on TestIntelligenceObjectMultilineFunction
 	set the script of tStack to tScript
 	
 	local tValidScript	
-	ideExecuteScript "put valueFunction(); put msg", empty, tStack, false, tValidScript
+	ideExecuteScript "put valueFunction(); put msg", tStack, false, tValidScript
 
 	TestAssert "intelligence object multiple function result", msg is "value"
 	TestAssert "intelligence object multiple function executed", tValidScript is "put valueFunction(); put msg"
@@ -139,14 +142,17 @@ on TestIntelligenceObject
 	set the script of tStack to tScript
 	
 	local tValidScript
-	ideExecuteScript "valueCommand", empty, tStack, false, tValidScript
+	ideExecuteScript "valueCommand", tStack, false, tValidScript
+	
+	TestDiagnostic "cValue:" && the cValue of tStack
+	TestDiagnostic "valid script:" && tValidScript
 	
 	TestAssert "intelligence object command result", the cValue of tStack is "value"
 	TestAssert "intelligence object command executed", tValidScript is "valueCommand"
 	
 	put empty into msg
 	
-	ideExecuteScript "valueFunction()", empty, tStack, false, tValidScript
+	ideExecuteScript "valueFunction()", tStack, false, tValidScript
 	
 	TestAssert "intelligence object function in msg box", msg is "value"
 	TestAssert "intelligence object function executed", tValidScript is "put valueFunction()"
@@ -163,14 +169,14 @@ on TestIntelligenceObjectMultipleCommand
 	set the script of tStack to tScript
 	
 	local tValidScript
-	ideExecuteScript "firstCommand; secondCommand", empty, tStack, false, tValidScript
+	ideExecuteScript "firstCommand; secondCommand", tStack, false, tValidScript
 	
 	TestAssert "intelligence object mutiple commands", the cValue of tStack is "value"
 end TestIntelligenceObjectMultipleCommand
 
 on TestDefaultStackCardScript
 	local tScript
-	put "on preOpenCard; set the cValue of this stack to" && quote & "value" & quote && "; end preOpenCard" into tScript
+	put "on preOpenCard; set the cValue of this stack of me to" && quote & "value" & quote && "; end preOpenCard" into tScript
 
 	local tStack
 	create stack
@@ -178,7 +184,7 @@ on TestDefaultStackCardScript
 	set the script of card 1 of tStack to tScript
 	
 	local tValidScript
-	ideExecuteScript "preOpenCard", tStack, empty, false, tValidScript
+	ideExecuteScript "preOpenCard", tStack, false, tValidScript
 	
 	TestAssert "intelligence object command result", the cValue of tStack is "value"
 	TestAssert "intelligence object command executed", tValidScript is "preOpenCard"
@@ -195,7 +201,7 @@ on TestIntelligenceObjectPutFunction
 	set the script of tStack to tScript
 
 	local tValidScript
-	ideExecuteScript "put valueFunction()", empty, tStack, false, tValidScript
+	ideExecuteScript "put valueFunction()", tStack, false, tValidScript
 	
 	TestAssert "intelligence object put function", msg is "value"
 end TestIntelligenceObjectPutFunction
@@ -211,7 +217,7 @@ on TestIntelligenceObjectGetFunction
 
 	local tValidScript
 
-	ideExecuteScript "get valueFunction(); put it", empty, tStack, false, tValidScript
+	ideExecuteScript "get valueFunction(); put it", tStack, false, tValidScript
 	TestAssert "intelligence object get function result", msg is "value"
 end TestIntelligenceObjectGetFunction
 
@@ -226,7 +232,7 @@ on TestCustomCommandWithStringLiteral
 	
 	local tValidScript, tToExecute
 	put "valueCommand" && quote & "value" & quote into tToExecute
-	ideExecuteScript tToExecute, empty, tStack, false, tValidScript
+	ideExecuteScript tToExecute, tStack, false, tValidScript
 	
 	TestAssert "command with string literal result", the cValue of tStack is "value"
 	TestAssert "command with string literal executed", tValidScript is tToExecute
@@ -255,7 +261,7 @@ on TestIntelligenceObjectPropertyCompleted
 	put the name of tButton into tButtonName
 	
 	local tValidScript
-	ideExecuteScript "width", empty, tButton, false, tValidScript
+	ideExecuteScript "width", tButton, false, tValidScript
 	TestAssert "intelligence object property autocomplete result", the result is empty
 	TestAssert "intelligence object property autocomplete executed", tValidScript is "put the width of" && tButtonName
 end TestIntelligenceObjectPropertyCompleted
@@ -275,7 +281,7 @@ on TestIntelligenceObjectFunctionNotFirstLine
 	put return & "put 1 into z" after tToExecute
 	put return & "put incr(z)" after tToExecute
 	
-	ideExecuteScript tToExecute, empty, tStack, false, tValidScript
+	ideExecuteScript tToExecute, tStack, false, tValidScript
 	
 	TestAssert "intelligence object command result", msg is 2
 	TestAssert "intelligence object command executed", tValidScript is tToExecute
@@ -293,7 +299,7 @@ on TestIntelligenceObjectCommandWithTwoParams
 	local tToExecute, tValidScript
 	put "testParameters 1, 2" into tToExecute
 	
-	ideExecuteScript tToExecute, empty, tStack, false, tValidScript
+	ideExecuteScript tToExecute, tStack, false, tValidScript
 	
 	TestAssert "intelligence object command two params result", msg is 2
 	TestAssert "intelligence object command two params executed", tValidScript is tToExecute


### PR DESCRIPTION
This patch simplifies message box execution by relying exclusively
on compile checking to find the correct form of the script to
execute, and always using the `send <script blob> to obj` form to
execute (in non-debug mode).

The message box has been changed to always display the (single)
context object, either the active stack, selectedObject: <obj>, or
mouseControl <obj>. Thus it is always explicit what the context of
message box execution is.

This also fixes bug 19480 since the latter was caused by the script
being executed a second time after throwing an execution error in
the context of the intelligence object.