### PR TITLE
[[ Bug 19832 ]] Format multi-line msg box on paste

### DIFF
--- a/Toolset/palettes/message box/behaviors/revmessageboxmultiplelinesmessagebehavior.livecodescript
+++ b/Toolset/palettes/message box/behaviors/revmessageboxmultiplelinesmessagebehavior.livecodescript
@@ -29,6 +29,7 @@ on commandKeyDown pKey
    end if
    if pKey is "V" then 
       put clipboardData["text"] into the selectedChunk
+      scriptFormat "script"
    else
       pass commandKeyDown
    end if

--- a/notes/bugfix-19832.md
+++ b/notes/bugfix-19832.md
@@ -1,0 +1,1 @@
+# Format multi-line message box when pasting script


### PR DESCRIPTION
This patch ensures that pasted code is formatted and colorized
correctly.