### PR TITLE
[Bug 17412] Added revDeleteFile command to revCommonLibrary

### DIFF
--- a/Toolset/libraries/revcommonlibrary.livecodescript
+++ b/Toolset/libraries/revcommonlibrary.livecodescript
@@ -962,6 +962,13 @@ on revDeleteFolder pSrcFolder
    return the result
 end revDeleteFolder
 
+on revDeleteFile pWhich
+   close file pWhich
+   if the platform is "MacOS" then put empty into URL ("resfile:"&pWhich)
+   put empty into URL ("binfile:"&pWhich)
+   delete file pWHich
+end revDeleteFile
+
 on revMoveFolder pSrcFolder, pDestFolder
    if the platform is "Win32" then
       revSetWindowsShellCommand


### PR DESCRIPTION
In `revideextensionlibrary` there is a call to `revDeleteFile`, but `revDeleteFile` was only implemented as a private command in `revSaveAsStandalone`.  So when this code was executed (to uninstall an extension), an error was thrown and the extension was not propely removed. This patch moves the implementation of `revDeleteFile` command to `revCommonLibrary`.
