### PR TITLE
[[ Tutorial ]] Allow instruction window to be moved

### DIFF
--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -1103,10 +1103,6 @@ command revTutorialPositionStackAndPointer pContentWidth, pContentHeight, pHighl
 end revTutorialPositionStackAndPointer   
 
 command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
-   if the platform is "win32" then
-      set the windowshape of stack "revTutorial" to empty
-   end if
-   
    # Store templategraphic props (in case we have a graphic tool selected)
    local tProps
    put the properties of the templategraphic into tProps
@@ -1118,6 +1114,9 @@ command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
    set the lineSize of the templateGraphic to 0
    set the backColor of the templateGraphic to "black"
    set the opaque of the templateGraphic to true
+   
+   # Ensure the window does not have a 1-bit mask
+   set the blendlevel of the templateGraphic to 1
    
    create group "Group"
    put it into tGroup

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -920,7 +920,7 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
       put true into tHasPointer
    end if
    
-   local tWidth, tHeight 
+   local tContentWidth, tContentHeight 
    local tMessageHeight, tMessageWidth
    if pWidthOverride is not empty then
       put max(kMessageWidth, pWidthOverride) into tMessageWidth
@@ -932,8 +932,8 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    
    set the height of tMsgFieldID to tMessageHeight
    
-   put tMessageHeight + kMargin * 2 into tHeight
-   put the formattedWidth of tMsgFieldID + kMargin * 2 into tWidth
+   put tMessageHeight + kMargin * 2 into tContentHeight
+   put the formattedWidth of tMsgFieldID + kMargin * 2 into tContentWidth
    
    if tHasScript then
       local tScriptHeight
@@ -951,26 +951,26 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
       end if
       
       set the height of tScriptFieldID to tScriptHeight
-      add tScriptHeight + kMargin * 2 to tHeight
+      add tScriptHeight + kMargin * 2 to tContentHeight
       
-      put max(tWidth, the width of tScriptFieldID + kMargin * 2) into tWidth
+      put max(tContentWidth, the width of tScriptFieldID + kMargin * 2) into tContentWidth
    end if
    
    if tHasUrl then
-      add the height of tUrlControlID + kMargin * 2 to tHeight
-      put max(tWidth, the width of tUrlControlID + kMargin * 2) into tWidth
+      add the height of tUrlControlID + kMargin * 2 to tContentHeight
+      put max(tContentWidth, the width of tUrlControlID + kMargin * 2) into tContentWidth
    end if
    
    if tActionButton is not empty then
       set the height of tActionButton to the formattedHeight of tActionButton
       set the width of tActionButton to the formattedWidth of tActionButton
       show tActionButton
-      add the height of tActionButton + kMargin to tHeight
+      add the height of tActionButton + kMargin to tContentHeight
    end if
    
    if tHasImage then
-      add the formattedheight of tImageID + kMargin * 2 to tHeight
-      put max(tWidth, the formattedwidth of tImageID + kMargin * 2) into tWidth
+      add the formattedheight of tImageID + kMargin * 2 to tContentHeight
+      put max(tContentWidth, the formattedwidth of tImageID + kMargin * 2) into tContentWidth
    end if
    
    # Work out what screen the tutorial stack should be on
@@ -985,14 +985,14 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    
    local tPointer
    if tHasPointer then
-      put revTutorialPointerCompute(tWidth, tHeight, tScreenRect, tRect, tPointVertical) \ 
+      put revTutorialPointerCompute(tContentWidth, tContentHeight, tScreenRect, tRect, tPointVertical) \ 
             into tPointer
    end if
    
    if tPointer is not empty then
       if revTutorialPointerDifferent(tPointer) then
          // Create the windowshape for the stack and pointer
-         revTutorialCreateStack tWidth, tHeight, tPointer
+         revTutorialCreateStack tContentWidth, tContentHeight, tPointer
       end if
    else
       set the windowshape of stack "revTutorial" to empty
@@ -1004,12 +1004,16 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    local tMessageLeft, tMessageTop
    put kMargin into tMessageLeft
    put kMargin into tMessageTop
+   
+   local tWidth, tHeight
    if tPointer is not empty then
-      revTutorialPositionStackAndPointer tWidth, tHeight, tRect, tPointer
+      revTutorialPositionStackAndPointer tContentWidth, tContentHeight, tRect, tPointer, tWidth, tHeight
       add revTutorialPointerLeftOverhang(tPointer) to tMessageLeft
       add revTutorialPointerTopOverhang(tPointer) to tMessageTop
    else
-      set the rect of stack "revTutorial" to 0, 0, tWidth, tHeight
+      put tContentWidth into tWidth
+      put tContentHeight into tHeight
+      set the rect of stack "revTutorial" to 0, 0, tContentWidth, tContentHeight
       set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
    end if
    
@@ -1018,8 +1022,8 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
       put tWidth - kMargin into tButtonRight
       put tHeight - kMargin into tButtonBottom
       
-      subtract revTutorialPointerRightOverhang(tPointer) from tButtonRight
-      subtract revTutorialPointerBottomOverhang(tPointer) from tButtonBottom
+      subtract revTutorialPointerRightOverhang(tPointer, tContentWidth) from tButtonRight
+      subtract revTutorialPointerBottomOverhang(tPointer, tContentHeight) from tButtonBottom
       set the bottomright of tActionButton to tButtonRight,tButtonBottom
    end if
    
@@ -1047,12 +1051,15 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    unlock screen
 end revTutorialPositionStack
 
-command revTutorialPositionStackAndPointer @xContentWidth, @xContentHeight, pHighlightRect, pPointer
+command revTutorialPositionStackAndPointer pContentWidth, pContentHeight, pHighlightRect, pPointer, @rWidth, @rHeight
    local tStackLeft, tStackTop, tWidth, tHeight
-   revTutorialPointerStackPosition xContentWidth, xContentHeight, pHighlightRect, pPointer, tStackLeft, tStackTop
-   revTutorialPointerStackSize xContentWidth, xContentHeight, pPointer
-   set the rect of stack "revTutorial" to 0, 0, xContentWidth, xContentHeight
+   revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, tStackLeft, tStackTop
+   revTutorialPointerStackSize pContentWidth, pContentHeight, pPointer, tWidth, tHeight
+   set the rect of stack "revTutorial" to 0, 0, tWidth, tHeight
    set the topleft of stack "revTutorial" to tStackLeft, tStackTop
+   
+   put tWidth into rWidth
+   put tHeight into rHeight
 end revTutorialPositionStackAndPointer   
 
 constant kPointerHeight = 30
@@ -1124,12 +1131,12 @@ end revTutorialCreateStack
 
 private function revTutorialPointerSide pPointer
    set the itemdelimiter to "-"
-   return item 1 of pPointer
+   return item 1 of pPointer["position"]
 end revTutorialPointerSide
 
 private function revTutorialPointerPositionOnSide pPointer
    set the itemdelimiter to "-"
-   return item 2 of pPointer
+   return item 2 of pPointer["position"]
 end revTutorialPointerPositionOnSide
 
 private function revTutorialPointerVertical pPointer
@@ -1144,7 +1151,7 @@ private function revTutorialPointerLeft pPointer
 end revTutorialPointerLeft
 
 private function revTutorialPointerSource pPointer, pStackWidth, pStackHeight
-   switch pPointer
+   switch pPointer["position"]
       case "top-left"
          return kPointerOffset, 0
       case "top-right"
@@ -1174,37 +1181,52 @@ command revTutorialSetPointer pPointer
 end revTutorialSetPointer
 
 function revTutorialPointerDifferent pPointer
-   return revTutorialPointerSide(pPointer) is not \ 
-         revTutorialPointerSide(sPointer)
+   return pPointer is not sPointer
 end revTutorialPointerDifferent
 
 function revTutorialPointerLeftOverhang pPointer
