### PR TITLE
[[ Bug 20145 ]] Fix issues with breakpoint movement on edit

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
@@ -401,42 +401,22 @@ private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, p
    
    if pOldNumber < pNewNumber then
       repeat for each line tBreakpoint in tBreakpoints
-         # In the case that the line that contained the breakpoint was where the text replacement
-         # started, we have to check for one of three options. This is slow :(
          if item -1 of tBreakpoint = pLine then
-            local tContext
-            put char 1 to pOffset of getScriptField() into tContext
-            local tNextChar
-            put char -1 of tContext into tNextChar
+            local tLineIndex
+            put the lineIndex of char pOffset of getScriptField() into tLineIndex
             
-            local tPreviousChars
-            repeat with x = the number of chars of tContext - 1 down to 1
-               if char x of tContext is empty or char x of tContext is return then
-                  exit repeat
-               end if
-               put char x of tContext after tPreviousChars
-            end repeat
+            local tCharIndex
+            put the charIndex of line tLineIndex of getScriptField() into tCharIndex
             
-            local tWhitespaceBefore
-            put matchText(tPreviousChars, "^\s*$") into tWhitespaceBefore
+            local tLine
+            put the text of line tLineIndex of getScriptField() into tLine
             
-            local tEndofLine
-            put (tNextChar is return or tNextChar is empty) into tEndofLine
-            
-            # This means the user has split the line containing the breakpoint, in this case we leave the breakpoint as it was
-            if (not tWhitespaceBefore) and (not tEndofLine) then
-               next repeat
-            end if
-            
-            # This means that the user has added a return to the end of the line containing the breakpoint, again we ignore this
-            #if (tPreviousChar is not return and tPreviousChar is not empty) and (tNextChar is return or tNextChar is empty) then
-            if (not tWhitespaceBefore) and tEndofLine then
-               next repeat
-            end if
+            local tBefore
+            put char 1 to (pOffset - tCharIndex) of tLine into tBefore
             
             # This means that the user has added a return before the beginning of the line containing the breakpoint. We move the breakpoint
             # to follow the line.
-            if tWhitespaceBefore then
+            if word 1 of tBefore is empty then
                revDebuggerMoveBreakpoint item 1 to -2 of tBreakpoint, item -1 of tBreakpoint, item 1 to -2 of tBreakpoint, item -1 of tBreakpoint + (pNewNumber - pOldNumber)
             end if
          end if
@@ -456,7 +436,7 @@ private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, p
       local tScript
       put textGetScript() into tScript
       repeat for each line tBreakpoint in tBreakpoints
-         if (item -1 of tBreakpoint >= pLine and item -1 of tBreakpoint < (pLine - (pNewNumber - pOldNumber))) and revDebuggerNextAvailableBreakpoint(tScript, item -1 of tBreakpoint + (pNewNumber - pOldNumber)) <> item -1 of tBreakpoint + (pNewNumber - pOldNumber) then
+         if (item -1 of tBreakpoint >= pLine and item -1 of tBreakpoint < (pLine - (pNewNumber - pOldNumber))) and revDebuggerNextAvailableBreakpoint(tScript, item -1 of tBreakpoint - 1 + (pNewNumber - pOldNumber)) <> item -1 of tBreakpoint + (pNewNumber - pOldNumber) then
             revDebuggerRemoveBreakpoint item 1 to -2 of tBreakpoint, item -1 of tBreakpoint
          else if item -1 of tBreakpoint > (pLine + pNewNumber - pOldNumber) then
             # If the breakpoint was below the removed lines, move it up

--- a/notes/bugfix-20145.md
+++ b/notes/bugfix-20145.md
@@ -1,0 +1,1 @@
+# Move breakpoints appropriately when editing scripts


### PR DESCRIPTION
This patch fixes a couple of issues with breakpoint movement and removal
when editing scripts. Additionally it uses more efficient code to determine
if the user was editing the line of a breakpoint with only whitespace
before the offset.

With this patch breakpoints should:

- move down correctly when the insertion point is on the beginning of the line
(such as `end Handler`)
- move up correctly if te user deletes part of (or before) the line they are on
and when moved up it is still valid to place a breakpoint on the line