### PR TITLE
[[ Bug 20388 ]] Layout menu buttons in SE

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
@@ -2,7 +2,15 @@
 # Description
 #   Sent by the parent when the menubar group may need to resize itself
 command resize
-   # Nothing to do at the moment
+   lock screen
+   local tTopLeft
+   put the topLeft of button "File" of me into tTopLeft
+   repeat for each item tButton in "File,Edit,Debug,Handler,Window,Help"
+      set the width of button tButton of me to the formattedWidth of button tButton of me
+      set the topLeft of button tButton of me to tTopLeft
+      put the topRight of button tButton of me into tTopLeft
+   end repeat
+   unlock screen
 end resize
 
 # Description

--- a/notes/bugfix-20388.md
+++ b/notes/bugfix-20388.md
@@ -1,0 +1,1 @@
+# Layout menu buttons in script editor for platforms where they are visible


### PR DESCRIPTION
This patch resizes and lays out the script editor menu buttons
for platforms that show them directly and may have larger default
fonts than have been used in development