-   if revTutorialPointerSide(pPointer) is "left" then
-      return kPointerWidth / 2
+   if pPointer["style"] is "original" then
+      if revTutorialPointerSide(pPointer) is "left" then
+         return kPointerWidth / 2
+      end if  
+   else if pPointer["end"]["x"] < 0 then
+      return -(pPointer["end"]["x"])
    end if
    
    return 0
 end revTutorialPointerLeftOverhang
 
 function revTutorialPointerTopOverhang pPointer
-   if revTutorialPointerSide(pPointer) is "top" then
-      return kPointerWidth / 2
+   if pPointer["style"] is "original" then
+      if revTutorialPointerSide(pPointer) is "top" then
+         return kPointerWidth / 2
+      end if  
+   else if pPointer["end"]["y"] < 0 then
+      return -(pPointer["end"]["y"])
    end if
    
    return 0
 end revTutorialPointerTopOverhang
 
-function revTutorialPointerRightOverhang pPointer
-   if revTutorialPointerSide(pPointer) is "right" then
-      return kPointerWidth / 2
+function revTutorialPointerRightOverhang pPointer, pWidth
+   if pPointer["style"] is "original" then
+      if revTutorialPointerSide(pPointer) is "right" then
+         return kPointerWidth / 2
+      end if  
+   else if pPointer["end"]["x"] > pWidth then
+      return pPointer["end"]["x"] - pWidth
    end if
    
    return 0
 end revTutorialPointerRightOverhang
 
-function revTutorialPointerBottomOverhang pPointer
-   if revTutorialPointerSide(pPointer) is "bottom" then
-      return kPointerWidth / 2
+function revTutorialPointerBottomOverhang pPointer, pHeight
+   if pPointer["style"] is "original" then
+      if revTutorialPointerSide(pPointer) is "bottom" then
+         return kPointerWidth / 2
+      end if  
+   else if pPointer["end"]["y"] > pHeight then
+      return pPointer["end"]["y"] - pHeight
    end if
    
    return 0
@@ -1302,7 +1324,11 @@ private function revTutorialPointerCompute pContentWidth, pContentHeight, pScree
    if not tCanFit then
       return empty
    end if
-   return revTutorialPointerPositionCompute(tPointerVertical, tPointerLeft, tPointerTop)
+   local tPointer
+   put revTutorialPointerPositionCompute(tPointerVertical, tPointerLeft, tPointerTop) \
+         into tPointer["position"]
+   put "original" into tPointer["style"]
+   return tPointer
 end revTutorialPointerCompute
 
 private command revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
@@ -1342,11 +1368,13 @@ private command revTutorialPointerStackPosition pContentWidth, pContentHeight, p
    put tStackLeft into rStackLeft
 end revTutorialPointerStackPosition
 
-command revTutorialPointerStackSize @xWidth, @xHeight, pPointer
+command revTutorialPointerStackSize pContentWidth, pContentHeight, pPointer, @rWidth, @rHeight
    if revTutorialPointerVertical(pPointer) then
-      add kPointerWidth / 2 to xHeight
+      put pContentHeight + kPointerWidth / 2 into rHeight
+      put pContentWidth into rWidth
    else
-      add kPointerWidth / 2 to xWidth
+      put pContentWidth + kPointerWidth / 2 into rWidth
+      put pContentHeight into rHeight
    end if
 end revTutorialPointerStackSize
 

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -828,7 +828,11 @@ constant kMaxScriptHeight = 200
 
 local sDontShow
 local sLastShape
-on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
+on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical, pTopLeftOverride
+   if pTopLeftOverride is not empty then
+      revTutorialSetTopLeftOverride true
+   end if
+   
    local tGotItButtonID, tCopyButtonID, tDoItButtonID
    local tMsgFieldID, tScriptFieldID, tImageID
    local tActionButton
@@ -985,18 +989,28 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    
    local tPointer
    if tHasPointer then
-      put revTutorialPointerCompute(tContentWidth, tContentHeight, tScreenRect, tRect, tPointVertical) \ 
-            into tPointer
+      if not revTutorialIsDraggingWindow() then
+         if pTopLeftOverride is empty then
+            put revTutorialPointerCompute(tContentWidth, tContentHeight, tScreenRect, tRect, tPointVertical) \ 
+                  into tPointer
+         else
+            put revTutorialPointerComputeForTopLeft(tContentWidth, tContentHeight, tRect, pTopLeftOverride) \ 
+                  into tPointer
+         end if
+      else
+         put revTutorialGetPointer() into tPointer
+         revTutorialSetPointer empty
+      end if
    end if
    
-   if tPointer is not empty then
-      if revTutorialPointerDifferent(tPointer) then
+   if revTutorialPointerDifferent(tPointer) then
+      if tPointer is not empty then
          // Create the windowshape for the stack and pointer
          revTutorialCreateStack tContentWidth, tContentHeight, tPointer
+      else      
+         set the windowshape of stack "revTutorial" to empty
+         set the decorations of stack "revTutorial" to empty
       end if
-   else
-      set the windowshape of stack "revTutorial" to empty
-      set the decorations of stack "revTutorial" to empty
    end if
    
    revTutorialSetPointer tPointer
@@ -1014,7 +1028,12 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
       put tContentWidth into tWidth
       put tContentHeight into tHeight
       set the rect of stack "revTutorial" to 0, 0, tContentWidth, tContentHeight
-      set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
+      if pTopLeftOverride is empty then
+         set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
+      else
+         set the topleft of stack "revTutorial" to pTopLeftOverride
+      end if
+      revTutorialSetEffectiveTopLeft the topleft of stack "revTutorial"
    end if
    
    if tActionButton is not empty then
@@ -1033,7 +1052,6 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
       set the backColor of stack "revTutorial" to revTutorialMessageColor()
    end if
    
-   
    set the topleft of tMsgFieldID to tMessageLeft, tMessageTop
    local tOtherTop
    put kMargin + the bottom of tMsgFieldID into tOtherTop
@@ -1051,6 +1069,28 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    unlock screen
 end revTutorialPositionStack
 
+local sEffectiveTopLeft
+private command revTutorialSetEffectiveTopLeft pStackTopLeft
+   put pStackTopLeft into sEffectiveTopLeft
+end revTutorialSetEffectiveTopLeft
+
+private function revTutorialGetEffectiveTopLeft
+   return sEffectiveTopLeft
+end revTutorialGetEffectiveTopLeft
+
+local sTopLeftOverride
+private function revTutorialTopLeftOverride
+   if sTopLeftOverride then
+      return revTutorialGetEffectiveTopLeft()
+   end if
+   
+   return empty
+end revTutorialTopLeftOverride
+
+private command revTutorialSetTopLeftOverride pValue
+   put pValue into sTopLeftOverride
+end revTutorialSetTopLeftOverride
+
 command revTutorialPositionStackAndPointer pContentWidth, pContentHeight, pHighlightRect, pPointer, @rWidth, @rHeight
    local tStackLeft, tStackTop, tWidth, tHeight
    revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, tStackLeft, tStackTop
@@ -1062,11 +1102,11 @@ command revTutorialPositionStackAndPointer pContentWidth, pContentHeight, pHighl
    put tHeight into rHeight
 end revTutorialPositionStackAndPointer   
 
-constant kPointerHeight = 30
-constant kPointerWidth = 40
-constant kPointerOffset = 40
-constant kPointerPadding = 5
 command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
+   if the platform is "win32" then
+      set the windowshape of stack "revTutorial" to empty
+   end if
+   
    # Store templategraphic props (in case we have a graphic tool selected)
    local tProps
    put the properties of the templategraphic into tProps
@@ -1078,6 +1118,7 @@ command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
    set the lineSize of the templateGraphic to 0
    set the backColor of the templateGraphic to "black"
    set the opaque of the templateGraphic to true
+   
    create group "Group"
    put it into tGroup
    set the margins of it to 0
@@ -1087,49 +1128,33 @@ command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
    set the style of it to "rectangle"
    set the width of it to pContentWidth
    set the height of it to pContentHeight
