### PR TITLE
[[ Bug 19824 ]] 'is scripted' step is never 'is not'

### DIFF
--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -2089,7 +2089,7 @@ function revTutorialCheckWaitCondition pActionData
                if revTutorialScriptIs(the script of tObject, sWait["current script"]) then
                   break
                end if
-               if revTutorialObjectPropertyIsValue(tObject, "script", pActionData["script"]) then
+               if revTutorialObjectPropertyIsValue(tObject, "script", pActionData["script"], false) then
                   return true
                else if sWait["current script"] is not empty then
                   add 1 to sWait["incorrect attempts"]


### PR DESCRIPTION
Pass false as the 'is not' parameter to the check that a property
has a given value when the step is an 'is scripted' step - this is
never an 'is not' situation.