### PR TITLE
[[ Tests ]] Redirect stderr to /dev/null in IDE test subprocess

### DIFF
--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -263,7 +263,7 @@ private command runAllTests pInfo
    end repeat
    
    -- Add the target stack (this one)
-   put tCommand && pInfo["self-script"] into tCommand
+   put tCommand && pInfo["self-script"] && "2>/dev/null" into tCommand
 
    -- Execute the shell command   
    put shell(tCommand) into tTestOutput


### PR DESCRIPTION
This patch fixes the interleaved stdout/stderr problem that is causing the IDE test runner to fail.