+   set the topleft of it to 0,0
    
    create graphic "Pointer" in tGroup
    put it into tPointer
    
-   local tSide, tPos, tSource
-   put revTutorialPointerSide(pPointer) into tSide
-   put revTutorialPointerPositionOnSide(pPointer) into tPos
-   put revTutorialPointerSource(pPointer, pContentWidth, pContentHeight) into tSource
+   revTutorialPointerSetGraphicProps tPointer, tGraphic, pPointer, pContentWidth, pContentHeight
    
-   if pPointer["style"] is "original" then
-      set the style of tPointer to "regular"
-      set the polysides of tPointer to 4
-      
-      if revTutorialPointerVertical(pPointer) then
-         set the width of tPointer to kPointerHeight
-         set the height of tPointer to kPointerWidth
-      else
-         set the width of tPointer to kPointerWidth
-         set the height of tPointer to kPointerHeight
-      end if
-      
-      set the loc of tPointer to \ 
-            the left of tGraphic + item 1 of tSource, \
-            the top of tGraphic + item 2 of tSource
-   else
-      set the style of tPointer to "line"
-      set the lineSize of tPointer to 3
-      
-      local tTarget
-      put tPointer["end"]["x"], tPointer["end"]["y"] into tTarget
-      set the points of tPointer to tTarget & return & tSource
+   set the rect of stack "revTutorial" to the formattedRect of tGroup
+   if revTutorialIsDraggingWindow() then
+      set the visible of tPointer to false
    end if
+   
+   set the topleft of tGroup to 0,0
    
    reset the templateGraphic
    set the properties of the templategraphic to tProps
    
    import snapshot from rect (the rect of tGroup) of tGroup
+   
    set the id of the last image to the id of stack "revIcons"
    put the long id of the last image into tWindowShape
+   set the topleft of tWindowShape to 0,0
    delete tGroup
    
    set the windowshape of stack "revTutorial" to the id of tWindowShape
    delete tWindowShape
+   
 end revTutorialCreateStack
 
 ##############################################################################
@@ -1137,6 +1162,41 @@ end revTutorialCreateStack
 #                     POINTER MANAGEMENT
 #
 ##############################################################################
+
+constant kPointerHeight = 30
+constant kPointerWidth = 40
+constant kPointerOffset = 40
+constant kPointerPadding = 5
+private command revTutorialPointerSetGraphicProps pPointerObj, pContentGraphic, pPointer, pContentWidth, pContentHeight
+   local tSide, tPos, tSource
+   put revTutorialPointerSide(pPointer) into tSide
+   put revTutorialPointerPositionOnSide(pPointer) into tPos
+   put revTutorialPointerSource(pPointer, pContentWidth, pContentHeight) into tSource
+   
+   if pPointer["style"] is "original" then
+      set the style of pPointerObj to "regular"
+      set the polysides of pPointerObj to 4
+      
+      if revTutorialPointerVertical(pPointer) then
+         set the width of pPointerObj to kPointerHeight
+         set the height of pPointerObj to kPointerWidth
+      else
+         set the width of pPointerObj to kPointerWidth
+         set the height of pPointerObj to kPointerHeight
+      end if
+      
+      set the loc of pPointerObj to \ 
+            the left of pContentGraphic + item 1 of tSource, \
+            the top of pContentGraphic + item 2 of tSource
+   else
+      set the style of pPointerObj to "line"
+      set the lineSize of pPointerObj to 3
+      
+      local tTarget
+      put pPointer["end"]["x"], pPointer["end"]["y"] into tTarget
+      set the points of pPointerObj to tTarget & return & tSource
+   end if
+end revTutorialPointerSetGraphicProps
 
 private function revTutorialPointerSide pPointer
    set the itemdelimiter to "-"
@@ -1200,7 +1260,7 @@ private command revTutorialPointerComputeTarget pContentWidth, pContentHeight, p
          put (tRight + tLeft) / 2 into tAbsoluteX
          break
       case "bottom"
-         put tTop - pContentHeight - kPointerPadding into tAbsoluteY
+         put tTop - kPointerPadding into tAbsoluteY
          put (tRight + tLeft) / 2 into tAbsoluteX
          break
       case "left"
@@ -1208,13 +1268,13 @@ private command revTutorialPointerComputeTarget pContentWidth, pContentHeight, p
          put (tTop + tBottom) / 2 into tAbsoluteY
          break
       case "right"
-         put tLeft - pContentWidth - kPointerPadding into tAbsoluteX
+         put tLeft - kPointerPadding into tAbsoluteX
          put (tTop + tBottom) / 2 into tAbsoluteY
          break
    end switch
    
-   put tAbsoluteX - item 1 of tSource into xPointer["end"]["x"]
-   put tAbsoluteY - item 2 of tSource into xPointer["end"]["y"]
+   put tAbsoluteX - item 1 of pStackTopLeft into xPointer["end"]["x"]
+   put tAbsoluteY - item 2 of pStackTopLeft into xPointer["end"]["y"]
    put pStackTopLeft into xPointer["stacktopleft"]
 end revTutorialPointerComputeTarget
 
@@ -1223,15 +1283,23 @@ function revTutorialStackHasPointer
    return sPointer is not empty
 end revTutorialStackHasPointer
 
-command revTutorialSetPointer pPointer
+private command revTutorialSetPointer pPointer
    put pPointer into sPointer
 end revTutorialSetPointer
+
+private function revTutorialGetPointer pPointer
+  return sPointer
+end revTutorialGetPointer
 
 function revTutorialPointerDifferent pPointer
    return pPointer is not sPointer
 end revTutorialPointerDifferent
 
 function revTutorialPointerLeftOverhang pPointer
+   if revTutorialIsDraggingWindow() then
+      return 0
+   end if
+   
    if pPointer["style"] is "original" then
       if revTutorialPointerSide(pPointer) is "left" then
          return kPointerWidth / 2
@@ -1244,6 +1312,10 @@ function revTutorialPointerLeftOverhang pPointer
 end revTutorialPointerLeftOverhang
 
 function revTutorialPointerTopOverhang pPointer
+   if revTutorialIsDraggingWindow() then
+      return 0
+   end if
+   
    if pPointer["style"] is "original" then
       if revTutorialPointerSide(pPointer) is "top" then
          return kPointerWidth / 2
@@ -1256,6 +1328,10 @@ function revTutorialPointerTopOverhang pPointer
 end revTutorialPointerTopOverhang
 
 function revTutorialPointerRightOverhang pPointer, pWidth
+   if revTutorialIsDraggingWindow() then
+      return 0
+   end if
+   
    if pPointer["style"] is "original" then
       if revTutorialPointerSide(pPointer) is "right" then
          return kPointerWidth / 2
@@ -1268,6 +1344,10 @@ function revTutorialPointerRightOverhang pPointer, pWidth
 end revTutorialPointerRightOverhang
 
 function revTutorialPointerBottomOverhang pPointer, pHeight
+   if revTutorialIsDraggingWindow() then
+      return 0
+   end if
+   
    if pPointer["style"] is "original" then
       if revTutorialPointerSide(pPointer) is "bottom" then
          return kPointerWidth / 2
@@ -1292,7 +1372,7 @@ private function revTutorialPointerPositionCompute pPointerVertical, pPointerLef
    else
       put "right" into tLeftRight
    end if
-   
+
    if pPointerVertical then
       return tTopBottom & "-" & tLeftRight
    else
@@ -1357,18 +1437,24 @@ end revTutorialTryToFitWithPointer
 
 private function revTutorialPointerComputeForTopLeft pWidth, pHeight, pTargetRect, pStackTopLeft
    # Determine where the target rect is wrt the new stack position
