### PR TITLE
Fixed malformed feature note

### DIFF
--- a/notes/feature-default_mac_64.md
+++ b/notes/feature-default_mac_64.md
@@ -1,1 +1,3 @@
 # The IDE is now 64-bit by default on Mac
+
+Moreover, the "Build for Mac OS X 64-bit" is checked by default on newly created stacks in the standalone settings for OS X. Existing stacks will retain their current settings.


### PR DESCRIPTION
Added some text in the "body" of the feature note, because the release notes builder does not like "empty" feature notes