### PR TITLE
[[ Bug 19890 ]] Remove the possibility of bringing up palettes for incorrect objects

### DIFF
--- a/Toolset/palettes/tutorial/courses/First Run/tutorials/BMI Calculator/lessons/App Lesson.txt
+++ b/Toolset/palettes/tutorial/courses/First Run/tutorials/BMI Calculator/lessons/App Lesson.txt
@@ -90,6 +90,14 @@ action
 	add guide "Stack" with rect "0,0,320,480" to stack "Mainstack"
 	highlight guide "Stack"
 	wait until stack "Mainstack" fits guide "Stack" with tolerance 5
+	go to step "Select Stack For Inspector"
+end step
+
+step "Select Stack For Inspector"
+	Ensure this is the active stack, by clicking on it.
+action
+	highlight stack "Mainstack"
+	wait until stack "Mainstack" is selected
 	go to step "Set Stack Properties"
 end step
 
@@ -162,6 +170,7 @@ step "Select Header 1"
 
 	The selection handles will show around the widget.
 action
+	highlight widget "Header"
 	wait until widget "Header" is selected
 	go to step "Set Header Rect"
 end step
@@ -172,6 +181,16 @@ action
 	add guide "Header" with rect "1,1,319,64" to stack "Mainstack"
 	highlight guide "Header"
 	wait until widget "Header" fits guide "Header" with tolerance 5
+	go to step "Select Header For Inspector"
+end step
+
+step "Select Header For Inspector"
+	Select the header bar widget by clicking on it.
+
+	The selection handles will show around the widget.
+action
+	highlight widget "Header"
+	wait until widget "Header" is selected
 	go to step "Open Property Inspector"
 end step
 
@@ -254,6 +273,7 @@ step "Select Footer 1"
 
 	The selection handles will show around the widget.
 action
+	highlight widget "Footer"
 	wait until widget "Footer" is selected
 	go to step "Set Footer Rect"
 end step
@@ -265,6 +285,16 @@ action
 	add guide "Footer" with rect "1,430,319,479" to stack "Mainstack"
 	highlight guide "Footer"
 	wait until widget "Footer" fits guide "Footer" with tolerance 5
+	go to step "Select Footer For Inspector"
+end step
+
+step "Select Footer For Inspector"
+	Select the navigation bar widget by clicking on it.
+
+	The selection handles will show around the widget.
+action
+	highlight widget "Footer"
+	wait until widget "Footer" is selected
 	go to step "Set Footer Properties"
 end step
 
@@ -324,6 +354,7 @@ step "Select Entry Background 1"
 
 	The selection handles will show around the graphic.
 action
+	highlight graphic "Entry Background"
 	wait until graphic "Entry Background" is selected
 	go to step "Set Entry Background Rect"
 end step
@@ -334,6 +365,16 @@ action
 	add guide "Background" with rect "14,74,308,228" to stack "Mainstack"
 	highlight guide "Background"
 	wait until graphic "Entry Background" fits guide "Background" with tolerance 5
+	go to step "Select Entry Background For Inspector"
+end step
+
+step "Select Entry Background For Inspector"
+	Select the graphic by clicking on it.
+
+	The selection handles will show around the graphic.
+action
+	highlight graphic "Entry Background"
+	wait until graphic "Entry Background" is selected
 	go to step "Set Entry Background Properties"
 end step
 
@@ -384,6 +425,7 @@ end step
 step "Select Height Label 1"
 	Select the field by clicking on it.
 action
+	highlight field "Height Label"
 	wait until field "Height Label" is selected
 	go to step "Set Height Label Rect"
 end step
@@ -394,6 +436,14 @@ action
 	add guide "Label" with rect "28,87,164,117" to stack "Mainstack"
 	highlight guide "Label"
 	wait until field "Height Label" fits guide "Label" with tolerance 3
+	go to step "Select Height Label For Inspector"
+end step
+
+step "Select Height Label For Inspector"
+	Select the field by clicking on it.
+action
+	highlight field "Height Label"
+	wait until field "Height Label" is selected
 	go to step "Set Height Label Properties"
 end step
 
@@ -426,6 +476,7 @@ end step
 step "Select Weight Label 1"
 	Select the field by clicking on it.
 action
+	highlight field "Weight Label"
 	wait until field "Weight Label" is selected
 	go to step "Set Weight Label Rect"
 end step
