### PR TITLE
[[ Tutorial ]] Don't show 'Do It For Me' in a popup answer dialog step

### DIFF
--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -877,7 +877,8 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    end if
    
    # If this is a non-script action step, show the 'Do It For Me' button
-   if sIsInterlude or tHasScript then
+   if sIsInterlude or tHasScript or \
+         revTutorialCanSkipStep() is not true then
       hide tDoItButtonID
    else
       put tDoItButtonID into tActionButton
@@ -1935,7 +1936,16 @@ on revTutorialSetContextualStepData pStepDataA
    put pStepDataA["file"] into sStepContextA["file"]
    put pStepDataA["value"] into sStepContextA["value"]
    put pStepDataA["image"] into sStepContextA["image"]
+   if pStepDataA["actions"]["wait"]["wait condition"] is "pops up" then
+      put false into sStepContextA["can skip"]
+   else
+      put true into sStepContextA["can skip"]
+   end if
 end revTutorialSetContextualStepData
+
+function revTutorialCanSkipStep
+   return sStepContextA["can skip"]
+end revTutorialCanSkipStep
 
 ##############################################################################
 #


### PR DESCRIPTION
If a tutorial step is `wait until button <name> pops up answer dialog`, the skipper doesn't know what to pop up or how, as it could be triggered from script when clicking the button (as it is here), or some other way.

So, don't show the option to 'Do It For Me' in this case.