### PR TITLE
[[ Bug 19031 ]] Search dictionary with $

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -50,8 +50,15 @@
 		tState.searched.term = pTerm;
 		tState.searched.data = [];
 		
+		// Escape leading special characters:  \ ^ $ [
+		var tTerm = pTerm;
+		if(pTerm.search(/^[\\\^\$\[]/) == 0)
+		{
+			tTerm = "\\" + pTerm;
+		}
+
 		// Get a list of space-delimited search terms				
-   		var tokensOfTerm = pTerm.match(/\S+/g);
+   		var tokensOfTerm = tTerm.match(/\S+/g);
 		
 		
 		// Generate two regexes - one that matches all syntax that 

--- a/notes/bugfix-19031.md
+++ b/notes/bugfix-19031.md
@@ -1,0 +1,1 @@
+# Searching the Dictionary for $


### PR DESCRIPTION
The dictionary uses regular expressions to perform the term matches.  \ ^ $ and [ are 4 special characters that make sense to escape when the first character.  While it would be "correct" to do global replacements, these characters only make sense as the first character is most cases.  Global replacements would remove the ability for an advanced user to perform RegEx searches if any of those characters were required.  As implemented, the only change needed would be for leading use of \ ^ or [ to be prefixed with a space.  A good example to see the impact (in the current dictionary) is "num" and "^num\b".

( and ) could be escaped as well, but I didn't see a useful reason to use them in a search unless doing some form of RegEx where they would need to be left alone.  There are too many results to searches on ( or () for either to be useful.

One alternative that would be easy to code would be to only escape \ ^ and [ if the string is a single character (but also account for []).  This would allow valid RegEx searches without modification from the current implementation.  The only reason that I didn't start with that is the code is much cleaner just escaping the characters.