@@ -436,6 +487,14 @@ action
 	add guide "Label" with rect "28,127,164,157" to stack "Mainstack"
 	highlight guide "Label"
 	wait until field "Weight Label" fits guide "Label" with tolerance 3
+	go to step "Select Weight Label For Inspector"
+end step
+
+step "Select Weight Label For Inspector"
+	Select the field by clicking on it.
+action
+	highlight field "Weight Label"
+	wait until field "Weight Label" is selected
 	go to step "Set Weight Label Properties"
 end step
 
@@ -468,6 +527,7 @@ end step
 step "Select Height Field 1"
 	Select the field by clicking on it.
 action
+	highlight field "Height Field"
 	wait until field "Height Field" is selected
 	go to step "Set Height Field Rect"
 end step
@@ -491,6 +551,14 @@ step "Name Interlude"
 	name that's descriptive of what it represents.
 action
 	interlude
+	go to step "Select Height Field For Inspector"
+end step
+
+step "Select Height Field For Inspector"
+	Select the field by clicking on it.
+action
+	highlight field "Height Field"
+	wait until field "Height Field" is selected
 	go to step "Set Height Field Properties"
 end step
 
@@ -523,6 +591,7 @@ end step
 step "Select Weight Field 1"
 	Select the field by clicking on it.
 action
+	highlight field "Weight Field"
 	wait until field "Weight Field" is selected
 	go to step "Set Weight Field Rect"
 end step
@@ -533,6 +602,14 @@ action
 	add guide "Entry Field" with rect "185,127,253,157" to stack "Mainstack"
 	highlight guide "Entry Field"
 	wait until field "Weight Field" fits guide "Entry Field" with tolerance 3
+	go to step "Select Weight Field For Inspector"
+end step
+
+step "Select Weight Field For Inspector"
+	Select the field by clicking on it.
+action
+	highlight field "Weight Field"
+	wait until field "Weight Field" is selected
 	go to step "Set Weight Field Properties"
 end step
 
@@ -566,6 +643,7 @@ end step
 step "Select Calculate Graphic 1"
 	Select the graphic by clicking on it.
 action
+	highlight graphic "Calculate Background"
 	wait until graphic "Calculate Background" is selected
 	go to step "Set Calculate Graphic Rect"
 end step
@@ -576,6 +654,14 @@ action
 	add guide "Calculate Graphic" with rect "23,178,300,216" to stack "Mainstack"
 	highlight guide "Calculate Graphic"
 	wait until graphic "Calculate Background" fits guide "Calculate Graphic" with tolerance 5
+	go to step "Select Calculate Graphic For Inspector"
+end step
+
+step "Select Calculate Graphic For Inspector"
+	Select the graphic by clicking on it.
+action
+	highlight graphic "Calculate Background"
+	wait until graphic "Calculate Background" is selected
 	go to step "Set Calculate Graphic Properties"
 end step
 
@@ -607,6 +693,7 @@ end step
 step "Select Calculate Button 1"
 	Select the button by clicking on it.
 action
+	highlight button "Calculate"
 	wait until button "Calculate" is selected
 	go to step "Set Calculate Button Rect"
 end step
@@ -617,6 +704,14 @@ action
 	add guide "Calculate" with rect "23,178,300,216" to stack "Mainstack"
 	highlight guide "Calculate"
 	wait until button "Calculate" fits guide "Calculate" with tolerance 3
+	go to step "Select Calculate Button For Inspector"
+end step
+
+step "Select Calculate Button For Inspector"
+	Select the button by clicking on it.
+action
+	highlight button "Calculate"
+	wait until button "Calculate" is selected
 	go to step "Set Calculate Button Properties"
 end step
 
@@ -666,6 +761,7 @@ end step
 step "Select Results Background 1"
 	Select the graphic by clicking on it.
 action
+	highlight graphic "Results Background"
 	wait until graphic "Results Background" is selected
 	go to step "Set Results Background Rect"
 end step
@@ -676,6 +772,14 @@ action
 	add guide "Background" with rect "14,240,308,422" to stack "Mainstack"
 	highlight guide "Background"
 	wait until graphic "Results Background" fits guide "Background" with tolerance 5
