### PR TITLE
[ Bug 20140 ] breakpoints lag Editor scrolling

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -1222,8 +1222,9 @@ command updateGutterRequest pOffset, pSelectedLine, pOldLines, pNewLines, pTextC
    # 2017-JUL-28 bhall2001
    # We always update the gutter's scroll immediately, as otherwise it looks bad.   
    # For best scroll performance, we set the Gutter scroll directly.
-   set the vScroll of field "Numbers" of group "Gutter" to the vScroll of field "Script" of group "Editor"
-   
+   if exists(field "Numbers" of group "Gutter") then
+      set the vScroll of field "Numbers" of group "Gutter" to the vScroll of field "Script" of me
+   end if
    # BUGFIX-20140
    # 2017-JUL-28 bhall2001 Due to blocking nature of scrolling and key presses, don't send in time.
    # UI effect is Gutter lags behind scrolling of Script Editor   

--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -51,6 +51,14 @@ local sEditPlaceholder
 constant kPlaceholderDefaultSearchLines = 20
 constant kPlaceholderDefaultBackgroundColor = "240,240,240"
 
+# 2017-08-01 bhall2001 previous vScroll position of the Editor field
+local sVScroll
+
+# 2017-08-01 bhall2001 Toggles between true/false on each up arrow key pressed
+# Note: up arrow key sends 2 scrollBarDrag messages. Used as flag
+# to process only 1 of the messages.
+local sSkipUpArrow = false
+
 # OK-2009-01-17 : Bug 7169
 command setDirty pObject, pValue
    put pValue into sDirty[pObject]
@@ -1999,8 +2007,6 @@ on optionKeyDown pKey
    keyDown pKey
 end optionKeyDown
 
-local sVScroll
-
 on scrollBarDrag
    if not handleEvent("scrollBarDrag", the long id of the target) then
       pass scrollBarDrag
@@ -2346,9 +2352,6 @@ private command pageDown
       select after char tEndChar of field (the short name of getScriptField()) of me
    end if
 end pageDown
-
-
-local sSkipUpArrow = false
 
 # Description
 #   RawKeyDown is handled mainly because of the home and end keys. These need to be manually implemented on OS X

--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2439,7 +2439,7 @@ on rawKeyDown pKey
          # 2017-JUL-28 bhall2001
          # when scrolling on up arrow, scrollBarDrag is sent twice. Set
          # flag to update on every other up arrow message
-         put not sSkipUpArrow into sKeyUpArrow
+         put not sSkipUpArrow into sSkipUpArrow
          put "up" into tKeyName
          break
       case kKeyDownArrow

--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -1,4 +1,4 @@
-﻿script "com.livecode.scripteditor.behavior.editorcommon"
+script "com.livecode.scripteditor.behavior.editorcommon"
 local sObjectId
 
 # The following variables store information used for the undo / redo system.
@@ -1200,8 +1200,8 @@ end getUpdateGutterRequestDetails
 #   pUpdateCompilationErrors : whether to update the gutter's compilation errors
 # Description
 #   Sends a request to update the gutter. This is called whenever the current script is edited, or the field
-#   is scrolled etc. A request is sent using a short delay and any previous requests are cancelled.
-#  The gutter's scroll is updated immediately however. Also a message is sent to the gutter to hide its
+#   is scrolled etc. 
+#  The gutter's scroll is updated immediately. Also a message is sent to the gutter to hide its
 #  mutable objects (the breakpoint / compilation error images). These are show again when the update is
 #  actually carried out.
 command updateGutterRequest pOffset, pSelectedLine, pOldLines, pNewLines, pTextChanged, pUpdateCompilationErrors, pForceBreakpointRedraw
@@ -1210,11 +1210,16 @@ command updateGutterRequest pOffset, pSelectedLine, pOldLines, pNewLines, pTextC
       cancel sGutterUpdateRequest
    end if
    
-   # We always update the gutter's scroll immediately, as otherwise it looks bad. Other stuff is delayed though.
-   if there is a group "Gutter" of me then
-      send "updateScroll" to group "Gutter" of me
-   end if
-   send "updateGutterDo" to me in 5 milliseconds
+   # BUGFIX-20140
+   # 2017-JUL-28 bhall2001
+   # We always update the gutter's scroll immediately, as otherwise it looks bad.   
+   # For best scroll performance, we set the Gutter scroll directly.
+   set the vScroll of field "Numbers" of group "Gutter" to the vScroll of field "Script" of group "Editor"
+   
+   # BUGFIX-20140
+   # 2017-JUL-28 bhall2001 Due to blocking nature of scrolling and key presses, don't send in time.
+   # UI effect is Gutter lags behind scrolling of Script Editor   
+   updateGutterDo
    put the result into sGutterUpdateRequest
 end updateGutterRequest
 
@@ -1994,12 +1999,27 @@ on optionKeyDown pKey
    keyDown pKey
 end optionKeyDown
 
