### PR TITLE
[[ Tutorial ]] Use <value> for default placeholder in property wait

### DIFF
--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -674,7 +674,7 @@ on revTutorialParseWait pTokens, @rData
          return empty
       end if
       
-      revTutorialParseSubexpression "the <token> of <object> is changed with default <token>", pTokens, tToken, tCondition
+      revTutorialParseSubexpression "the <token> of <object> is changed with default <value>", pTokens, tToken, tCondition
       
       if the result is empty then
          put "property" into rData["wait condition"]


### PR DESCRIPTION
<token> does not allow empty ("") whereas <value> does, and clearly
"" is a useful default value for `wait until ... is changed`