### PR TITLE
[[ Bug 20342 ]] Save script selection when updated

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -326,6 +326,8 @@ command selectionUpdate
    updateHandlerList
     
    updateSelectedHandler
+   
+   contextSave
     
    # Update the toolbar so that the handlers list can reflect the new selection. For efficiency we pass
    # a parameter to the update command which tells it that the selected handler can be assumed to be

--- a/notes/bugfix-20342.md
+++ b/notes/bugfix-20342.md
@@ -1,0 +1,1 @@
+# Ensure selection is retained when opening/closing scripts or returning to a tab


### PR DESCRIPTION
This patch ensures that `contextSave` and therefore the script selection
is called at times when the script is `the focusedObject` allowing the
selection to be restored when the user returns to the tab or re-opens
the script.