+   local tStackLoc, tTargetLoc
+   put item 1 of pStackTopLeft + pWidth / 2,  \ 
+         item 2 of pStackTopLeft + pHeight / 2 into tStackLoc
+   put (item 1 of pTargetRect + item 3 of pTargetRect) / 2, \
+         (item 2 of pTargetRect + item 4 of pTargetRect) / 2 into tTargetLoc
+   
    local tLeftOffset, tTopOffset
-   put item 1 of pStackTopLeft - item 1 of pTargetRect into tLeftOffset
-   put item 2 of pStackTopLeft - item 2 of pTargetRect into tTopOffset
+   put item 1 of tTargetLoc - item 1 of tStackLoc into tLeftOffset
+   put item 2 of tTargetLoc - item 2 of tStackLoc into tTopOffset
    
    local tPointerVertical, tPointerLeft, tPointerTop
-   if tLeftOffset >= -(pWidth / 2) then
+   if tLeftOffset <= 0 then
       put true into tPointerLeft
    end if
-   if tTopOffset >= -(pHeight / 2) then
+   if tTopOffset <= 0 then
       put true into tPointerTop
    end if
-   put tTopOffset >= tLeftOffset into tPointerVertical
+   put abs(tTopOffset) >= abs(tLeftOffset) into tPointerVertical
    
    local tPointer
    put revTutorialPointerPositionCompute(tPointerVertical, tPointerLeft, tPointerTop) \
@@ -1414,7 +1500,7 @@ private command revTutorialPointerStackPositionOriginal pContentWidth, pContentH
    local tSource
    put revTutorialPointerSource(pPointer, pContentWidth, pContentHeight) into tSource
    
-   local tStackTop, tStackLeft
+   local tStackTop, tStackLeft, tEffectiveTop, tEffectiveLeft
    switch tSide
       case "top"
          put tBottom + kPointerPadding into tStackTop
@@ -1434,6 +1520,10 @@ private command revTutorialPointerStackPositionOriginal pContentWidth, pContentH
          break
    end switch
    
+   put tStackLeft - revTutorialPointerLeftOverhang(pPointer) into tEffectiveLeft
+   put tStackTop - revTutorialPointerTopOverhang(pPointer) into tEffectiveTop
+   
+   revTutorialSetEffectiveTopLeft (tEffectiveLeft, tEffectiveTop)
    put tStackTop into rStackTop
    put tStackLeft into rStackLeft
 end revTutorialPointerStackPositionOriginal
@@ -1444,6 +1534,8 @@ private command revTutorialPointerStackPositionOverride pContentWidth, pContentH
    
    put item 1 of tTopLeftOverride - revTutorialPointerLeftOverhang(pPointer) into rStackLeft
    put item 2 of tTopLeftOverride - revTutorialPointerTopOverhang(pPointer) into rStackTop
+   
+   revTutorialSetEffectiveTopLeft tTopLeftOverride
 end revTutorialPointerStackPositionOverride
 
 private command revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
@@ -1545,6 +1637,7 @@ on revInitialiseTutorial
    end if
    
    set the windowShape of stack "revTutorial" to empty
+   set the decorations of stack "revTutorial" to empty
    
    set the textStyle of stack "revTutorial" to "bold"
    set the textColor of stack "revTutorial" to "white"
@@ -1635,6 +1728,7 @@ on revTutorialInitialiseStep
    put false into sWaiting
    put false into sIsInterlude
    put 0 into sActionNumber
+   revTutorialSetTopLeftOverride false
 end revTutorialInitialiseStep
 
 on revFinaliseTutorial
@@ -2491,7 +2585,7 @@ on revTutorialHighlightPalette pPaletteName
    put pPaletteName into sHighlight["stack"]
    
    revIDESubscribe "ideStackMoved", the long id of stack revIDEPaletteToStackName(pPaletteName)
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightPalette
 
 function revTutorialPaletteForObject pPaletteName, pObject
@@ -2531,7 +2625,7 @@ on revTutorialHighlightObjectByID pObjID
    end if
    revIDESubscribe "ideStackMoved", revIDEStackOfObject(pObjID)
    revIDESubscribe "idePropertyChanged", pObjID
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightObjectByID
 
 on revTutorialHighlightItemOfPaletteForObject pPalette, pItem, pObject
@@ -2556,7 +2650,7 @@ on revTutorialHighlightItemOfStack pStackID, pItem
    put pItem into sHighlight["object"]
    put "object" into sHighlight["type"]
    revIDESubscribe "ideStackMoved", pStackID
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightItemOfStack
    
    
@@ -2577,7 +2671,7 @@ on revTutorialHighlightTool pTool
    revIDESubscribe "ideStackMoved", the long id of stack revIDEPaletteToStackName("tools")
    put "tool" into sHighlight["type"]
    put pTool into sHighlight["tool"]
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightTool
 
 function revTutorialHighlightedPalette pPalette
@@ -2617,7 +2711,7 @@ on revTutorialHighlightInspector pSection, pGroup
    put "property" into sHighlight["type"]
    put pGroup into sHighlight["group"]
    put sLastObjects["inspector"] into sHighlight["object"]
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
    put false into sDismissA["inspector"]
 end revTutorialHighlightInspector
 
@@ -2629,7 +2723,7 @@ on revTutorialHighlightMenuItem pMenu, pItem
    revIDESubscribe "ideStackMoved", the long id of stack revIDEPaletteToStackName("menubar")
    put "menu" into sHighlight["type"]
    put pMenu into sHighlight["menu"]
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightMenuItem
 
 on revTutorialHighlightToolbarItem pItem
@@ -2637,7 +2731,7 @@ on revTutorialHighlightToolbarItem pItem
    revIDESubscribe "ideStackMoved", the long id of stack revIDEPaletteToStackName("menubar")
    put "toolbar" into sHighlight["type"]
    put pItem into sHighlight["item"]
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightToolbarItem
 
 on disableToolsPalette
@@ -2700,7 +2794,7 @@ on revTutorialHighlightGuide pGuide
    revIDESubscribe "ideStackMoved", revIDEStackOfObject(sGuides[pGuide])
    put "guide" into sHighlight["type"]
    put pGuide into sHighlight["guide"]
-   revTutorialPositionStackForHighlight
+   revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
 end revTutorialHighlightGuide
 
 on revTutorialClearGuides
@@ -2872,7 +2966,7 @@ end ideNewCard
 on idePropertyChanged pObject
    # If a highlighted object moved then reposition the tutorial step pointer
    if not pObject begins with "stack" and revTutorialObjectIsHighlighted(pObject) then
-      revTutorialPositionStackForHighlight
+      revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
    end if
    
    if revTutorialObjectIsTaggedObject(pObject, sWait["object"]) then
@@ -2894,7 +2988,7 @@ on ideStackMoved pStack
    put revIDEStackOfObject(pStack) into tStack
    # If the highlighted stack is moved, then reposition the tutorial step pointer
    if revTutorialObjectIsHighlighted(tStack) then
-      revTutorialPositionStackForHighlight
+      revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
    end if
 end ideStackMoved
 
@@ -2904,7 +2998,7 @@ on ideResumeStack pStack
    if not revTutorialObjectIsHighlighted(tStack) then
       # If the target stack is not highlighted then react accordingly
    else
-      revTutorialPositionStackForHighlight
+      revTutorialPositionStackForHighlight revTutorialTopLeftOverride()
    end if
 end ideResumeStack
 
@@ -2928,6 +3022,8 @@ on mouseDown
    put the long id of the target into tObject
    if word 1 of tObject is "button" then
       revTutorialSetPressedState tObject
+   else
+      revTutorialDragWindow
    end if
 end mouseDown
 
@@ -2937,6 +3033,8 @@ on mouseRelease
    if word 1 of tObject is "button" then
       revTutorialSetUnpressedState tObject
    end if
+   
+   revTutorialDragStop
 end mouseRelease
 
 on mouseUp pWhich
@@ -2960,7 +3058,67 @@ on mouseUp pWhich
    if word 1 of tObject is "button" then
       revTutorialSetUnpressedState tObject
    end if
