### PR TITLE
[[ Bug 20039 ]] Tutorial 'do it for me' should center new controls

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3389,7 +3389,11 @@ on revIDECreateObject pObjectTypeID, pTarget, pLoc
    if sClassicObjectProperties is empty then __objectPropertiesRead
    # Set the default stack to the target we're creating the object on
    set the defaultstack to revIDEStackOfObject(pTarget)
-
+   
+   if pLoc is empty then
+      put the loc of this card of the defaultStack into pLoc
+   end if
+   
    # Create the object
    lock screen
    lock messages

--- a/Toolset/palettes/tutorial/revtutorial.livecodescript
+++ b/Toolset/palettes/tutorial/revtutorial.livecodescript
@@ -3757,7 +3757,7 @@ on revTutorialCreateAndCaptureObjects pWaitData, pCaptureData, pHighlightData
       else
          if pHighlightData["tool"] is not empty then
             dispatch function "toolObjectName" to stack "revTools" with pHighlightData["tool"]
-            revIDECreateObject the result, sTaggedObjects["stack"][tCapture["target stack"]["tag"]], "0,0"
+            revIDECreateObject the result, sTaggedObjects["stack"][tCapture["target stack"]["tag"]]
             put the result into sTaggedObjects[tType][tCapture["tag"]]
          else if pHighlightData["item"][1] contains "Import" then
             # Deal with 'import'

--- a/notes/bugfix-20039.md
+++ b/notes/bugfix-20039.md
@@ -1,0 +1,1 @@
+# Position tutorial controls in better location when using 'Do It For Me'


### PR DESCRIPTION
Tweak revIDECreateObject to default to center of target stack, and
use default positioning with tutorial 'do it for me' functionality.