### PR TITLE
[[ Bug 20374 ]] Fix deselecting of current line when adding handler

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -941,6 +941,9 @@ command goLine pLine, pHighlightMode, pPosition
       select char tStart to tEnd of line pLine of field "Script" of me
       get the selectedChunk
       put word 2 of it & comma & word 4 of it into sLastSelectedGoneToChunk
+   else if pHighlightMode is "after" then
+      put empty into sLastSelectedGoneToChunk
+      select after line pLine of field "Script" of me
    else
       put empty into sLastSelectedGoneToChunk
       select before line pLine of field "Script" of me

--- a/Toolset/palettes/script editor/behaviors/revseleftbarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseleftbarbehavior.livecodescript
@@ -118,8 +118,10 @@ on handlerSelected pNewlyAdded
    -- If we just added this handler, select at the (empty) line after the handler decl.
    if pNewlyAdded then
       add 1 to tLine
+      send "goLine tLine, after" to group "Editor"
+   else
+      send "goLine tLine, true" to group "Editor"
    end if
    
-   send "goLine tLine, true" to group "Editor"
    seUpdateToolbar
 end handlerSelected

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -3053,7 +3053,11 @@ function revSEConstructDefaultScript pObj, pHandler
       end if
       put " " & tInfo["params"][x]["name"] after tScript
    end repeat
-   put return & return & "end" && pHandler after tScript
+   local tIndent
+   repeat for sePrefGet("editor,tabdepth")
+      put space after tIndent
+   end repeat
+   put return & tIndent & return & "end" && pHandler after tScript
    return tScript
 end revSEConstructDefaultScript
 


### PR DESCRIPTION
This patch adds a select `after` mode to the `goLine` command and
uses that for slecting the line in the middle of the new handler
when the handler is added to the script editor. It also adds an
indent so the cursor is positioned correctly.