+   
+   revTutorialDragStop
 end mouseUp
+
+on mouseMove
+   if revTutorialIsDraggingWindow() then
+      revTutorialTrackToMouse
+   end if
+end mouseMove
+
+local sMouseLoc, sMoved
+command revTutorialDragWindow
+   if sMouseLoc is not empty or the mouse is not "down" then
+      exit revTutorialDragWindow
+   end if
+   put the screenmouseloc into sMouseLoc
+end revTutorialDragWindow
+
+command revTutorialDragStart
+   lock screen
+   lock messages
+   local tTopLeft
+   put revTutorialGetEffectiveTopLeft() into tTopLeft
+   revTutorialOverrideLocation tTopLeft
+   unlock messages
+   unlock screen
+   
+   put true into sMoved
+end revTutorialDragStart
+
+command revTutorialDragStop
+   lock screen
+   lock messages
+   put empty into sMouseLoc
+   if sMoved then
+      revTutorialOverrideLocation the topleft of stack "revTutorial"
+   end if
+   put false into sMoved
+   unlock messages
+   unlock screen
+end revTutorialDragStop
+
+private function revTutorialIsDraggingWindow
+   return sMouseLoc is not empty
+end revTutorialIsDraggingWindow
+
+private command revTutorialTrackToMouse
+   if not sMoved then
+      revTutorialDragStart
+   end if
+   local tNewLoc, tNewTopLeft
+   put the screenmouseloc into tNewLoc
+   
+   local tTopLeft
+   put revTutorialGetEffectiveTopLeft() into tTopLeft
+   repeat with x = 1 to 2
+      put item x of tTopLeft + (item x of tNewLoc - item x of sMouseLoc) \ 
+            into item x of tNewTopLeft
+   end repeat
+   set the topleft of stack "revTutorial" to tNewTopLeft
+end revTutorialTrackToMouse
 
 on ideMouseDoubleUp pWhich, pTarget
    if sWait["wait condition"] is "state" and sWait["state"] is "double clicked" then
@@ -3104,33 +3262,40 @@ function revTutorialObjectIsHighlighted pObject
    return false
 end revTutorialObjectIsHighlighted
 
-on revTutorialPositionStackForHighlight
+on revTutorialPositionStackForHighlight pTopLeft
    lock screen
    switch sHighlight["type"]
       case "guide"
-         revTutorialPositionStack "", sGuides[sHighlight["guide"]]
+         revTutorialPositionStack "", sGuides[sHighlight["guide"]], "", "", pTopLeft
          break
       case "property"        
-         revTutorialPositionStack "inspector", sHighlight
+         revTutorialPositionStack "inspector", sHighlight, "", "", pTopLeft
          break
       case "menu"
-         revTutorialPositionStack "menubar", sHighlight["menu"]
+         revTutorialPositionStack "menubar", sHighlight["menu"], "", "", pTopLeft
          break
       case "toolbar"
-         revTutorialPositionStack "menubar", sHighlight["item"]
+         revTutorialPositionStack "menubar", sHighlight["item"], "", "", pTopLeft
          break
       case "tool"
-         revTutorialPositionStack "tools", sHighlight["tool"]
+         revTutorialPositionStack "tools", sHighlight["tool"], "", "", pTopLeft
          break
       case "object"  
-         revTutorialPositionStack sHighlight["stack"], sHighlight["object"], "", sHighlight["line"] is not empty
+         revTutorialPositionStack sHighlight["stack"], sHighlight["object"], "", sHighlight["line"] is not empty, pTopLeft
          break
       case "stack"
-         revTutorialPositionStack sHighlight["stack"], ""
+         revTutorialPositionStack sHighlight["stack"], "", "", "", pTopLeft
+         break
+      default
+         revTutorialPositionStack "", "", "", "", pTopLeft
          break
    end switch
    unlock screen
 end revTutorialPositionStackForHighlight
+
+on revTutorialOverrideLocation pTopLeft
+      revTutorialPositionStackForHighlight pTopLeft
+end revTutorialOverrideLocation
 
 on revTutorialClearHighlights
    switch sHighlight["type"]

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -443,7 +443,7 @@ end revTutorialParseLoad
 on revTutorialParseCapture pTokens, @rData
    local tData
    revTutorialParseLine "capture set <objlist> as <token>", pTokens, tData
-      if the result is empty then
+   if the result is empty then
       put "set" into rData["type"]
       put tData[1] into rData["objects"]
       put tData[2] into rData["tag"]
@@ -824,10 +824,6 @@ constant kMargin = 20
 constant kMessageWidth = 200
 constant kProgressHeight = 5
 
-constant kPointerHeight = 30
-constant kPointerWidth = 40
-constant kPointerOffset = 5
-
 constant kMaxScriptHeight = 200
 
 local sDontShow
@@ -987,70 +983,52 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
       put the working screenrect into tScreenRect
    end if
    
+   local tPointer
    if tHasPointer then
-      local tPointerLeft, tPointerTop, tCanFit
-      revTutorialEnsureOnscreen tWidth, tHeight, tScreenRect, tRect, tPointVertical, tPointerLeft, tPointerTop, tCanFit
-      
-      if not tCanFit then
-         put false into tHasPointer
-      end if
+      put revTutorialPointerCompute(tWidth, tHeight, tScreenRect, tRect, tPointVertical) \ 
+            into tPointer
    end if
    
-   local tNewShape
-   put revTutorialWindowShape(tWidth, tHeight, tHasPointer, tPointVertical, tPointerLeft, tPointerTop) into tNewShape
-   
-   if revTutorialWindowShapeDifferent(sLastShape, tNewShape) then
-      put tNewShape into sLastShape
-      if tHasPointer then
-         if the platform is "win32" then
-            set the windowshape of stack "revTutorial" to empty
-         end if
-      
-         revTutorialSetWindowShape tWidth, tHeight, tPointVertical, tPointerLeft, tPointerTop
-      else
-         set the windowshape of stack "revTutorial" to empty
-         set the decorations of stack "revTutorial" to empty
+   if tPointer is not empty then
+      if revTutorialPointerDifferent(tPointer) then
+         // Create the windowshape for the stack and pointer
+         revTutorialCreateStack tWidth, tHeight, tPointer
       end if
+   else
+      set the windowshape of stack "revTutorial" to empty
+      set the decorations of stack "revTutorial" to empty
    end if
+   
+   revTutorialSetPointer tPointer
    
    local tMessageLeft, tMessageTop
    put kMargin into tMessageLeft
    put kMargin into tMessageTop
-   if tHasPointer then
-      local tStackLeft, tStackTop
-      revTutorialStackPosition tWidth, tHeight, tRect, tPointVertical, tPointerLeft, tPointerTop, tStackLeft, tStackTop
-      
-      if tPointVertical then
-         add kPointerWidth / 2 to tHeight
-         if tPointerTop then
-            add kPointerWidth / 2 to tMessageTop
-         end if
-      else
-         add kPointerWidth / 2 to tWidth
-         if tPointerLeft then
-            add kPointerWidth / 2 to tMessageLeft
-         end if
-      end if
-      set the rect of stack "revTutorial" to 0, 0, tWidth, tHeight
-      set the topleft of stack "revTutorial" to tStackLeft, tStackTop
+   if tPointer is not empty then
+      revTutorialPositionStackAndPointer tWidth, tHeight, tRect, tPointer
+      add revTutorialPointerLeftOverhang(tPointer) to tMessageLeft
+      add revTutorialPointerTopOverhang(tPointer) to tMessageTop
    else
       set the rect of stack "revTutorial" to 0, 0, tWidth, tHeight
       set the loc of stack "revTutorial" to item 3 of tScreenRect / 2, item 4 of tScreenRect / 2
    end if
+   
    if tActionButton is not empty then
       local tButtonBottom, tButtonRight
       put tWidth - kMargin into tButtonRight
       put tHeight - kMargin into tButtonBottom
