### PR TITLE
[[ Bug 19710 ]] Fix a few variants of message box intelligence

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11198,8 +11198,12 @@ command ideExecuteScript pScript, pObject, pDebugMode, @rValidScript
    
    if pObject is empty then
       put the long id of this card of the defaultStack into pObject
-   else if word 1 of pObject is "stack" then
-      set the defaultStack to the short name of pObject
+   else 
+      set the defaultStack to the short name of ideStackOfObject(pObject)
+   end if
+   
+   -- Need to target 'this card' if a stack is selected
+   if word 1 of pObject is "stack" then
       put the long id of this card of pObject into pObject
    end if
    

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -262,7 +262,7 @@ on TestIntelligenceObjectPropertyCompleted
 	
 	local tValidScript
 	ideExecuteScript "width", tButton, false, tValidScript
-	TestAssert "intelligence object property autocomplete result", the result is empty
+	TestAssert "intelligence object property autocomplete result", msg is the width of tButton
 	TestAssert "intelligence object property autocomplete executed", tValidScript is "put the width of" && tButtonName
 end TestIntelligenceObjectPropertyCompleted
 
@@ -304,3 +304,25 @@ on TestIntelligenceObjectCommandWithTwoParams
 	TestAssert "intelligence object command two params result", msg is 2
 	TestAssert "intelligence object command two params executed", tValidScript is tToExecute
 end TestIntelligenceObjectCommandWithTwoParams
+
+on TestReferenceControlOnActiveStack
+	local tStack, tField
+	create stack
+	put it into tStack
+
+	set the defaultStack to the short name of tStack
+	
+	create field
+	put it into tField
+	
+	-- change the default stack
+	create stack
+	set the defaultStack to the short name of it
+	
+	local tToExecute
+	put "put bar into field 1" into tToExecute
+	ideExecuteScript tToExecute, tStack, false, tValidScript
+	
+	TestAssert "intelligence object command two params result", the text of tField is "bar"
+	TestAssert "intelligence object command two params executed", tValidScript is tToExecute
+end TestReferenceControlOnActiveStack


### PR DESCRIPTION
If a control is the intelligence object, the default stack must be
set to its main stack in order for various object references to
work in the message box.