### PR TITLE
[[ Bug 19887 ]] Ensure sObjectID is a rugged id

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -54,7 +54,11 @@ command getDirty pObject
 end getDirty
 
 command setObjectID pObjectID
-   put pObjectID into sObjectID
+   if pObjectID is not empty then
+      put revRuggedId(pObjectID) into sObjectID
+   else
+      put empty into sObjectID
+   end if
 end setObjectID
 
 function getObjectID


### PR DESCRIPTION
In a previous patch it was made possible for sObjectID to
be set to something other than a rugged id or empty.