### PR TITLE
[[ Bug 20392 ]] Eat closing brackets when typing

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -3125,29 +3125,24 @@ command scriptGetCurrentHandler
 end scriptGetCurrentHandler
 
 
-private command __BracketCompletion pOffset, pOldText, @xNewText
+private command __BracketCompletion pOffset, @xOldText, @xNewText
    local tBracketCompletion
    put __GetPreference("editor,bracketcompletion", true) into tBracketCompletion
    if tBracketCompletion is not true then
       return empty for value
    end if
    
+   if the length of xNewText is not 1 then
+      return empty for value
+   end if
+   
+   local tNextChar
+   put char pOffset of field "script" of me into tNextChar
+   
    local tCompletionChar
    switch xNewText
       case quote
-         if pOldText is empty then
-            -- ensure we really want to insert an extra quote
-            local tLine
-            put the last line of (char 1 to pOffset of field "script" of me) & space into tLine
-            split tLine by quote
-            if (the number of elements in tLine -1) mod 2 is 0 then
-               put space & the first line of (char pOffset to -1 of field "script" of me) into tLine
-               split tLine by quote
-               if (the number of elements in tLine -1) mod 2 is 0 then
-                  put quote into tCompletionChar
-               end if
-            end if
-         else
+         if tNextChar is not quote then
             put quote into tCompletionChar
          end if
          break
@@ -3160,12 +3155,17 @@ private command __BracketCompletion pOffset, pOldText, @xNewText
    end switch
    
    if tCompletionChar is not empty then
-      if pOldText is empty then
+      if xOldText is empty then
          put tCompletionChar after xNewText
          return "pair" for value
       else
-         put pOldText & tCompletionChar after xNewText
+         put xOldText & tCompletionChar after xNewText
          return "wrap" for value
+      end if
+   else if xOldText is empty then
+      if xNewText is in quote & "])" and \
+            xNewText is tNextChar then
+         put xNewText into xOldText
       end if
    end if
    return empty for value

--- a/notes/bugfix-20392.md
+++ b/notes/bugfix-20392.md
@@ -1,0 +1,1 @@
+# Type over closing brackets if they match the next char


### PR DESCRIPTION
Because we have bracket completion and people are used to typing
closing brackets it saves time if when typing a closing bracket
that we look ahead and if the next char is already that closing
bracket then we just replace it rather than inserting another.
This means the selection will now be outside the brackets.