### PR TITLE
[Bug 19887] Correct setter of sObjectID in revSECommonEditorBehavior

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -54,7 +54,7 @@ command getDirty pObject
 end getDirty
 
 command setObjectID pObjectID
-   put revRuggedId(pObjectID) into sObjectID
+   put pObjectID into sObjectID
 end setObjectID
 
 function getObjectID

--- a/notes/bugfix-19887.md
+++ b/notes/bugfix-19887.md
@@ -1,0 +1,1 @@
+# Make sure script loads correctly when Script Editor is not already opened


### PR DESCRIPTION
The script editor behavior was divided in 2 behaviors in PR https://github.com/livecode/livecode-ide/pull/1576.

In the refactored code, any occurrences of `sObjectID` were replaced by its getter and setter, implemented in `revsecommoneditorbehavior.livecodescript`:

The existing setter did:
```
command setObjectID pObjectID
    put revRuggedId(pObjectID) into sObjectID
 end setObjectID
```

So in `command initialize` of `revseeditorbehavior`, there was a line:
```
put empty into sObjectId
```
which was replaced by 
```
setObjectID empty
```

With the existing setter, this resulted in `sObjectID` never actually being empty, so the condition:
```
if getObjectID() is not empty and tRuggedObjectId is getObjectID() then
      if not pDontSendCallbacks then
         seSendCallbacks sObjectId, the name of stack (revTargetStack(the long id of me))
      end if
      exit setObject
   end if
```

was true when the SE was opened for the very first time, so this handler exited before calling `loadScript` thus failing to display the existing script.
