### PR TITLE
[[ Bug 19961 ]] Fix set property editor

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.set.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.set.behavior.livecodescript
@@ -51,7 +51,10 @@ on editorResize
    lock screen
    lock messages
    set the lockLoc of me to true
-   set the rect of field 1 of me to the rect of me
+   local tRect
+   put the rect of me into tRect
+   put item 2 of tRect + the formattedHeight of field 1 of me into item 4 of tRect
+   set the rect of field 1 of me to tRect
    unlock messages
    unlock screen
 end editorResize

--- a/notes/bugfix-19961.md
+++ b/notes/bugfix-19961.md
@@ -1,0 +1,1 @@
+# Prevent property inspector 'set type' property editor from expanding at will


### PR DESCRIPTION
The height of editor components needs to be dependent on the content
rather than the height of the group containing the content, otherwise
it is not fixed, which causes the layout to be calculated incorrectly.