### PR TITLE
Fix start center field

### DIFF
--- a/Toolset/palettes/start center/revStartCenterBehavior.livecodescript
+++ b/Toolset/palettes/start center/revStartCenterBehavior.livecodescript
@@ -76,6 +76,11 @@ command initialiseInterface
    end if
 end initialiseInterface
 
+on firstRunVisible pVisible
+   revIDESetPreference "StartCenterClassic", not pVisible
+   initialiseInterface
+end firstRunVisible
+
 on ideDesktopChanged
    set the loc of me to revIDEStackScreenLoc(the short name of me)
 end ideDesktopChanged

--- a/notes/bugfix-20471.md
+++ b/notes/bugfix-20471.md
@@ -1,0 +1,1 @@
+# [Start Center] Ensure "Skip interactive tour and take me to the Start Center" responds to clicks


### PR DESCRIPTION
In LC 8.2 DP-1, the script of `revStartCenterBehavior` was refactored, and the `firstRunVisible` command is no longer present. However, the script of `field "firstRunSkip" of group "firstRun" of card "interface" of stack "revStartCenter.livecode"` still refers to it:

```
on mouseUp
   firstRunVisible "false"
end mouseUp
```

Rather than modifying this script (which lives in a binary .livecode file), this patch has re-introduced this command (`firstRunVisible`) in `revStartCenterBehavior.livecodescript`, and modified it accordingly.