### PR TITLE
[[ Bug 18881 ]] Sort API Dictionaries

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -9,6 +9,11 @@
 	function dataGet(){
 		//console.log(dictionary_data.docs);
 		
+		//sort API dictionaries, leave LiveCode Script/LiveCode Builder as first 2 entries
+		if(tState.selected_api_id == ""){
+			dictionary_data.docs = dictionary_data.docs.sort(compareDictionaryObject);
+		}
+
 		if(!dictionary_data.docs.hasOwnProperty(tState.selected_api_id)){
 			
 			$.each(dictionary_data.docs, function(index, libraryData){
@@ -25,6 +30,29 @@
 		return tState.data;
 	}
 	
+
+	//customized sort for API dictionaries
+	function compareDictionaryObject(entryObject1,entryObject2) {
+		if(entryObject1["display name"] == "LiveCode Script" && entryObject2["display name"] == "LiveCode Builder")
+			return -1;
+		if(entryObject2["display name"] == "LiveCode Script" && entryObject1["display name"] == "LiveCode Builder")
+			return 1;
+		if(entryObject1["display name"] == "LiveCode Script")
+			return -3;
+		if(entryObject2["display name"] == "LiveCode Script")
+			return 3;
+		if(entryObject1["display name"] == "LiveCode Builder")
+			return -2;
+		if(entryObject2["display name"] == "LiveCode Builder")
+			return 2;
+		if(entryObject1["display name"].toLowerCase() < entryObject2["display name"].toLowerCase())
+			return -1;
+		if (entryObject1["display name"].toLowerCase() > entryObject2["display name"].toLowerCase())
+			return 1;
+		return 0;
+	}
+
+
 	// Return all the syntax associated with an entry
 	// as a (matchable) string
 	function collectSyntax(pEntry)

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -11,7 +11,7 @@
 		
 		//sort API dictionaries, leave LiveCode Script/LiveCode Builder as first 2 entries
 		if(tState.selected_api_id == ""){
-			dictionary_data.docs = dictionary_data.docs.sort(compareDictionaryObject);
+			dictionary_data.docs.sort(compareDictionaryObject);
 		}
 
 		if(!dictionary_data.docs.hasOwnProperty(tState.selected_api_id)){

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -33,18 +33,14 @@
 
 	//customized sort for API dictionaries
 	function compareDictionaryObject(entryObject1,entryObject2) {
-		if(entryObject1["display name"] == "LiveCode Script" && entryObject2["display name"] == "LiveCode Builder")
-			return -1;
-		if(entryObject2["display name"] == "LiveCode Script" && entryObject1["display name"] == "LiveCode Builder")
-			return 1;
 		if(entryObject1["display name"] == "LiveCode Script")
-			return -3;
+			return -1;
 		if(entryObject2["display name"] == "LiveCode Script")
-			return 3;
+			return 1;
 		if(entryObject1["display name"] == "LiveCode Builder")
-			return -2;
+			return -1;
 		if(entryObject2["display name"] == "LiveCode Builder")
-			return 2;
+			return 1;
 		if(entryObject1["display name"].toLowerCase() < entryObject2["display name"].toLowerCase())
 			return -1;
 		if (entryObject1["display name"].toLowerCase() > entryObject2["display name"].toLowerCase())

--- a/notes/bugfix-18881.md
+++ b/notes/bugfix-18881.md
@@ -1,0 +1,1 @@
+# Dictionary: sort API menu


### PR DESCRIPTION
Add custom sort function to dictionary_functions.js and call upon load to sort the API dictionaries.
Keeps "LiveCode Script" and "LiveCode Builder" as the first two entries.
LC requests to display an entry use the dictionary name vice ID.