### PR TITLE
[[ Bug ]] Don't fall through switch in menu handling

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
@@ -500,6 +500,7 @@ private command handleHelpMenuPick pItemName
       case "Resource Center"
       case "Start Center"
          revIDEOpenPalette pItemName
+         break
       case "User Guide"
          revIDELaunchResource pItemName
          break


### PR DESCRIPTION
This will unintentionally cause the user guide to be opened as
well as the start center from this menu