### PR TITLE
[[ Bug 18739 ]] Dictionary auto-search on first char freezing cursor

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -1158,13 +1158,30 @@
 		return (typeof liveCode !== 'undefined');
 	}
 	
+	// Returns a function, that, as long as it continues to be invoked, will not
+	// be triggered. The function will be called after it stops being called for
+	// N milliseconds.  Used to make search more responsive.
+	var debounce = function(func, wait) {
+		var timeout;
+		return function() {
+			var context = this, args = arguments;
+			var later = function() {
+				timeout = null;
+				func.apply(context, args);
+			};
+			clearTimeout(timeout);
+			timeout = setTimeout(later, wait);
+		};
+	};
+
 	function setActions()
 	{	
 		breadcrumb_draw();
-				
-		$('#ui_filer').keyup(function() {
-		  displayEntryListGrep(this.value);
-		})
+		
+		// Delay search until 250ms after last character typed
+		$('#ui_filer').keyup( debounce( function() {
+			displayEntryListGrep(this.value);
+		}, 250));
 		
 		$("body").on( "click", ".load_entry", function() {
 			var tEntryID = $(this).attr("entryid");

--- a/notes/bugfix-18739.md
+++ b/notes/bugfix-18739.md
@@ -1,0 +1,1 @@
+# Dictionary auto-search on first char freezing cursor


### PR DESCRIPTION
Did some preliminary timing at various points of the js.  The actual search `tData = dataSearch(pTerm);` was not the primary driver of the amount of time taken between typing a character and presentation of the information.  The search was in the 100ms range but the HTML generation `$("#table_list").html(tHTML);` would get up to 500ms frequently.  After researching methods to improve performance, the idea of delaying the actual search stood out as a preferred method for this use case.

Implemented a function (debounce) so that the search is not performed until 250ms after the last character is typed.  This would add 250ms to a single character search, but will more than overcome that when multiple characters are typed in quick succession.  If looking for something like "#", then the extra time is barely noticeable.  If typing multiple letters (especially 3 or more), the performance improvement is very evident.

The code is based on the following post:
https://stackoverflow.com/questions/12538344/asynchronous-keyup-events-how-to-short-circuit-sequential-keyup-events-for-speed
The actual lines of code are cut down from a function included in this project:
https://github.com/jashkenas/underscore
The project code is under the MIT License