### PR TITLE
[[ Bug 19836 ]] Add stack rect step to Todo list tutorial

### DIFF
--- a/Toolset/palettes/tutorial/courses/First Run/tutorials/To Do List/lessons/App Lesson.txt
+++ b/Toolset/palettes/tutorial/courses/First Run/tutorials/To Do List/lessons/App Lesson.txt
@@ -59,13 +59,22 @@ action
 end step
 
 step "Create Mainstack"
-		Click on the File menu, and select 'New Stack' → 'iPhone 5 (320x568)'.
+	Click on the File menu, and select 'New Stack' → 'iPhone 5 (320x568)'.
 action
     highlight menu item "iPhone 5 (320x568)" of menu item "New Stack" of menu "File"
     capture the next new stack as "Mainstack"
     capture the next new card of stack "Mainstack" as "ToDoList"
     wait until there is a stack "Mainstack"
-		go to step "Properties interlude"
+	go to step "Set Stack Rect"
+end step
+
+step "Set Stack Rect"
+	Resize the stack so that it has width 320 and height 568.
+action
+	add guide "Stack" with rect "0,0,320,568" to stack "Mainstack"
+	highlight guide "Stack"
+	wait until stack "Mainstack" fits guide "Stack" with tolerance 5
+	go to step "Properties interlude"
 end step
 
 step "Properties interlude"


### PR DESCRIPTION
Wait actions for creating stacks don't know about the IDE stack size
choices, so add a step for resizing the stack in case the user
chooses a different size, or decides to skip the step.

The step will be automatically skipped if the user chooses the
indicated size from the menu.