-      if tHasPointer and not tPointerLeft and not tPointVertical then
-         subtract kPointerWidth / 2 from tButtonRight
-      end if
+      
+      subtract revTutorialPointerRightOverhang(tPointer) from tButtonRight
+      subtract revTutorialPointerBottomOverhang(tPointer) from tButtonBottom
       set the bottomright of tActionButton to tButtonRight,tButtonBottom
    end if
+   
    if sIsInterlude then
       set the backColor of stack "revTutorial" to revTutorialInterludeColor()
    else
       set the backColor of stack "revTutorial" to revTutorialMessageColor()
    end if
+   
    
    set the topleft of tMsgFieldID to tMessageLeft, tMessageTop
    local tOtherTop
@@ -1069,72 +1047,19 @@ on revTutorialPositionStack pStack, pObject, pWidthOverride, pForceVertical
    unlock screen
 end revTutorialPositionStack
 
-function revTutorialWindowShape pWidth, pHeight, pHasPointer, pPointVertical, pPointerLeft, pPointerTop
-   local tShapeA
-   put pWidth into tShapeA["width"]
-   put pHeight into tShapeA["height"]
-   if not pHasPointer then
-      put false into tShapeA["pointer"]
-      return tShapeA
-   end if
-   
-   put true into tShapeA["pointer"]
-   put pPointVertical into tShapeA["pointer-vertical"]
-   put pPointerLeft into tShapeA["pointer-left"]
-   put pPointerTop into tShapeA["pointer-top"]
-   return tShapeA
-end revTutorialWindowShape
+command revTutorialPositionStackAndPointer @xContentWidth, @xContentHeight, pHighlightRect, pPointer
+   local tStackLeft, tStackTop, tWidth, tHeight
+   revTutorialPointerStackPosition xContentWidth, xContentHeight, pHighlightRect, pPointer, tStackLeft, tStackTop
+   revTutorialPointerStackSize xContentWidth, xContentHeight, pPointer
+   set the rect of stack "revTutorial" to 0, 0, xContentWidth, xContentHeight
+   set the topleft of stack "revTutorial" to tStackLeft, tStackTop
+end revTutorialPositionStackAndPointer   
 
-function revTutorialWindowShapeDifferent pOldShape, pNewShape
-   repeat for each key tKey in pNewShape
-      if pOldShape[tKey] is not pNewShape[tKey] then
-         return true
-      end if
-   end repeat
-   return false
-end revTutorialWindowShapeDifferent
-
-command revTutorialStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointVertical, pPointerLeft, pPointerTop, @rStackLeft, @rStackTop
-   local tLeft, tTop, tRight, tBottom
-   put item 1 of pHighlightRect into tLeft
-   put item 2 of pHighlightRect into tTop
-   put item 3 of pHighlightRect into tRight
-   put item 4 of pHighlightRect into tBottom
-   
-   local tStackTop, tStackLeft, tMiddle
-   if not pPointVertical then
-      put (tBottom + tTop) / 2 into tMiddle
-      if pPointerTop then
-         put tMiddle - kPointerWidth into tStackTop
-      else
-         put tMiddle - pContentHeight + kPointerWidth into tStackTop
-      end if
-      
-      if pPointerLeft then
-         put tRight + kPointerOffset into tStackLeft
-      else
-         put tLeft - pContentWidth - kPointerHeight + kPointerOffset into tStackLeft
-      end if
-   else
-      put (tRight + tLeft) / 2 into tMiddle
-      if pPointerTop then
-         put tBottom + 5 into tStackTop
-      else
-         put tTop - pContentHeight - kPointerHeight + kPointerOffset into tStackTop
-      end if
-      
-      if pPointerLeft then
-         put tMiddle - kPointerWidth into tStackLeft
-      else
-         put tMiddle - pContentWidth + kPointerWidth into tStackLeft
-      end if
-   end if
-   
-   put tStackLeft into rStackLeft
-   put tStackTop into rStackTop
-end revTutorialStackPosition   
-
-command revTutorialSetWindowShape pContentWidth, pContentHeight, pPointVertical, pPointerLeft, pPointerTop
+constant kPointerHeight = 30
+constant kPointerWidth = 40
+constant kPointerOffset = 40
+constant kPointerPadding = 5
+command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
    # Store templategraphic props (in case we have a graphic tool selected)
    local tProps
    put the properties of the templategraphic into tProps
@@ -1155,46 +1080,29 @@ command revTutorialSetWindowShape pContentWidth, pContentHeight, pPointVertical,
    set the style of it to "rectangle"
    set the width of it to pContentWidth
    set the height of it to pContentHeight
-
+   
    create graphic "Pointer" in tGroup
    put it into tPointer
    set the style of tPointer to "regular"
    set the polysides of tPointer to 4
    
-   local tX, tY
-   if not pPointVertical then
-      set the width of tPointer to kPointerWidth
-      set the height of tPointer to kPointerHeight
-      
-      if pPointerTop then
-         put the top of tGraphic + kPointerWidth into tY
-      else
-         put the bottom of tGraphic - kPointerWidth into tY
-      end if
-      
-      if pPointerLeft then
-         put the left of tGraphic into tX
-      else
-         put the right of tGraphic into tX
-      end if
-   else
+   local tSide, tPos
+   put revTutorialPointerSide(pPointer) into tSide
+   put revTutorialPointerPositionOnSide(pPointer) into tPos
+   
+   if revTutorialPointerVertical(pPointer) then
       set the width of tPointer to kPointerHeight
       set the height of tPointer to kPointerWidth
-
-      if pPointerTop then
-         put the top of tGraphic into tY
-      else
-         put the bottom of tGraphic into tY
-      end if
-      
-      if pPointerLeft then
-         put the left of tGraphic + kPointerWidth into tX
-      else
-         put the right of tGraphic - kPointerWidth into tX
-      end if
+   else
+      set the width of tPointer to kPointerWidth
+      set the height of tPointer to kPointerHeight
    end if
    
-   set the loc of tPointer to tX,tY
+   local tSource
+   put revTutorialPointerSource(pPointer, pContentWidth, pContentHeight) into tSource
+   set the loc of tPointer to \ 
+         the left of tGraphic + item 1 of tSource, \
+         the top of tGraphic + item 2 of tSource
    
    reset the templateGraphic
    set the properties of the templategraphic to tProps
@@ -1206,7 +1114,122 @@ command revTutorialSetWindowShape pContentWidth, pContentHeight, pPointVertical,
    
    set the windowshape of stack "revTutorial" to the id of tWindowShape
    delete tWindowShape
