### PR TITLE
[[Bug 20289]] Improve dictionary sort

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -85,20 +85,24 @@
    		var tokensOfTerm = tTerm.match(/\S+/g);
 		
 		
-		// Generate two regexes - one that matches all syntax that 
+		// Generate three regexes - one that matches all syntax that 
 		// contains each search term, and one that matches all syntax that
 		// contains a word beginning with each search term. This way we 
-		// can prioritise matches that start with the search terms.
-    	var matchExp = '';
-    	var priorityMatch = '';
-    	$.each(tokensOfTerm, function(index, matchToken)
-    	{
-       		matchExp += '(?=.*' + matchToken + ')';
-       		priorityMatch += '(?=.*\\b' + matchToken + ')';
-   		});
+		// can prioritize matches that start with the search terms.
+        // Third regex will match full words.
+        var matchExp = '';
+        var priorityMatch = '';
+        var wordMatch = '';
+        $.each(tokensOfTerm, function(index, matchToken)
+        {
+            matchExp += '(?=.*' + matchToken + ')';
+            priorityMatch += '(?=.*\\b' + matchToken + ')';
+            wordMatch += '(?=.*\\b' + matchToken + '\\b)';
+        });
 
-		var regex = new RegExp(matchExp, "i");
-		var priorityRegex = new RegExp(priorityMatch, "i");
+        var regex = new RegExp(matchExp, "i");
+        var priorityRegex = new RegExp(priorityMatch, "i");
+        var wordRegex = new RegExp(wordMatch, "i");
 		
 		// Grep for the general search term
 		tState . searched . data = $.grep(tState.filtered_data, function (e) 
@@ -108,19 +112,35 @@
 			return tMatched;
 		});
 
-		// Sort the priority matches to the top
-		tState . searched . data . sort(function(a, b) 
-		{
-			var tToMatch = collectSyntax(a);		
-			if (priorityRegex.test(tToMatch))
-				return -1;
-			
-			tToMatch = collectSyntax(b);
-			if (priorityRegex.test(tToMatch))
-				return 1;
-				
-			return 0;
-		});
+        // Sort the priority matches to the top
+        tState . searched . data . sort(function(a, b) 
+        {
+            var tNameA = a["display name"].toLowerCase();
+            var tNameB = b["display name"].toLowerCase();
+
+            // full word matches in display name sort to the top
+            var tWordA = wordRegex.test(tNameA);
+            var tWordB = wordRegex.test(tNameB);
+            if (tWordA && !tWordB)
+                return -1;
+            if (tWordB && !tWordA)
+                return 1;
+
+            // display names with words that start with terms prioritized
+            var tPriorityA = priorityRegex.test(tNameA);
+            var tPriorityB = priorityRegex.test(tNameB);
+            if (tPriorityA && !tPriorityB)
+                return -1;
+            if (tPriorityB && !tPriorityA)
+                return 1;
+
+            // alphabetical sort by display name for everything else
+            if (tNameA < tNameB)
+                return -1;
+            if (tNameA > tNameB)
+                return 1;
+            return 0;
+        });
 	
 		$(window).scrollTop(0);
 		return tState . searched . data;

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -81,28 +81,28 @@
 			tTerm = "\\" + pTerm;
 		}
 
-		// Get a list of space-delimited search terms				
-   		var tokensOfTerm = tTerm.match(/\S+/g);
+		// Get a list of space-delimited search terms
+		var tokensOfTerm = tTerm.match(/\S+/g);
 		
 		
 		// Generate three regexes - one that matches all syntax that 
 		// contains each search term, and one that matches all syntax that
 		// contains a word beginning with each search term. This way we 
 		// can prioritize matches that start with the search terms.
-        // Third regex will match full words.
-        var matchExp = '';
-        var priorityMatch = '';
-        var wordMatch = '';
-        $.each(tokensOfTerm, function(index, matchToken)
-        {
-            matchExp += '(?=.*' + matchToken + ')';
-            priorityMatch += '(?=.*\\b' + matchToken + ')';
-            wordMatch += '(?=.*\\b' + matchToken + '\\b)';
-        });
+		// Third regex will match full words.
+		var matchExp = '';
+		var priorityMatch = '';
+		var wordMatch = '';
+		$.each(tokensOfTerm, function(index, matchToken)
+		{
+			matchExp += '(?=.*' + matchToken + ')';
+			priorityMatch += '(?=.*\\b' + matchToken + ')';
+			wordMatch += '(?=.*\\b' + matchToken + '\\b)';
+		});
 
