### PR TITLE
[[Bug 19585]] Corrects positioning of windows in the Interactive Tuto…

### DIFF
--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -1129,9 +1129,9 @@ command revTutorialSetWindowShape pContentWidth, pContentHeight, pPointVertical,
    create graphic "Shape" in tGroup
    put it into tGraphic
    set the style of it to "rectangle"
-   set the width of it to pContentWidth * the screenpixelscale
-   set the height of it to pContentHeight * the screenpixelscale
-   
+   set the width of it to pContentWidth
+   set the height of it to pContentHeight
+
    create graphic "Pointer" in tGroup
    put it into tPointer
    set the style of tPointer to "regular"

--- a/notes/bugfix-19585.md
+++ b/notes/bugfix-19585.md
@@ -1,0 +1,1 @@
+# Improve rendering of Interactive Tutorial on Windows when screenPixelScale > 1


### PR DESCRIPTION
…rial

Some of the instructional windows in the Interactive Tutorial were
positioned incorrectly on Windows when the screenPixelScale > 1. This was
because the tutorial was unnecessarily compensating for the
screenPixelScale in one place, resulting in the pointer on the instructional
window appearing in the wrong position.