-end revTutorialSetWindowShape
+end revTutorialCreateStack
+
+##############################################################################
+#
+#                     POINTER MANAGEMENT
+#
+##############################################################################
+
+private function revTutorialPointerSide pPointer
+   set the itemdelimiter to "-"
+   return item 1 of pPointer
+end revTutorialPointerSide
+
+private function revTutorialPointerPositionOnSide pPointer
+   set the itemdelimiter to "-"
+   return item 2 of pPointer
+end revTutorialPointerPositionOnSide
+
+private function revTutorialPointerVertical pPointer
+   local tSide
+   put revTutorialPointerSide(pPointer) into tSide
+   return tSide is "top" or tSide is "bottom"
+end revTutorialPointerVertical
+
+private function revTutorialPointerLeft pPointer
+   return revTutorialPointerSide(pPointer) is "left" or  \
+         revTutorialPointerPositionOnSide(pPointer) is "left"
+end revTutorialPointerLeft
+
+private function revTutorialPointerSource pPointer, pStackWidth, pStackHeight
+   switch pPointer
+      case "top-left"
+         return kPointerOffset, 0
+      case "top-right"
+         return pStackWidth - kPointerOffset, 0
+      case "right-top"
+         return pStackWidth, kPointerOffset
+      case "right-bottom"
+         return pStackWidth, pStackHeight - kPointerOffset
+      case "bottom-right"
+         return pStackWidth - kPointerOffset, pStackHeight
+      case "bottom-left"
+         return kPointerOffset, pStackHeight
+      case "left-bottom"
+         return 0, pStackHeight - kPointerOffset
+      case "left-top"
+         return 0, kPointerOffset
+   end switch
+end revTutorialPointerSource
+
+local sPointer
+function revTutorialStackHasPointer
+   return sPointer is not empty
+end revTutorialStackHasPointer
+
+command revTutorialSetPointer pPointer
+   put pPointer into sPointer
+end revTutorialSetPointer
+
+function revTutorialPointerDifferent pPointer
+   return revTutorialPointerSide(pPointer) is not \ 
+         revTutorialPointerSide(sPointer)
+end revTutorialPointerDifferent
+
+function revTutorialPointerLeftOverhang pPointer
+   if revTutorialPointerSide(pPointer) is "left" then
+      return kPointerWidth / 2
+   end if
+   
+   return 0
+end revTutorialPointerLeftOverhang
+
+function revTutorialPointerTopOverhang pPointer
+   if revTutorialPointerSide(pPointer) is "top" then
+      return kPointerWidth / 2
+   end if
+   
+   return 0
+end revTutorialPointerTopOverhang
+
+function revTutorialPointerRightOverhang pPointer
+   if revTutorialPointerSide(pPointer) is "right" then
+      return kPointerWidth / 2
+   end if
+   
+   return 0
+end revTutorialPointerRightOverhang
+
+function revTutorialPointerBottomOverhang pPointer
+   if revTutorialPointerSide(pPointer) is "bottom" then
+      return kPointerWidth / 2
+   end if
+   
+   return 0
+end revTutorialPointerBottomOverhang
+
+private function revTutorialPointerPositionCompute pPointerVertical, pPointerLeft, pPointerTop
+   local tTopBottom, tLeftRight
+   if pPointerTop then
+      put "top" into tTopBottom
+   else
+      put "bottom" into tTopBottom
+   end if
+   
+   if pPointerLeft then
+      put "left" into tLeftRight
+   else
+      put "right" into tLeftRight
+   end if
+   
+   if pPointerVertical then
+      return tTopBottom & "-" & tLeftRight
+   else
+      return tLeftRight & "-" & tTopBottom
+   end if
+end revTutorialPointerPositionCompute
 
 private command revTutorialDecideSide pNear, pFar, @rNear, @rCanFit
    # If they are both zero then we can't fit
@@ -1263,9 +1286,9 @@ private command revTutorialTryToFitWithPointer pContentWidth, pContentHeight, pS
    put true into rCanFit
 end revTutorialTryToFitWithPointer
 
-private command revTutorialEnsureOnscreen pContentWidth, pContentHeight, pScreenRect, pHighlightRect, @xPointerVertical, @rPointerLeft, @rPointerTop, @rCanFit
+private function revTutorialPointerCompute pContentWidth, pContentHeight, pScreenRect, pHighlightRect, pPointerVertical
    local tPointerVertical, tPointerLeft, tPointerTop, tCanFit
-   put xPointerVertical into tPointerVertical
+   put pPointerVertical into tPointerVertical
    
    # Try with the pre-existing preference of pointer vertical / horizontal
    revTutorialTryToFitWithPointer pContentWidth, pContentHeight, pScreenRect, pHighlightRect, tPointerVertical, tPointerLeft, tPointerTop, tCanFit
@@ -1276,11 +1299,57 @@ private command revTutorialEnsureOnscreen pContentWidth, pContentHeight, pScreen
       revTutorialTryToFitWithPointer pContentWidth, pContentHeight, pScreenRect, pHighlightRect, tPointerVertical, tPointerLeft, tPointerTop, tCanFit
    end if
    
-   put tPointerVertical into xPointerVertical
-   put tPointerLeft into rPointerLeft
-   put tPointerTop into rPointerTop
-   put tCanFit into rCanFit
-end revTutorialEnsureOnscreen
+   if not tCanFit then
+      return empty
+   end if
+   return revTutorialPointerPositionCompute(tPointerVertical, tPointerLeft, tPointerTop)
+end revTutorialPointerCompute
+
+private command revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
+   local tLeft, tTop, tRight, tBottom
+   put item 1 of pHighlightRect into tLeft
+   put item 2 of pHighlightRect into tTop
+   put item 3 of pHighlightRect into tRight
+   put item 4 of pHighlightRect into tBottom
+   
+   local tSide
+   put revTutorialPointerSide(pPointer) into tSide
+   
+   local tSource
+   put revTutorialPointerSource(pPointer, pContentWidth, pContentHeight) into tSource
+   
+   local tStackTop, tStackLeft
+   switch tSide
+      case "top"
+         put tBottom + kPointerPadding into tStackTop
+         put (tRight + tLeft) / 2 - item 1 of tSource into tStackLeft
+         break
+      case "bottom"
+         put tTop - pContentHeight - kPointerPadding into tStackTop
+         put (tRight + tLeft) / 2 - item 1 of tSource into tStackLeft
+         break
+      case "left"
+         put tRight + kPointerPadding into tStackLeft
+         put (tTop + tBottom) / 2 - item 2 of tSource into tStackTop
+         break
+      case "right"
+         put tLeft - pContentWidth - kPointerPadding into tStackLeft
+         put (tTop + tBottom) / 2 - item 2 of tSource into tStackTop
+         break
+   end switch
+   
+   put tStackTop into rStackTop
+   put tStackLeft into rStackLeft
+end revTutorialPointerStackPosition
+
+command revTutorialPointerStackSize @xWidth, @xHeight, pPointer
+   if revTutorialPointerVertical(pPointer) then
+      add kPointerWidth / 2 to xHeight
+   else
+      add kPointerWidth / 2 to xWidth
+   end if
+end revTutorialPointerStackSize
+
 ##############################################################################
 #
 #                     MAIN FUNCTIONALITY
@@ -1644,11 +1713,15 @@ function revTutorialDonePercentage
    return 100 * (sStepNum - 1) / sNumSteps
 end revTutorialDonePercentage
 
+private command revTutorialShow
+   show stack "revTutorial"
+end revTutorialShow
+
 on revTutorialPrologue
    if sSteps["prologue"] is not empty then
       revTutorialDoInterlude false
       revTutorialSetText "prologue"
-      show stack "revTutorial"
+      revTutorialShow
    else
       send "revTutorialContinue" to stack "revTutorial" in 0 millisecs
    end if
@@ -1658,7 +1731,7 @@ on revTutorialEpilogue
    if sSteps["epilogue"] is not empty then
       revTutorialDoInterlude true
       revTutorialSetText "epilogue"
-      show stack "revTutorial"
+      revTutorialShow
    else
       revIDEStopTutorial
    end if
@@ -1739,7 +1812,7 @@ on revTutorialContinue
       revTutorialExecuteAction sSteps[sStepName]["actions"]["highlight"]
       unlock screen
       
-      show stack "revTutorial"
+      revTutorialShow
       -- Work around windowShape issue on Windows
       set the backcolor of this card of stack "revTutorial" to the backcolor of this card of stack "revTutorial"
       

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -1090,26 +1090,35 @@ command revTutorialCreateStack pContentWidth, pContentHeight, pPointer
    
    create graphic "Pointer" in tGroup
    put it into tPointer
-   set the style of tPointer to "regular"
-   set the polysides of tPointer to 4
    
-   local tSide, tPos
+   local tSide, tPos, tSource
    put revTutorialPointerSide(pPointer) into tSide
    put revTutorialPointerPositionOnSide(pPointer) into tPos
-   
-   if revTutorialPointerVertical(pPointer) then
-      set the width of tPointer to kPointerHeight
-      set the height of tPointer to kPointerWidth
-   else
-      set the width of tPointer to kPointerWidth
-      set the height of tPointer to kPointerHeight
-   end if
-   
-   local tSource
    put revTutorialPointerSource(pPointer, pContentWidth, pContentHeight) into tSource