-        var regex = new RegExp(matchExp, "i");
-        var priorityRegex = new RegExp(priorityMatch, "i");
-        var wordRegex = new RegExp(wordMatch, "i");
+		var regex = new RegExp(matchExp, "i");
+		var priorityRegex = new RegExp(priorityMatch, "i");
+		var wordRegex = new RegExp(wordMatch, "i");
 		
 		// Grep for the general search term
 		tState . searched . data = $.grep(tState.filtered_data, function (e) 
@@ -112,35 +112,48 @@
 			return tMatched;
 		});
 
-        // Sort the priority matches to the top
-        tState . searched . data . sort(function(a, b) 
-        {
-            var tNameA = a["display name"].toLowerCase();
-            var tNameB = b["display name"].toLowerCase();
+		//console.log(pTerm);
+		//console.time("Search");
+		// Sort the priority matches to the top
+		tState . searched . data . sort(function(a, b) 
+		{
+			var tNameA, tNameB, tMatchA, tMatchB
 
-            // full word matches in display name sort to the top
-            var tWordA = wordRegex.test(tNameA);
-            var tWordB = wordRegex.test(tNameB);
-            if (tWordA && !tWordB)
-                return -1;
-            if (tWordB && !tWordA)
-                return 1;
+			tNameA = a["display name"].toLowerCase();
+			tNameB = b["display name"].toLowerCase();
 
-            // display names with words that start with terms prioritized
-            var tPriorityA = priorityRegex.test(tNameA);
-            var tPriorityB = priorityRegex.test(tNameB);
-            if (tPriorityA && !tPriorityB)
-                return -1;
-            if (tPriorityB && !tPriorityA)
-                return 1;
+			// full word matches in display name sort to the top
+			tMatchA = wordRegex.test(tNameA);
+			tMatchB = wordRegex.test(tNameB);
+			if (tMatchA && !tMatchB)
+				return -1;
+			if (tMatchB && !tMatchA)
+				return 1;
 
-            // alphabetical sort by display name for everything else
-            if (tNameA < tNameB)
-                return -1;
-            if (tNameA > tNameB)
-                return 1;
-            return 0;
-        });
+			// display names with words that start with terms next
+			tMatchA = priorityRegex.test(tNameA);
+			tMatchB = priorityRegex.test(tNameB);
+			if (tMatchA && !tMatchB)
+				return -1;
+			if (tMatchB && !tMatchA)
+				return 1;
+
+			// display name contains search terms next
+			tMatchA = regex.test(tNameA);
+			tMatchB = regex.test(tNameB);
+			if (tMatchA && !tMatchB)
+				return -1;
+			if (tMatchB && !tMatchA)
+				return 1;
+
+			// alphabetical sort by display name for everything else
+			if (tNameA < tNameB)
+				return -1;
+			if (tNameA > tNameB)
+				return 1;
+			return 0;
+		});
+		//console.timeEnd("Search");
 	
 		$(window).scrollTop(0);
 		return tState . searched . data;
@@ -521,7 +534,7 @@
 		
 		pEntryID = tEntryObject.id;
 		
-		console.log(tEntryObject);
+		//console.log(tEntryObject);
 		
 		if(tState.selected == pEntryID) return 1;
 		tState.selected = pEntryID;

--- a/notes/bugfix-20289.md
+++ b/notes/bugfix-20289.md
@@ -1,0 +1,1 @@
+# Improve dictionary sort ("me" was difficult to find)


### PR DESCRIPTION
Initial complaint was that "me" is very difficult to locate in the dictionary.  The current priority search ends up with terms in an unsorted state since it does not explicitly maintain the alphabetical sort.  Additionally, the prioritized sort is looking at all syntax terms which is probably more than is needed for the priority portion.

Added a new regex for an exact word match.  This will be the first one used for the sort and will use the display name.  This will allow for things like "me" to appear at the top and other short words to be closer to the top.  The second regex will use the existing "start of word" search, but also only search the display name.  Finally, the display names will be compared to maintain alphabetical order.