+	go to step "Select Results Background For Inspector"
+end step
+
+step "Select Results Background For Inspector"
+	Select the graphic by clicking on it.
+action
+	highlight graphic "Results Background"
+	wait until graphic "Results Background" is selected
 	go to step "Set Results Background Properties"
 end step
 
@@ -724,6 +828,7 @@ end step
 step "Select Results Label 1"
 	Select the field by clicking on it.
 action
+	highlight field "Results Label"
 	wait until field "Results Label" is selected
 	go to step "Set Results Label Rect"
 end step
@@ -734,6 +839,14 @@ action
 	add guide "Label" with rect "112,254,212,284" to stack "Mainstack"
 	highlight guide "Label"
 	wait until field "Results Label" fits guide "Label" with tolerance 3
+	go to step "Set Results Label Properties"
+end step
+
+step "Select Results Label For Inspector"
+	Select the field by clicking on it.
+action
+	highlight field "Results Label"
+	wait until field "Results Label" is selected
 	go to step "Set Results Label Properties"
 end step
 
@@ -782,6 +895,7 @@ end step
 step "Select Results Field 1"
 	Select the field by clicking on it.
 action
+	highlight field "Results"
 	wait until field "Results" is selected
 	go to step "Set Results Rect"
 end step
@@ -792,6 +906,14 @@ action
 	add guide "Label" with rect "22,287,300,325" to stack "Mainstack"
 	highlight guide "Label"
 	wait until field "Results" fits guide "Label" with tolerance 3
+	go to step "Select Results Field For Inspector"
+end step
+
+step "Select Results Field For Inspector"
+	Select the field by clicking on it.
+action
+	highlight field "Results"
+	wait until field "Results" is selected
 	go to step "Set Results Properties"
 end step
 
@@ -841,6 +963,7 @@ end step
 step "Select Advice Field 1"
 	Select the field.
 action
+	highlight field "Advice"
 	wait until field "Advice" is selected
 	go to step "Set Advice Rect"
 end step
@@ -851,6 +974,14 @@ action
 	add guide "Label" with rect "22,327,300,417" to stack "Mainstack"
 	highlight guide "Label"
 	wait until field "Advice" fits guide "Label" with tolerance 3
+	go to step "Select Advice Field For Inspector"
+end step
+
+step "Select Advice Field For Inspector"
+	Select the field.
+action
+	highlight field "Advice"
+	wait until field "Advice" is selected
 	go to step "Set Advice Properties"
 end step
 
@@ -952,6 +1083,14 @@ action
 	capture the next new group of stack "Mainstack" as "Background Group"
 	capture set widget "Header", widget "Footer" as "Shared Controls"
 	wait until set "Shared Controls" is grouped
+	go to step "Select Group For Inspector"
+end step
+
+step "Select Group For Inspector"
+	Select the new group.
+action
+	highlight group "Background Group"
+	wait until group "Background Group" is selected
 	go to step "Set Group Properties"
 end step
 
@@ -1012,6 +1151,14 @@ action
 	highlight menu item "Graph from CSV File" of menu item "Import As Control" of menu "File"
 	capture the next new widget of stack "Mainstack" as "BMI Chart"
 	wait until there is a widget "BMI Chart"
+	go to step "Select Chart For Inspector"
+end step
+
+step "Select Chart For Inspector"
+	Select the new chart widget.
+action
+	highlight widget "BMI Chart"
+	wait until widget "BMI Chart" is selected
 	go to step "Set Chart Properties"
 end step
 
@@ -1133,6 +1280,14 @@ step "Navigation Bar Script Interlude"
 	user to navigate between the Chart and Calculator cards.
 action
 	interlude
+	go to step "Select Navigation Bar For Editor"
+end step
+
+step "Select Navigation Bar For Editor"
+	Select the navigation bar.
+action
+	highlight widget "Footer"
+	wait until widget "Footer" is selected
 	go to step "Open Navigation Bar Script Editor"
 end step
 
@@ -1270,6 +1425,14 @@ step "Function Interlude"
 	corresponding BMI.
 action
 	interlude 	
+	go to step "Select Stack For Editor"
+end step
+
+step "Select Stack For Editor"
+	Ensure this is the active stack, by clicking on it.
+action
+	highlight stack "Mainstack"
+	wait until stack "Mainstack" is selected
 	go to step "Open Stack Script"
 end step
 
@@ -2071,6 +2234,7 @@ end step
 step "Select Browser 1"
 	Select the browser widget.
 action
