### PR TITLE
[[ Bug 20307 ]] Fix cantSelect property tooltip on PB

### DIFF
--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsercontrolrowbehavior.livecodescript
@@ -45,23 +45,8 @@ on FillInData pDataA, pRow
       show button "controlIcon" of me
    end if
    
-   ## Visibility
-   if pDataA["visible"] is true then
-      set the icon of button "visible" of me to the id of image "visible_on" of card "templates" of this stack
-      set the tooltip of button "visible" of me to "Hide"
-   else if pDataA["visible"] is false then
-      set the icon of button "visible" of me to the id of image "visible_off" of card "templates" of this stack
-      set the tooltip of button "visible" of me to "Show"
-   end if  
-   
-   ## Can't select
-   if pDataA["cantSelect"] is true then
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_on" of card "templates" of this stack
-      set the tooltip of button "cantSelect" of me to "Hide"
-   else if pDataA["cantSelect"] is false then
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_off" of card "templates" of this stack
-      set the tooltip of button "cantSelect" of me to "Show"
-   end if  
+   __SetBoolProp "visible", pDataA["visible"]
+   __SetBoolProp "cantSelect", pDataA["cantSelect"]
 end FillInData
 
 on LayoutControl pControlRect
@@ -248,24 +233,24 @@ on ExitFieldEditor pFieldEditor, pRow, pKey, pClosingTriggeredBy
 end ExitFieldEditor
 
 on toggleVisible
-   if the icon of button "visible" of me is the id of image "visible_on" of card "templates" of this stack then
-      set the icon of button "visible" of me to the id of image "visible_off" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "visible", "false"
-   else
-      set the icon of button "visible" of me to the id of image "visible_on" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "visible", "true"
-   end if  
+   __SetBoolProp "visible", the icon of button "visible" of me is the id of image "visible_off" of card "templates" of this stack, true
 end toggleVisible
 
 on toggleCantSelect
-   if the icon of button "cantSelect" of me is the id of image "cantSelect_on" of card "templates" of this stack then
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_off" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "cantSelect", "false"
-   else
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_on" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "cantSelect", "true"
-   end if  
+   __SetBoolProp "cantSelect", the icon of button "cantSelect" of me is the id of image "cantSelect_off" of card "templates" of this stack, true
 end toggleCantSelect
+
+private command __SetBoolProp pProp, pValue, pUpdate
+   if pValue then
+      set the icon of button pProp of me to the id of image (pProp & "_on") of card "templates" of this stack
+   else
+      set the icon of button pProp of me to the id of image (pProp & "_off") of card "templates" of this stack
+   end if
+   set the tooltip of button pProp of me to "Set" && pProp && "to" && not pValue
+   if pUpdate then
+      updateProperty the cObjectLongID of me, pProp, pValue
+   end if
+end __SetBoolProp
 
 getProp dvAcceptsDrop
    local theA, tRow, tDraggedRow, tDraggedType, tDraggedStyle

--- a/Toolset/palettes/project browser/behaviors/revideprojectbrowsergrouprowbehavior.livecodescript
+++ b/Toolset/palettes/project browser/behaviors/revideprojectbrowsergrouprowbehavior.livecodescript
@@ -45,23 +45,8 @@ on FillInData pDataA, pRow
       enable group "disclosure" of me 
    end if
    
-   ## Visibility
-   if pDataA["visible"] is true then
-      set the icon of button "visible" of me to the id of image "visible_on" of card "templates" of this stack
-      set the tooltip of button "visible" of me to "Hide"
-   else if pDataA["visible"] is false then
-      set the icon of button "visible" of me to the id of image "visible_off" of card "templates" of this stack
-      set the tooltip of button "visible" of me to "Show"
-   end if  
-   
-   ## Can't select
-   if pDataA["cantSelect"] is true then
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_on" of card "templates" of this stack
-      set the tooltip of button "cantSelect" of me to "Hide"
-   else if pDataA["cantSelect"] is false then
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_off" of card "templates" of this stack
-      set the tooltip of button "cantSelect" of me to "Show"
-   end if  
+   __SetBoolProp "visible", pDataA["visible"]
+   __SetBoolProp "cantSelect", pDataA["cantSelect"]
    
    if revIDEGetPreference("pb_indicator") is "text" then
       show field "type" of me
@@ -252,24 +237,24 @@ on mouseDown pButton
 end mouseDown
 
 on toggleVisible
-   if the icon of button "visible" of me is the id of image "visible_on" of card "templates" of this stack then
-      set the icon of button "visible" of me to the id of image "visible_off" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "visible", "false"
-   else
-      set the icon of button "visible" of me to the id of image "visible_on" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "visible", "true"
-   end if  
+   __SetBoolProp "visible", the icon of button "visible" of me is the id of image "visible_off" of card "templates" of this stack, true
 end toggleVisible
 
 on toggleCantSelect
-   if the icon of button "cantSelect" of me is the id of image "cantSelect_on" of card "templates" of this stack then
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_off" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "cantSelect", "false"
-   else
-      set the icon of button "cantSelect" of me to the id of image "cantSelect_on" of card "templates" of this stack
-      updateProperty the cObjectLongID of me, "cantSelect", "true"
-   end if  
+   __SetBoolProp "cantSelect", the icon of button "cantSelect" of me is the id of image "cantSelect_off" of card "templates" of this stack, true
 end toggleCantSelect
+
+private command __SetBoolProp pProp, pValue, pUpdate
+   if pValue then
+      set the icon of button pProp of me to the id of image (pProp & "_on") of card "templates" of this stack
+   else
+      set the icon of button pProp of me to the id of image (pProp & "_off") of card "templates" of this stack
+   end if
+   set the tooltip of button pProp of me to "Set" && pProp && "to" && not pValue
+   if pUpdate then
+      updateProperty the cObjectLongID of me, pProp, pValue
+   end if
+end __SetBoolProp
 
 on mouseDoubleUp 
    if the short name of the target is "name" then

--- a/notes/bugfix-20307.md
+++ b/notes/bugfix-20307.md
@@ -1,0 +1,1 @@
+# Ensure cantSelect buttons on Broject Browser have appropriate toolTips


### PR DESCRIPTION
This patch overall improves the `toolTip` of the `visible` and `cantSelect`
buttons on the project browser by making them update ater the user
has toggled the button. It also gives `cantSelect` an appropriate
`toolTip` as it had a copy/paste error making it `Show` or `Hide`.