### PR TITLE
[Bug 18366] Enable control-tab on Mac OS

### DIFF
--- a/Documentation/guides/The LiveCode IDE.md
+++ b/Documentation/guides/The LiveCode IDE.md
@@ -784,6 +784,8 @@ Figure 12 – Find and Replace
 | Find next                                      | Control-g                               | Command-g                               |
 | Find selected text                             | Control-Option-f                        | Command-Option-f                        |
 | Format current handler                         | Tab                                     | Tab                                     |
+| Next tab in Editor                             | Control-tab                             | Control-tab                             |
+| Previous tab in Editor                         | Control-shift-tab                       | Control-shift-tab                       |
 
 | **The Message Box** |  **Windows / Linux** | **Mac OS X**|
 |------|--------|-------|

--- a/Documentation/guides/The LiveCode IDE.md
+++ b/Documentation/guides/The LiveCode IDE.md
@@ -784,8 +784,8 @@ Figure 12 – Find and Replace
 | Find next                                      | Control-g                               | Command-g                               |
 | Find selected text                             | Control-Option-f                        | Command-Option-f                        |
 | Format current handler                         | Tab                                     | Tab                                     |
-| Next tab in Editor                             | Control-tab                             | Control-tab                             |
-| Previous tab in Editor                         | Control-shift-tab                       | Control-shift-tab                       |
+| Next tab in Editor                             | Command-tab                             | Control-tab                             |
+| Previous tab in Editor                         | Command-shift-tab                       | Control-shift-tab                       |
 
 | **The Message Box** |  **Windows / Linux** | **Mac OS X**|
 |------|--------|-------|

--- a/Documentation/guides/The LiveCode IDE.md
+++ b/Documentation/guides/The LiveCode IDE.md
@@ -784,8 +784,8 @@ Figure 12 – Find and Replace
 | Find next                                      | Control-g                               | Command-g                               |
 | Find selected text                             | Control-Option-f                        | Command-Option-f                        |
 | Format current handler                         | Tab                                     | Tab                                     |
-| Next tab in Editor                             | Command-tab                             | Control-tab                             |
-| Previous tab in Editor                         | Command-shift-tab                       | Control-shift-tab                       |
+| Next tab in Editor                             | Control-tab                             | Control-tab                             |
+| Previous tab in Editor                         | Control-shift-tab                       | Control-shift-tab                       |
 
 | **The Message Box** |  **Windows / Linux** | **Mac OS X**|
 |------|--------|-------|

--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -1971,6 +1971,12 @@ on tabKey
       pass tabKey
    end if
    
+   # bhall2001-2017-07-18: Bug 18366 On MacOS, to prevent interference
+   # with the use of control+tab to cycle between tabs
+   if (the platform is "MacOS") and (the controlKey is "down") then
+      pass tabKey
+   end if 
+
    if scriptLocked() then
       exit tabKey
    end if

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -2639,7 +2639,12 @@ end closeStackRequest
 #   This handles tabKey based keyboard shortcuts. The only one by default is to switch between tabs
 #   Note that only command + tab shortcuts are allowed to prevent interference with other functions.
 on tabKey
-   if the commandKey is not "down" then
+   # bhall2001-2017-07-18: Bug 18366 On MacOS, Use control+tab to cycle between tabs
+   if (the commandKey is not "down") and (the platform is not "MacOS") then
+      pass tabKey
+   end if
+
+   if (the platform is "MacOS") and (the controlKey is not "down") then
       pass tabKey
    end if
    

--- a/notes/bugfix-18366.md
+++ b/notes/bugfix-18366.md
@@ -1,0 +1,1 @@
+# Enable control+tab on MacOS


### PR DESCRIPTION
Allow use of control-tab & control-shift-tab on Mac OS to cycle between tabs in the Script Editor.