### PR TITLE
[[ Bug 20264 ]] Fix infinite loop

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -3269,7 +3269,7 @@ private command __LookForPair pChar, pPairChar, pStep, @xCharNum
       put 0 into tCharNum
    end if
    
-   if tScriptLine is empty then
+   if tScriptLine is empty or tCharNum is tEndCondition then
       return false for value
    end if
    

--- a/notes/bugfix-20264.md
+++ b/notes/bugfix-20264.md
@@ -1,0 +1,1 @@
+# Fix infinite loop when looking for bracket pairs and right bracket is at the beginning of the line


### PR DESCRIPTION
In the case where a line was not continued and the right bracket
was the first char of the line then the script editor would not
reach the end condition when looking for a bracket pair and remain
in the infinite loop.