+	highlight widget "Browser"
 	wait until widget "Browser" is selected
 	go to step "Set Browser Rect"
 end step
@@ -2081,6 +2245,14 @@ action
 	add guide "Browser" with rect "0,62,320,432" to stack "Mainstack"
 	highlight guide "Browser"
 	wait until widget "Browser" fits guide "Browser" with tolerance 5
+	go to step "Select Browser For Inspector"
+end step
+
+step "Select Browser For Inspector"
+	Select the browser widget.
+action
+	highlight widget "Browser"
+	wait until widget "Browser" is selected
 	go to step "Open Browser Inspector"
 end step
 

--- a/Toolset/palettes/tutorial/courses/First Run/tutorials/Hello World/lessons/App Lesson.txt
+++ b/Toolset/palettes/tutorial/courses/First Run/tutorials/Hello World/lessons/App Lesson.txt
@@ -49,6 +49,14 @@ step "Properties interlude"
 	The Property Inspector is a window that allows you to control these properties.
 action
 	interlude
+	go to step "Select Stack"
+end step
+
+step "Select Stack"
+	Ensure this is the active stack, by clicking on it.
+action
+	highlight stack "Mainstack"
+	wait until stack "Mainstack" is selected
 	go to step "Set Stack Properties"
 end step
 
@@ -103,6 +111,7 @@ step "Select Button 1"
 
 	The selection handles should show around the button.
 action
+	highlight button "hello"
 	wait until button "hello" is selected
 	go to step "Set Button Location"
 end step
@@ -113,6 +122,16 @@ action
 	add guide "buttonLoc" with rect "159,119,241,142" to stack "Mainstack"
 	highlight guide "buttonLoc"
 	wait until button "hello" fits guide "buttonLoc" with tolerance 5
+	go to step "Select Button For Inspector"
+end step
+
+step "Select Button For Inspector"
+	Select the button by clicking on it.
+
+	The selection handles should show around the button.
+action
+	highlight button "hello"
+	wait until button "hello" is selected
 	go to step "Open Property Inspector"
 end step
 
@@ -149,6 +168,16 @@ step "Events and messages interlude"
 	messages in different ways.
 action
 	interlude
+	go to step "Select Button For Editor"
+end step
+
+step "Select Button For Editor"
+	Select the button by clicking on it.
+
+	The selection handles should show around the button.
+action
+	highlight button "hello"
+	wait until button "hello" is selected
 	go to step "Open Add Script"
 end step
 

--- a/Toolset/palettes/tutorial/courses/First Run/tutorials/To Do List/lessons/App Lesson.txt
+++ b/Toolset/palettes/tutorial/courses/First Run/tutorials/To Do List/lessons/App Lesson.txt
@@ -85,6 +85,14 @@ step "Properties interlude"
 	The Property Inspector is a window that allows you to control these properties.
 action
 	interlude
+	go to step "Select Stack For Inspector"
+end step
+
+step "Select Stack For Inspector"
+	Ensure this is the active stack, by clicking on it.
+action
+	highlight stack "Mainstack"
+	wait until stack "Mainstack" is selected
 	go to step "Set Stack Properties"
 end step
 
@@ -152,6 +160,7 @@ step "Select SVG Icon 1"
 
 	The selection handles will show around the icon.
 action
+	highlight widget "add"
 	wait until widget "add" is selected
 	go to step "Set Add Location"
 end step
@@ -162,6 +171,16 @@ action
 	add guide "addLoc" with rect "280,10,310,40" to stack "Mainstack"
 	highlight guide "addLoc"
 	wait until widget "add" fits guide "addLoc" with tolerance 5
+	go to step "Select SVG Icon For Inspector"
+end step
+
+step "Select SVG Icon For Inspector"
+	Select the SVG Icon by clicking on it.
+
+	The selection handles will show around the icon.
+action
+	highlight widget "add"
+	wait until widget "add" is selected
 	go to step "Open Property Inspector"
 end step
 
@@ -219,6 +238,7 @@ step "Select Field 1"
 
 	The selection handles will show around the field.
 action
+	highlight field "TaskList"
 	wait until field "TaskList" is selected
 	go to step "Set task list Location"
 end step
