### PR TITLE
[[ Bug 20465 ]] Fix optionKeyDown handler

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -1994,14 +1994,11 @@ on optionKeyDown pKey
       pass optionKeyDown
    end if
    
-   # Block this message on OS X as it can cause weird characters to be entered into the field
-   if the platform is not "MacOS" then
-      pass optionKeyDown
+   if pKey is not an integer or pKey <= 9 then
+      __DoKeyDown pKey
    end if
-   
-   -- OK-2009-03-09 : But simulate the message as a normal keydown
-   keyDown pKey
 end optionKeyDown
+
 
 on scrollBarDrag
    if not handleEvent("scrollBarDrag", the long id of the target) then
@@ -2033,6 +2030,10 @@ on keyDown pChar
       exit keyDown
    end if
    
+   __DoKeyDown pChar
+end keyDown
+
+private command __DoKeyDown pChar
    get the selectedChunk
    
    local tFrom, tTo
@@ -2048,7 +2049,7 @@ on keyDown pChar
       put tTo - tFrom + 1 into tLength
    end if
    textReplace tAt, char tAt to tAt + tLength - 1 of field "Script" of me, pChar
-end keyDown
+end __DoKeyDown
 
 on backspaceKey
    if not handleEvent("backspaceKey", the long id of the target) then

--- a/notes/bugfix-20465.md
+++ b/notes/bugfix-20465.md
@@ -1,0 +1,1 @@
+# Fix special key codes being entered into the script editor when the option key is down


### PR DESCRIPTION
The `optionKeyDown` handler in the script editor was passing the message
this means the charahter was being typed into the script editor without
going via textReplace. Additionally on mac where it was not being
passed special key codes were not being blocked.