### PR TITLE
[bug 20214] Fix for breakpoints that may not toggle

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
@@ -676,9 +676,9 @@ on mouseUp pButtonNumber
    local tTarget, tClickLoc
    put the long id of the target into tTarget
    put the clickloc into tClickLoc
-   -- We might delete the target if it is a breakpoint, so do mouseUp
-   -- handling with a send.
-   send "gutterMouseUp tTarget, tClickLoc" to me in 0 millisecs
+   # 2017-08-01 bhall2001
+   # bugfix 20214 handle changes to gutter directly
+   gutterMouseUp tTarget, tClickLoc
 end mouseUp
 
 on gutterMouseUp pTarget, pClickLoc

--- a/notes/bugfix-20214.md
+++ b/notes/bugfix-20214.md
@@ -1,0 +1,1 @@
+# Breakpoints may not toggle when clicked


### PR DESCRIPTION
Breakpoints do not toggle if clicked on in short time frame. Removed “send in time” message.