### PR TITLE
[[ DefaultHandlers ]] Make sure textSetScriptRaw is still always called

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -330,16 +330,14 @@ command loadScript
       # If there is a cached script, this means that the user is coming back to this object from another tab.
       textSetScriptRaw tCachedScript
    else
-      # If the object has no script, get the default script for it, otherwise the current script is used
-      if the script of sObjectId is not empty then
-         local tScript
-         put the script of sObjectId into tScript
-         
-         textSetScriptRaw tScript
-         
-         # OK-2008-07-07 : Bug 6746
-         seUpdateCheckSum sObjectId, tScript
-      else
+      local tScript
+      put the script of sObjectId into tScript
+      
+      textSetScriptRaw tScript
+      
+      # OK-2008-07-07 : Bug 6746
+      seUpdateCheckSum sObjectId, tScript
+      if tScript is empty then   
          select before field "Script" of me
       end if
    end if

--- a/Toolset/palettes/script editor/behaviors/revsehandlerlistbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsehandlerlistbehavior.livecodescript
@@ -259,7 +259,7 @@ command resize
    unlock screen
 end resize
 
-command jumpToHandler pHandler
+command jumpToHandler pHandler, pAdded
    local tLineNumber
    put word 3 of pHandler into tLineNumber
    
@@ -268,7 +268,7 @@ command jumpToHandler pHandler
    set the cChoice of me to tLineNumber & comma & word 2 of pHandler & comma & word 1 of pHandler
    
    if the cCallback of me is not empty then
-      send the cCallback of me to the cCallbackTarget of me
+      send the cCallback of me && pAdded to the cCallbackTarget of me
    end if
    
    hideGroup
@@ -279,7 +279,10 @@ command closeAccept
    local tHandler
    put line (the hilitedLine of field "Handlers" of me) of the cHandlers of field "Handlers" of me into tHandler
    
+   local tAdded
+   put false into tAdded
    if the number of words in tHandler is 1 then
+      put true into tAdded
       -- Adding a default handler
       revSEAddDefaultHandler tHandler
       update
@@ -291,7 +294,7 @@ command closeAccept
    end if
    
    -- Select the (now) extant handler
-   jumpToHandler tHandler
+   jumpToHandler tHandler, tAdded
    
    unlock screen
 end closeAccept

--- a/Toolset/palettes/script editor/behaviors/revseleftbarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseleftbarbehavior.livecodescript
@@ -98,7 +98,7 @@ end updateSelectedHandler
 # Description
 #   Callback for the handler list object. This is called when the stack is closed
 #   which either means the user has chosen a handler, or dismissed the stack.
-on handlerSelected
+on handlerSelected pNewlyAdded
    local tObject
    put the long id of group "Left Handler List" of me into tObject
    
@@ -114,6 +114,11 @@ on handlerSelected
    # list may be wrong because its the last known location of the handler when the script was compiled. To try and locate
    # the handler correctly we call this function which will check if tLine is wrong, and attempt to adjust it.
    put seLocateHandler(tHandler, tLine, tType) into tLine
+   
+   -- If we just added this handler, select at the (empty) line after the handler decl.
+   if pNewlyAdded then
+      add 1 to tLine
+   end if
    
    send "goLine tLine, true" to group "Editor"
    seUpdateToolbar


### PR DESCRIPTION
Removing this call previously caused objects with empty scripts to
acquire the non-empty script of the currently displayed object.