### PR TITLE
[[ Bug 20366 ]] Add edition icon and upgrade button to docs

### DIFF
--- a/Documentation/html_viewer/api.html.template
+++ b/Documentation/html_viewer/api.html.template
@@ -123,6 +123,7 @@
 	
     $(document).ready(function(e)
 	{
+      setEdition('[[ the editionType]]');
 		setActions();		
 		dataFilter();		
 		displayLibraryChooser();

--- a/Documentation/html_viewer/css/lcdoc.css
+++ b/Documentation/html_viewer/css/lcdoc.css
@@ -37,6 +37,53 @@
 	content: "\e107  ";
 }
 
+#table_list tr.indy > td:nth-child(1):before {
+	font-family: "Glyphicons Halflings";
+	content: "\e107  ";
+}
+
+#table_list tr.communityplus > td:nth-child(1):before {
+   content: url('../../../Toolset/resources/communityplus/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
+#table_list tr.indy > td:nth-child(1):before {
+   content: url('../../../Toolset/resources/commercial/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
+#table_list tr.business > td:nth-child(1):before {
+	content: url('../../../Toolset/resources/professional/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
+div.community:before {
+	content: url('../../../Toolset/resources/community/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
+div.communityplus:before {
+	content: url('../../../Toolset/resources/communityplus/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
+div.indy:before {
+	content: url('../../../Toolset/resources/commercial/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
+div.business:before {
+	content: url('../../../Toolset/resources/professional/ideSkin/bubble.png');
+   display: inline-block;
+   width: 20px;
+}
+
 #table_list tr:after {
     content: ' ';
     display: block;

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -1,4 +1,4 @@
-	var tState = {selected:"",history:{list:[],selected:-1},searched:{},filters:{},filtered_data:[],data:"",selected_api_id:"", sort_type:""};
+	var tState = {selected:"",history:{list:[],selected:-1},searched:{},filters:{},filtered_data:[],data:"",selected_api_id:"", sort_type:"", edition:""};
 	
 	if($.session.get("selected_api_id")) tState.selected = $.session.get("selected_api_id");
 	
@@ -353,6 +353,9 @@
 			if (value.hasOwnProperty("deprecated") && value.deprecated != '')
 				tClass = " deprecated";
 
+			if (value.hasOwnProperty("edition") && value.edition != '' && value.edition.toLowerCase() != 'community')
+				tClass = " "+value.edition.toLowerCase();
+
 			tHTML += '<tr class="entry_list_item load_entry'+tClass+'" ';
 			tHTML += 'entryid="'+value["id"]+'" id="entry_list_item_'+value["id"]+'">';
 			tHTML += '<td>'+value["display name"]+'</td>';
@@ -483,7 +486,30 @@
 		
 		var tHTML = "";
 		var references = [];
-		tHTML += '<h1 style="margin:0px 0px 30px 12px">'+tEntryObject["display name"]+'</h1><div class="row">';
+		
+		tHTML += '<h1 style="margin:0px 0px 30px 12px">'+tEntryObject["display name"];
+		
+		var tUpgrade = true;
+		if (!tEntryObject.hasOwnProperty("edition"))
+			tUpgrade = false;
+		else if (tState.edition == "professional")
+			tUpgrade = false;
+		else if (tState.edition == "commercial" && tEntryObject["edition"].toLowerCase() != "business")
+			tUpgrade = false;
+		else if (tState.edition == "communityplus" && (tEntryObject["edition"].toLowerCase() != "business" || tEntryObject["edition"].toLowerCase() != "indy"))
+			tUpgrade = false;
+		else if (tEntryObject["edition"].toLowerCase() == "community")
+			tUpgrade = false;
+		
+		if (tUpgrade)
+		{
+			tHTML += ' <a href="#" class="upgrade btn btn-default" edition="' + tEntryObject["edition"] 
+					+ '" display_name="' + tEntryObject["display name"] 
+					+ '">Upgrade to ' + tEntryObject["edition"] + '</a>';
+		}
+		
+		tHTML += '</h1><div class="row">';
+	
 		$.each(tEntryObject, function(index, value) {
 			if(index == "id" || index == "name") return;
 			
@@ -600,9 +626,13 @@
 				case "display syntax":
 				case "changes":
 					break;
-					
 				
-					
+				case "edition":
+					tHTML += '<div class="col-md-2 lcdoc_section_title">'+index+'</div><div class="col-md-10 '+value.toLowerCase()+'" style="margin-bottom:10px">';
+					tHTML += value;
+					tHTML += '</div>';
+					break;
+				
 				default:
 					
 					tHTML += '<div class="col-md-2 lcdoc_section_title">'+index+'</div><div class="col-md-10" style="margin-bottom:10px">';
@@ -1127,9 +1157,27 @@
 		return (typeof liveCode !== 'undefined');
 	}
 	
+	function setEdition(pEdition)
+	{
+		tState.edition = pEdition;
+	}
+	
 	function setActions()
 	{	
 		breadcrumb_draw();
+		
+		$("body").on("click", ".upgrade", function() {
+			if (isRunningInLiveCodeBrowser())
+			{
+         	var tEdition = $(this).attr("edition");
+				var tDisplayName = $(this).attr("display_name");
+				liveCode.showUpgradeOptions(tEdition, tDisplayName);
+			}
+			else
+			{
+				window.location.href = 'https://livecode.com/products/livecode-platform/pricing/';
+			}
+ 		});
 				
 		$('#ui_filer').keyup(function() {
 		  displayEntryListGrep(this.value);

--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1930,6 +1930,7 @@ function revEnvironmentEditionProperty pProp, pEdition
                return false
          end switch
          break
+      case "indy"
       case "commercial"
          switch pProp
             case "name"
@@ -1969,6 +1970,7 @@ function revEnvironmentEditionProperty pProp, pEdition
                return true
          end switch
          break
+      case "business"
       case "professional"
          switch pProp
             case "name"

--- a/Toolset/palettes/dictionary/behaviors/revdictionarybehavior.livecodescript
+++ b/Toolset/palettes/dictionary/behaviors/revdictionarybehavior.livecodescript
@@ -22,7 +22,7 @@ on openStack
    lock screen
    --Force the browser to actually resize
    set the rect of widget "Dictionary" of me to 0,0,0,0
-   set the javascripthandlers of widget "Dictionary" of me to "linkClicked"
+   set the javascripthandlers of widget "Dictionary" of me to "linkClicked" & return & "showUpgradeOptions"
    set the width of me to tMinWidth
    set the minWidth of me to tMinWidth
    set the title of me to "Dictionary"
@@ -83,3 +83,11 @@ end navigateToEntry
 on linkClicked pLink
    launch url pLink
 end linkClicked
+
+on showUpgradeOptions pEdition, pDisplayName
+   put urlEncode(pDisplayName) into pDisplayName
+   replace "+" with "%20" in pDisplayName
+   
+   launch url revEnvironmentEditionProperty("edition_external_url", pEdition) & \
+         "?utm_source=ide&utm_medium=docs&utm_campaign="&pDisplayName
+end showUpgradeOptions

--- a/notes/bugfix-20366.md
+++ b/notes/bugfix-20366.md
@@ -1,0 +1,1 @@
+# Add icon to edition element in docs and upgrade button for APIs not in the current edition


### PR DESCRIPTION
This patch uses the edition element to add an icon to each non-community
API in the search results list. The same icon use used in the edition
element. If the API is not available in the current edition an upgrade
button is shown.