@@ -229,6 +249,16 @@ action
 	add guide "taskListLoc" with rect "0,60,320,568" to stack "Mainstack"
 	highlight guide "taskListLoc"
 	wait until field "taskList" fits guide "taskListLoc" with tolerance 5
+	go to step "Select Field For Inspector"
+end step
+
+step "Select Field For Inspector"
+	Select the field by clicking on it.
+
+	The selection handles will show around the field.
+action
+	highlight field "TaskList"
+	wait until field "TaskList" is selected
 	go to step "Task List PI"
 end step
 
@@ -280,6 +310,16 @@ step "Events and messages interlude"
 	messages in different ways.
 action
 	interlude
+	go to step "Select SVG Icon For Editor"
+end step
+
+step "Select SVG Icon For Editor"
+	Select the SVG Icon by clicking on it.
+
+	The selection handles will show around the icon.
+action
+	highlight widget "add"
+	wait until widget "add" is selected
 	go to step "Open Add Script"
 end step
 
@@ -426,6 +466,7 @@ step "Select SVG Icon 2"
 
 	The selection handles will show around the icon.
 action
+	highlight widget "delete"
 	wait until widget "delete" is selected
 	go to step "Set Delete Location"
 end step
@@ -436,6 +477,16 @@ action
 	add guide "deleteLoc" with rect "240,10,270,40" to stack "Mainstack"
 	highlight guide "deleteLoc"
 	wait until widget "delete" fits guide "deleteLoc" with tolerance 5
+	go to step "Select Delete For Inspector"
+end step
+
+step "Select Delete For Inspector"
+	Select the icon by clicking on it.
+
+	The selection handles will show around the icon.
+action
+	highlight widget "delete"
+	wait until widget "delete" is selected
 	go to step "Open Delete Property Inspector"
 end step
 
@@ -466,6 +517,16 @@ step "Set delete icon"
 action
 	highlight property "iconPresetName" of section "Basic"
 	wait until the iconPresetName of widget "delete" is "trash"
+	go to step "Select Delete For Editor"
+end step
+
+step "Select Delete For Editor"
+	Select the icon by clicking on it.
+
+	The selection handles will show around the icon.
+action
+	highlight widget "delete"
+	wait until widget "delete" is selected
 	go to step "Open Delete script"
 end step
 
@@ -547,6 +608,14 @@ step "closeStack handler"
 	to be loaded in the next time the app is opened. There is a 'Documents' folder on all platforms so this code will work on desktop and mobile.
 action
 	interlude
+	go to step "Select Stack For Editor"
+end step
+
+step "Select Stack For Editor"
+	Ensure this is the active stack, by clicking on it.
+action
+	highlight stack "Mainstack"
+	wait until stack "Mainstack" is selected
 	go to step "Open Stack Script"
 end step
 

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -1571,6 +1571,17 @@ on revTutorialStartAtStep pCourse, pTutorial, pLesson, pLocation, pStepName
    revTutorialStartWithState pStepName, sTaggedObjects
 end revTutorialStartAtStep
 
+command revTutorialGoBackToSelectStep
+   // At the moment it should be a safe assumption that the relevant
+   // 'select' step is the previous one
+   local tPreviousStep
+   put revTutorialPreviousStep() into tPreviousStep
+   if sSteps[tPreviousStep]["actions"]["wait"]["wait condition"] is "state" and \
+         sSteps[tPreviousStep]["actions"]["wait"]["state"] is "selected" then
+      revTutorialGoBackToPreviousStep
+   end if
+end revTutorialGoBackToSelectStep
+
 command revTutorialSkipCurrentStep
    revTutorialSkipStep sStepName
 end revTutorialSkipCurrentStep
@@ -1686,7 +1697,7 @@ on revTutorialClearAllPalettes
    end repeat
 end revTutorialClearAllPalettes
 
-on revTutorialContinue
+on revTutorialContinue pBack
    repeat forever
       if sWaiting then
          exit repeat
@@ -1698,7 +1709,7 @@ on revTutorialContinue
       else if sSteps[sStepName]["actions"]["go"] is empty then
          revTutorialFinish
          exit repeat
-      else
+      else if not pBack then
          // Otherwise we're here after a wait, so go to the next step
          revTutorialExecuteAction sSteps[sStepName]["actions"]["go"]
       end if
@@ -1953,7 +1964,23 @@ end revTutorialCanSkipStep
 #
 ##############################################################################
 