+local sVScroll
+
 on scrollBarDrag
    if not handleEvent("scrollBarDrag", the long id of the target) then
       pass scrollBarDrag
    end if
+
+   local tVScroll
+   
+   # 2017-JUL-28 bhall2001
+   # update only when vScroll changes. Mouse wheel scrolling sends
+   # vScrolls that don't change. Up arrow causes 2 scrollBarDrag message
+   # so we skip the message when up arrow flag is set.
+   put the vScroll of the target into tVScroll
+   if (tVScroll = sVScroll) or sSkipUpArrow then exit scrollBarDrag
+   
+   lock screen
+   put tVScroll into sVScroll
    
    updateGutterRequest empty, empty, empty, empty, false, true
+   unlock screen
 end scrollBarDrag
 
 on keyDown pChar
@@ -2328,6 +2348,8 @@ private command pageDown
 end pageDown
 
 
+local sSkipUpArrow = false
+
 # Description
 #   RawKeyDown is handled mainly because of the home and end keys. These need to be manually implemented on OS X
 #   and both platforms after pressing the home key we have to ensure the caret ends up in the right place.
@@ -2411,6 +2433,10 @@ on rawKeyDown pKey
          put "right" into tKeyName
          break
       case kKeyUpArrow
+         # 2017-JUL-28 bhall2001
+         # when scrolling on up arrow, scrollBarDrag is sent twice. Set
+         # flag to update on every other up arrow message
+         put not sSkipUpArrow into sKeyUpArrow
          put "up" into tKeyName
          break
       case kKeyDownArrow

--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -977,10 +977,11 @@ end getLastGoneToLine
 #   Deselects the last line that was selected by the goLine command if there was one
 #   and it is still selected.
 command deselectLastGoneToLine
+   lock screen
    get the selectedChunk
    -- MM-2012-06-20: [[ Bug 10027 ]] Make sure there was a last line selected - causes bugs deselects elsewhere within the IDE.
    if sLastSelectedGoneToChunk is not empty and word 2 of it is item 1 of sLastSelectedGoneToChunk and word 4 of it is item 2 of sLastSelectedGoneToChunk then
-      lock screen
+      
       lock messages
       local tSelobj
       put revIDESelectedObjects() into tSelobj
@@ -990,12 +991,13 @@ command deselectLastGoneToLine
       end if
       set the backgroundColor of char (item 1 of sLastSelectedGoneToChunk) to (item 2 of sLastSelectedGoneToChunk) of field "Script" of me to empty
       unlock messages
-      unlock screen
+      
    end if
    put empty into sLastSelectedGoneToChunk
    
    # We update the gutter here to remove the current line indicator
    updateGutterRequest empty, empty, empty, empty, false, false
+   unlock screen
 end deselectLastGoneToLine
 
 

--- a/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
@@ -33,9 +33,12 @@ local sErrors
 #   Causes the gutter to update itself.
 command update pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, pUpdateCompilationErrors, pForceBreakpointRedraw
    local tContext, tUpdateRequired
+   
+   lock screen
    put updateGetContext(pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, pUpdateCompilationErrors, pForceBreakpointRedraw, tContext) into tUpdateRequired
    
    if not tUpdateRequired then
+      unlock screen
       exit update
    end if
    
@@ -50,8 +53,6 @@ command update pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, pUp
    if tContext["object"] is not empty then
       put tContext["object"] into sLastObject
    end if
-   
-   lock screen
    
    updateBreakpoints pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, tContext
    updateLineNumbers pTextChanged, pOldNumber, pNewNumber, tContext
@@ -310,6 +311,10 @@ end updateCurrentLine
 # Description
 #   If there are not enough line numbers to add to the field
 command updateLineNumbers pTextEdited, pOldNumber, pNewNumber, pContext
+   
+   # only update if there's work to be done
+   if pContext["numberOfAdditions"] <= 0 then exit updateLineNumbers
+   
    # Add the lines in a non-locking manner, and after we've finished adding lines, the scroll
    # of the line numbers field should be updated.
    repeat pContext["numberOfAdditions"] times
@@ -775,6 +780,10 @@ end menuPick
 on rawKeyDown
   # Block this message as the gutter must only be scrolled in response to the main script field
 end rawKeyDown
+
+on scrollBarDrag
+  # Block this message as the gutter must only be scrolled in response to the main script field
+end scrollBarDrag
 
 # Returns
 #   A random name used for naming mutable controls. In particular, breakpoint images.

--- a/notes/bugfix-20140.md
+++ b/notes/bugfix-20140.md
@@ -1,0 +1,1 @@
+# breakpoints better tracking of editor scrolling


### PR DESCRIPTION
Removed send in time messages for gutter updates
Enhanced scrolling performance to account for not sending in time
   - moved/added lock screen
   - reduced duplicate calls to update gutter
        - vScroll doesn’t change
        - up arrow duplicate scrollBarDrag message
        - line number update gutter on each call
   - update vScroll of Gutter directly instead of using “send” command