### PR TITLE
[[ Extensions ]] Add 'objc' as builtin module

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -758,6 +758,7 @@ private function __extensionIsBuiltin pID
       case "com.livecode.typeconvert"
       case "com.livecode.extensions.libbrowser"
       case "com.livecode.java"
+      case "com.livecode.objc"
          return true
       default
          return false


### PR DESCRIPTION
This patch adds 'com.livecode.objc' to the list of builtin modules
in revideextensionlibrary.livecodescript.