-on revTutorialDoGoToStep pStep
+local sPreviousStep
+private function revTutorialPreviousStep
+   return sPreviousStep
+end revTutorialPreviousStep
+
+command revTutorialGoBackToPreviousStep
+   if sPreviousStep is empty then
+      exit revTutorialGoBackToPreviousStep
+   end if
+   revTutorialDoGoToStep sPreviousStep, true
+   send "revTutorialContinue true" to stack "revTutorial" in 0 millisecs
+end revTutorialGoBackToPreviousStep
+
+on revTutorialDoGoToStep pStep, pBack
+   if not pBack then
+      put sStepName into sPreviousStep
+   end if
    revTutorialInitialiseStep
    revTutorialClearHighlights
    revTutorialClearGuides
@@ -2184,6 +2211,7 @@ on revTutorialWaitUntilThereIsAPaletteForObject pPalette
       revIDEHighlightPaletteObject "menubar", "standard"
       revIDESubscribe "ideEditScript"
    end if
+   revIDESubscribe "ideSelectedObjectChanged"
 end revTutorialWaitUntilThereIsAPaletteForObject
 
 on revTutorialWaitUntilTheToolIs
@@ -2549,6 +2577,20 @@ end revTutorialReShow
 
 on ideActiveStacksChanged
    revTutorialReShow
+   
+   local tObject
+   put revIDESelectedObjects() into tObject
+   if sWait["wait condition"] is "there is a palette for object" then
+      -- If the object became deselected, go back a step
+      if not revTutorialObjectIsTaggedObject(tObject, sWait["object"]) then
+         revTutorialGoBackToSelectStep
+      end if
+   else if sWait["wait condition"] is "state" and sWait["state"] is "selected" then
+      if revTutorialObjectIsTaggedObject(tObject, sWait["object"]) then
+         revIDEUnsubscribe "ideSelectedObjectChanged"
+         revTutorialWaitConditionSatisfied
+      end if
+   end if
 end ideActiveStacksChanged
 
 on ideCloseStackRequest pStack
@@ -2780,11 +2822,17 @@ on ideMouseDoubleUp pWhich, pTarget
 end ideMouseDoubleUp
 
 on ideSelectedObjectChanged 
+   local tObject
+   put revIDESelectedObjects() into tObject
    if sWait["wait condition"] is "state" and sWait["state"] is "selected" then
-      local tObject
-      put revIDESelectedObjects() into tObject
       if revTutorialObjectIsTaggedObject(tObject, sWait["object"]) then
+         revIDEUnsubscribe "ideSelectedObjectChanged"
          revTutorialWaitConditionSatisfied
+      end if
+   else if sWait["wait condition"] is "there is a palette for object" then
+      -- If the object became deselected, go back a step
+      if not revTutorialObjectIsTaggedObject(tObject, sWait["object"]) then
+         revTutorialGoBackToSelectStep
       end if
    end if
 end ideSelectedObjectChanged
@@ -2793,6 +2841,7 @@ on ideInspectObjects pObjects
    if sWait["wait condition"] is "there is a palette for object" and sWait["palette"] is "inspector" then
       if revTutorialObjectIsTaggedObject(pObjects, sWait["object"]) then
          revIDEUnsubscribe "ideInspectObjects"
+         revIDEUnsubscribe "ideSelectedObjectChanged"
          put pObjects into sLastObjects[sWait["palette"]]
          revTutorialWaitConditionSatisfied
       end if
@@ -2803,6 +2852,7 @@ on ideEditScript pObject
    if sWait["wait condition"] is "there is a palette for object" and sWait["palette"] is "script editor" then
       if revTutorialObjectIsTaggedObject(the long id of pObject, sWait["object"]) then
          revIDEUnsubscribe "ideEditScript"
+         revIDEUnsubscribe "ideSelectedObjectChanged"
          put pObject into sLastObjects[sWait["palette"]]
          revTutorialWaitConditionSatisfied
       end if


### PR DESCRIPTION
- Ensure object is always selected when step requires
If an object waiting for a palette to open becomes deselected, go
back to the selection step.
Also, ensure this works for stacks by implementing similar code in
ideActiveStacksChanged to ideSelectedObjectChanged

- Ensure all palette for obj steps are preceded by select steps
This is required for the enforcement of correct selection to work.
Also, ensure all select steps highlight the object in question.