### PR TITLE
[[ Bug 19988 ]] Add Edit Behavior Script contextual menu

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -1983,6 +1983,8 @@ function revMenubarStackContextMenu pStack, pIndent
    
    local tText
    put tIndent & "Edit Script" & return after tText
+   put tIndent & enableMenuItem("Edit Behavior Script", \
+         exists(the behavior of stack pStack)) & return after tText
    put tIndent & "Property Inspector" & return after tText
    put tIndent & "-" & return after tText
    put tIndent & "Stack Mode" & return after tText
@@ -2040,7 +2042,7 @@ function revMenuBarCardContextMenu pCard, pIndent
    put revIDEStackOfObject(pCard) into tTargetStack
    
    local tText
-   put revMenuBarStandardContextMenu(pIndent) & return into tText
+   put revMenuBarStandardContextMenu(pCard, pIndent) & return into tText
    put tIndent & "-" & return after tText
    put tIndent & enableMenuItem("Paste Objects", the clipboard is "objects" and the mode of stack tTargetStack is 1) & return after tText
    put tIndent & "-" & return after tText
@@ -2059,7 +2061,7 @@ function revMenuBarObjectContextMenu pExtraText, pObject, pIndent, pSelectable
    end repeat
    
    local tText
-   put revMenuBarStandardContextMenu(pIndent, pSelectable) & return into tText
+   put revMenuBarStandardContextMenu(pObject, pIndent, pSelectable) & return into tText
    repeat for each line tLine in pExtraText
       put tIndent & tLine & return after tText
    end repeat
@@ -2069,7 +2071,7 @@ function revMenuBarObjectContextMenu pExtraText, pObject, pIndent, pSelectable
    return tText
 end revMenuBarObjectContextMenu
 
-function revMenuBarStandardContextMenu pIndent, pSelectable
+function revMenuBarStandardContextMenu pObject, pIndent, pSelectable
    local tIndent
    repeat pIndent
       put tab after tIndent
@@ -2077,6 +2079,8 @@ function revMenuBarStandardContextMenu pIndent, pSelectable
    
    local tText
    put tIndent & "Edit Script" & return after tText
+   put tIndent & enableMenuItem("Edit Behavior Script", \
+         exists(the behavior of pObject)) & return after tText
    put tIndent & "Property Inspector" & return after tText
    put tIndent & "-" & return after tText
    put tIndent & enableMenuItem("Cut", pSelectable) & return after tText
@@ -2472,6 +2476,9 @@ on revMenubarContextMenuPickTarget pWhich, pTarget
       ######## OBJECTS #########
       case "Edit Script"
          revIDEEditScriptOfObjects pTarget
+         break
+      case "Edit Behavior Script"
+         revIDEEditScriptOfObjects the behavior of pTarget
          break
       case "Property Inspector"
          revIDEOpenInspectorForObjects pTarget

--- a/notes/bugfix-19988.md
+++ b/notes/bugfix-19988.md
@@ -1,0 +1,1 @@
+i# Add Edit Behavior Script contextul menu item


### PR DESCRIPTION
This patch adds an Edit Behavior Scropt contextual menu that is
enabled when an object has a behavior that is currently loaded
into memory.