-   set the loc of tPointer to \ 
-         the left of tGraphic + item 1 of tSource, \
-         the top of tGraphic + item 2 of tSource
+   
+   if pPointer["style"] is "original" then
+      set the style of tPointer to "regular"
+      set the polysides of tPointer to 4
+      
+      if revTutorialPointerVertical(pPointer) then
+         set the width of tPointer to kPointerHeight
+         set the height of tPointer to kPointerWidth
+      else
+         set the width of tPointer to kPointerWidth
+         set the height of tPointer to kPointerHeight
+      end if
+      
+      set the loc of tPointer to \ 
+            the left of tGraphic + item 1 of tSource, \
+            the top of tGraphic + item 2 of tSource
+   else
+      set the style of tPointer to "line"
+      set the lineSize of tPointer to 3
+      
+      local tTarget
+      put tPointer["end"]["x"], tPointer["end"]["y"] into tTarget
+      set the points of tPointer to tTarget & return & tSource
+   end if
    
    reset the templateGraphic
    set the properties of the templategraphic to tProps
@@ -1170,6 +1179,44 @@ private function revTutorialPointerSource pPointer, pStackWidth, pStackHeight
          return 0, kPointerOffset
    end switch
 end revTutorialPointerSource
+
+private command revTutorialPointerComputeTarget pContentWidth, pContentHeight, pHighlightRect, pStackTopLeft, @xPointer
+   local tLeft, tTop, tRight, tBottom
+   put item 1 of pHighlightRect into tLeft
+   put item 2 of pHighlightRect into tTop
+   put item 3 of pHighlightRect into tRight
+   put item 4 of pHighlightRect into tBottom
+   
+   local tSide
+   put revTutorialPointerSide(xPointer) into tSide
+   
+   local tSource
+   put revTutorialPointerSource(xPointer, pContentWidth, pContentHeight) into tSource
+   
+   local tAbsoluteX, tAbsoluteY
+   switch tSide
+      case "top"
+         put tBottom + kPointerPadding into tAbsoluteY
+         put (tRight + tLeft) / 2 into tAbsoluteX
+         break
+      case "bottom"
+         put tTop - pContentHeight - kPointerPadding into tAbsoluteY
+         put (tRight + tLeft) / 2 into tAbsoluteX
+         break
+      case "left"
+         put tRight + kPointerPadding into tAbsoluteX
+         put (tTop + tBottom) / 2 into tAbsoluteY
+         break
+      case "right"
+         put tLeft - pContentWidth - kPointerPadding into tAbsoluteX
+         put (tTop + tBottom) / 2 into tAbsoluteY
+         break
+   end switch
+   
+   put tAbsoluteX - item 1 of tSource into xPointer["end"]["x"]
+   put tAbsoluteY - item 2 of tSource into xPointer["end"]["y"]
+   put pStackTopLeft into xPointer["stacktopleft"]
+end revTutorialPointerComputeTarget
 
 local sPointer
 function revTutorialStackHasPointer
@@ -1308,6 +1355,29 @@ private command revTutorialTryToFitWithPointer pContentWidth, pContentHeight, pS
    put true into rCanFit
 end revTutorialTryToFitWithPointer
 
+private function revTutorialPointerComputeForTopLeft pWidth, pHeight, pTargetRect, pStackTopLeft
+   # Determine where the target rect is wrt the new stack position
+   local tLeftOffset, tTopOffset
+   put item 1 of pStackTopLeft - item 1 of pTargetRect into tLeftOffset
+   put item 2 of pStackTopLeft - item 2 of pTargetRect into tTopOffset
+   
+   local tPointerVertical, tPointerLeft, tPointerTop
+   if tLeftOffset >= -(pWidth / 2) then
+      put true into tPointerLeft
+   end if
+   if tTopOffset >= -(pHeight / 2) then
+      put true into tPointerTop
+   end if
+   put tTopOffset >= tLeftOffset into tPointerVertical
+   
+   local tPointer
+   put revTutorialPointerPositionCompute(tPointerVertical, tPointerLeft, tPointerTop) \
+         into tPointer["position"]
+   revTutorialPointerComputeTarget pWidth, pHeight, pTargetRect, pStackTopLeft, tPointer
+   put "override" into tPointer["style"]
+   return tPointer
+end revTutorialPointerComputeForTopLeft
+
 private function revTutorialPointerCompute pContentWidth, pContentHeight, pScreenRect, pHighlightRect, pPointerVertical
    local tPointerVertical, tPointerLeft, tPointerTop, tCanFit
    put pPointerVertical into tPointerVertical
@@ -1331,7 +1401,7 @@ private function revTutorialPointerCompute pContentWidth, pContentHeight, pScree
    return tPointer
 end revTutorialPointerCompute
 
-private command revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
+private command revTutorialPointerStackPositionOriginal pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
    local tLeft, tTop, tRight, tBottom
    put item 1 of pHighlightRect into tLeft
    put item 2 of pHighlightRect into tTop
@@ -1366,16 +1436,36 @@ private command revTutorialPointerStackPosition pContentWidth, pContentHeight, p
    
    put tStackTop into rStackTop
    put tStackLeft into rStackLeft
+end revTutorialPointerStackPositionOriginal
+
+private command revTutorialPointerStackPositionOverride pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
+   local tTopLeftOverride
+   put pPointer["stacktopleft"] into tTopLeftOverride
+   
+   put item 1 of tTopLeftOverride - revTutorialPointerLeftOverhang(pPointer) into rStackLeft
+   put item 2 of tTopLeftOverride - revTutorialPointerTopOverhang(pPointer) into rStackTop
+end revTutorialPointerStackPositionOverride
+
+private command revTutorialPointerStackPosition pContentWidth, pContentHeight, pHighlightRect, pPointer, @rStackLeft, @rStackTop
+   if pPointer["style"] is "original" then
+      revTutorialPointerStackPositionOriginal pContentWidth, pContentHeight, pHighlightRect, pPointer, rStackLeft, rStackTop
+   else
+      revTutorialPointerStackPositionOverride pContentWidth, pContentHeight, pHighlightRect, pPointer, rStackLeft, rStackTop
+   end if
 end revTutorialPointerStackPosition
 
 command revTutorialPointerStackSize pContentWidth, pContentHeight, pPointer, @rWidth, @rHeight
-   if revTutorialPointerVertical(pPointer) then
-      put pContentHeight + kPointerWidth / 2 into rHeight
-      put pContentWidth into rWidth
-   else
-      put pContentWidth + kPointerWidth / 2 into rWidth
-      put pContentHeight into rHeight
-   end if
+   local tWidth, tHeight
+   put pContentWidth into tWidth
+   put pContentHeight into tHeight
+   
+   add revTutorialPointerLeftOverhang(pPointer) to tWidth
+   add revTutorialPointerRightOverhang(pPointer, pContentWidth) to tWidth
+   add revTutorialPointerTopOverhang(pPointer) to tHeight
+   add revTutorialPointerBottomOverhang(pPointer, pContentHeight) to tHeight
+   
+   put tWidth into rWidth
+   put tHeight into rHeight
 end revTutorialPointerStackSize
 
 ##############################################################################

--- a/notes/bugfix-19889.md
+++ b/notes/bugfix-19889.md
@@ -1,0 +1,1 @@
+# Allow tutorial instruction window to be moved


### PR DESCRIPTION
- Turn pointer 'object' into array
The 'pointer' that is passed to various utility functions is now
an array, with its old value (the string top-left, top-right etc)
now under the array key "position".

- Tweak pointer API for top left override
Add to pointer API so that the topleft of the content rect of the
tutorial stack can be overridden

- Allow tutorial window to be dragged 
This patch uses the modified pointer API to allow the tutorial
message stack to be dragged anywhere on the screen while continuing
to point to the intended target.