### PR TITLE
[[ Autocomplete ]] Edition props

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1195,8 +1195,11 @@ command revInternal__InitialiseLibraries
    revInternal__LoadLibrary "revDatabaseLibrary"
    revInternal__LoadLibrary "revTableLibrary"
    
-   if the editionType is not "community" then
+   if revEnvironmentEditionProperty("autocomplete_pro") then
       revInternal__LoadLibrary "autocomplete-pro"
+   end if
+   
+   if revEnvironmentEditionProperty("autocomplete") then
       revInternal__LoadLibrary "autocomplete"
    end if
    
@@ -1884,7 +1887,9 @@ function revEnvironmentEditionProperty pProp, pEdition
                return "communityplus"
             case "edition_external_url"
                return "https://livecode.com/products/community-edition/"
-               break        
+            case "autocomplete"
+            case "autocomplete_pro"
+               return false
          end switch
          break
       case "communityplus"
@@ -1917,6 +1922,10 @@ function revEnvironmentEditionProperty pProp, pEdition
                return "commercial"
             case "edition_external_url"
                return "https://livecode.com/products/community-plus-edition/"
+            case "autocomplete"
+               return true
+            case "autocomplete_pro"
+               return false
          end switch
          break
       case "commercial"
@@ -1953,6 +1962,9 @@ function revEnvironmentEditionProperty pProp, pEdition
                return "professional"
             case "edition_external_url"
                return "https://livecode.com/products/indy-edition/"
+            case "autocomplete"
+            case "autocomplete_pro"
+               return true
          end switch
          break
       case "professional"
@@ -1985,6 +1997,9 @@ function revEnvironmentEditionProperty pProp, pEdition
                return empty
             case "edition_external_url"
                return "https://livecode.com/products/business-edition/"
+            case "autocomplete"
+            case "autocomplete_pro"
+               return true
          end switch
          break
    end switch

--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -75,7 +75,7 @@ command setObjectID pObjectID
       if tRuggedID is not sObjectID then
          put tRuggedID into sObjectID
          if exists(sObjectId) and \
-               there is a stack "com.livecode.script-library.autocomplete" then
+               revEnvironmentEditionProperty("autocomplete") then
             ideAutocompleteIntrospectMessagePath sObjectId
          end if
       end if
@@ -126,7 +126,7 @@ command clearCache pObject, pDontCheckId
       put revRuggedId(pObject) into tObject
    end if
    delete variable sScriptCache[tObject]
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteClearObjectCache tObject
    end if
 end clearCache
@@ -1377,28 +1377,28 @@ on selectionUpdate
 end selectionUpdate
 
 on mouseMove
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteCancelFind the long id of me
    end if
    pass mouseMove
 end mouseMove
 
 on closeField
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteCancelFind the long id of me
    end if
    pass closeField
 end closeField
 
 on exitField
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteCancelFind the long id of me
    end if
    pass exitField
 end exitField
 
 on escapeKey
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteCancelFind the long id of me
    end if
    pass escapeKey
@@ -1582,7 +1582,7 @@ on returnInField
       exit returnInField
    end if
    
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteCancelFind the long id of me
    end if
    
@@ -2188,7 +2188,7 @@ on tabKey
    local tDoTab = true
    
    if tProviderCompletion and \
-         there is a stack "com.livecode.script-library.autocomplete" then
+         revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteHandleTab the long id of me, sObjectId, sPlaceholders, sEditPlaceholder, sEditChunks
       put the result into tDoTab
    end if
@@ -2438,7 +2438,7 @@ on rawKeyDown pKey
    end switch
    
    local tPass = true
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteHandleArrow the long id of me, tKeyName, sObjectId, sPlaceholders, sEditPlaceholder, sEditChunks
       put the result into tPass
    end if
@@ -3343,7 +3343,7 @@ end __LookForPair
 private command __UpdateAutoCompleteList pUUID
    local tProviderCompletion
    put __GetPreference("editor,providercompletion", true) into tProviderCompletion
-   if tProviderCompletion and there is a stack "com.livecode.script-library.autocomplete" then
+   if tProviderCompletion and revEnvironmentEditionProperty("autocomplete") then
       ideAutocompleteUpdate the long id of me, sObjectID, sPlaceholders[pUUID]["classes"]
    end if
 end __UpdateAutoCompleteList

--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -703,7 +703,7 @@ command scriptCompile pObject
       --! TODO remove use of revAvailableHandlers here (quite invasive)
       put the revAvailableHandlers of button "revCompileObject" of me into sHandlerList
       get getObjectID()
-      if exists(it) and there is a stack "com.livecode.script-library.autocomplete" then
+      if exists(it) and revEnvironmentEditionProperty("autocomplete") then
          ideAutocompleteUpdateScriptDescription it, the revScriptDescription of button "revCompileObject" of me
       end if
    end if

--- a/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
@@ -136,7 +136,7 @@ private command buildEditMenu pContext
          "Find Selection/^#F" & return & \
          "Go.../L" & return after tEdit
    
-   if there is a stack "com.livecode.palette.autocomplete-pro" then
+   if revEnvironmentEditionProperty("autocomplete_pro") then
       put "Autocomplete Snippets..." & return after tEdit
    end if
    
@@ -147,7 +147,7 @@ private command buildEditMenu pContext
    put toggleMenuItem(tab & "Bracket Highlighting", sePrefGet("editor,brackethighlighting")) & return after tEdit
    put toggleMenuItem(tab & "Control Structure Completion", sePrefGet("editor,autocomplete")) & return after tEdit
    
-   if there is a stack "com.livecode.script-library.autocomplete" then
+   if revEnvironmentEditionProperty("autocomplete") then
       put toggleMenuItem(tab & "Autocomplete", sePrefGet("editor,providercompletion")) & return after tEdit
    end if
    


### PR DESCRIPTION
This patch adds edition properties for autocomplete and autocomplete pro
allowing IDE stacks to check if the libraries and dialogs are expected to
be aviailable. This allows us to load community and communityplus from
source and not get interference from autocomplete as we do with using
stack existence here.