### PR TITLE
[[ Docs ]] Put language / context relevant syntax in the same API

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -28,11 +28,7 @@
 	
 	library_set(tState.selected_api_id);
 
-	function dataGet(){
-		//sort API dictionaries, leave LiveCode Script/LiveCode Builder as first 2 entries
-		if (tState.selected_api_id == ""){
-			dictionary_data.docs.sort(compareDictionaryObject);
-		}
+	function dataGet() {		
 		if(!dictionary_data.docs.hasOwnProperty(tState.selected_api_id)){
 			$.each(dictionary_data.docs, function(index, libraryData) {
 				tState.selected_api_id = index;
@@ -47,7 +43,7 @@
 		
 		return tState.data;
 	}
-	
+
 	// Return all the syntax associated with an entry
 	// as a (matchable) string
 	function collectSyntax(pEntry)

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -1,23 +1,46 @@
-	var tState = {selected:"",history:{list:[],selected:-1},searched:{},filters:{},filtered_data:[],data:"",selected_api_id:"", sort_type:"", edition:""};
+	var tState = { 	
+		selected_api_id:"",
+		selected_entry_index:{},
+		history:{
+			list:[],
+			selected_index:-1
+		},	
+		cached_search_data:{},
+		filters:{},
+		filtered_data:[],
+		data:"",
+		sort_type:"",
+		edition: ""
+	};
 	
-	if($.session.get("selected_api_id")) tState.selected = $.session.get("selected_api_id");
-	
-	if($.session.get("selected")) tState.selected = $.session.get("selected");
-	else tState.selected = 1;
+	if ($.session.get("selected_api_id")) {
+		tState.selected_api_id = $.session.get("selected_api_id");
+	} else {
+		tState.selected_api_id = 1;
+	}
 
+	if ($.session.get("selected_entry_index")) {
+		var tIndexArray = $.session.get("selected_entry_index");
+		tState.selected_entry_index[tState.selected_api_id] = tIndexArray[tState.selected_api_id];
+	} else { 
+		tState.selected_entry_index[tState.selected_api_id] = 1;
+	}
 	
+	library_set(tState.selected_api_id);
+
 	function dataGet(){
-		//console.log(dictionary_data.docs);
-		
+		//sort API dictionaries, leave LiveCode Script/LiveCode Builder as first 2 entries
+		if (tState.selected_api_id == ""){
+			dictionary_data.docs.sort(compareDictionaryObject);
+		}
 		if(!dictionary_data.docs.hasOwnProperty(tState.selected_api_id)){
-			
-			$.each(dictionary_data.docs, function(index, libraryData){
+			$.each(dictionary_data.docs, function(index, libraryData) {
 				tState.selected_api_id = index;
 				return false;
 			});
 		}
 		
-		if(tState.dirtyData == true || tState.data == ""){
+		if (tState.dirtyData == true || tState.data == ""){
 			tState.data = dictionary_data.docs[tState.selected_api_id].doc.sort(compareEntryObject);
 			tState.dirtyData = false;
 		}
@@ -44,15 +67,14 @@
 	function dataSearch(pTerm)
 	{
 		// Check the cached search data
-		if (tState.searched.hasOwnProperty("term") && tState.searched.term == pTerm) 
-			return tState.searched.data;
+		if (tState.cached_search_data.hasOwnProperty("term") && tState.cached_search_data.term == pTerm) 
+			return tState.cached_search_data.data;
 			
-		tState.searched.term = pTerm;
-		tState.searched.data = [];
+		tState.cached_search_data.term = pTerm;
+		tState.cached_search_data.data = [];
 		
 		// Get a list of space-delimited search terms				
-   		var tokensOfTerm = pTerm.match(/\S+/g);
-		
+   		var tokensOfTerm = pTerm.match(/\S+/g);	
 		
 		// Generate two regexes - one that matches all syntax that 
 		// contains each search term, and one that matches all syntax that
@@ -70,7 +92,7 @@
 		var priorityRegex = new RegExp(priorityMatch, "i");
 		
 		// Grep for the general search term
-		tState . searched . data = $.grep(tState.filtered_data, function (e) 
+		tState . cached_search_data . data = $.grep(tState.filtered_data, function (e) 
 		{
 			var tToMatch = collectSyntax(e);
 			var tMatched = regex.test(tToMatch);
@@ -78,7 +100,7 @@
 		});
 
 		// Sort the priority matches to the top
-		tState . searched . data . sort(function(a, b) 
+		tState . cached_search_data . data . sort(function(a, b) 
 		{
 			var tToMatch = collectSyntax(a);		
 			if (priorityRegex.test(tToMatch))
@@ -91,10 +113,11 @@
 			return 0;
 		});
 	
-		return tState . searched . data;
+		return tState . cached_search_data . data;
 	}
 	
-	function dataFilter(){
+	// Return the data of the current API subject to the applied filters
+	function dataFilter() {
 		var filtered_data = [];
 		var tFound_data = []
 		
@@ -136,20 +159,22 @@
 				});
 			
 				var tMatch = true;
-				$.each(tState.filters, function(category, values){
-					if(tFound_data[category] == 0){
+				$.each(tState.filters, function(category, values) {
+					if (tFound_data[category] == 0) {
 						tMatch = false;
 					}
 				});
 			
-				if(tMatch == true) filtered_data.push(entryData);
+				if (tMatch == true) {
+					filtered_data.push(entryData);
+				}
 			});
 			
 			tState.filtered_data = filtered_data;
 		}
 		displayFilters();
 		
-		tState.searched = {};
+		tState.cached_search_data = {};
 		displayEntryListGrep($("#ui_filer").val());	
 	}
 	
@@ -165,12 +190,12 @@
 	function filterOptions(pCategories){
 		var tFilterOptionWithCount = {}
 		var tShowCatogories = pCategories.split(',');
-		$.each(tShowCatogories, function( index, category_name) {
+		$.each(tShowCatogories, function(index, category_name) {
 			tFilterOptionWithCount[category_name] = {}
 		});
 		
-		$.each(tState.filtered_data, function( entry_index, entry_data) {
-			$.each(tShowCatogories, function( category_index, category_name) {
+		$.each(tState.filtered_data, function(entry_index, entry_data) {
+			$.each(tShowCatogories, function(category_index, category_name) {
 				// If the category is already being filtered on then don't count
 				if(!tState.filters.hasOwnProperty(category_name)){
 					if(entry_data[category_name]){
@@ -466,23 +491,28 @@
 	}
 	
 	function displayEntry(pEntryID)
-	{		
-		var tEntryObject = entryData(pEntryID);
+	{	
+		var tIndex = entryIdToIndex(pEntryID);
+	    displayEntryAtIndex(tIndex);
+	}
+	
+	function displayEntryAtIndex(pIndex)
+	{
+		var tEntryObject = tState.data[pIndex];
+
 		history_add(tEntryObject);
 		
-		pEntryID = tEntryObject.id;
+		var tEntryId = tEntryObject.id;
 		
-		console.log(tEntryObject);
-		
-		if(tState.selected == pEntryID) return 1;
-		tState.selected = pEntryID;
-		$.session.set("selected", pEntryID);
+		if (tState.selected_entry_index[tState.selected_api_id] == pIndex) return 1;
+		tState.selected_entry_index[tState.selected_api_id] = pIndex;
+		$.session.set("selected_entry_index", tState.selected_entry_index);
 		
 		breadcrumb_draw();
 		
 		$(".entry_list_item").removeClass("active");
-		$("#entry_list_item_"+pEntryID).addClass("active");
-		selectedEntryEnsureInView(tEntryObject.id);
+		$("#entry_list_item_"+tEntryId).addClass("active");
+		selectedEntryEnsureInView(tEntryId);
 		
 		var tHTML = "";
 		var references = [];
@@ -552,12 +582,12 @@
 						tHTML += reference_type + ': ';
 						var reference_html = "";
 						$.each(reference_array, function(reference_index, reference_name) {
-							var tReference, tID;
-							tID = entryNameToID(reference_name, reference_type);
-							if (tID == 0)
+							var tReference, tIndex;
+							tIndex = entryNameToIndex(reference_name, reference_type);
+							if (tIndex == 0)
 								tReference = reference_name;
 							else
-								tReference = click_text(reference_name, tID);
+								tReference = click_text_from_index(reference_name, tIndex);
 							
 							if (reference_html == "") 
 								reference_html = tReference;
@@ -592,18 +622,18 @@
 							var tTypes, tType;
 							tTypes = ["object","library","glossary"];
 							
-							var tID;
+							var tIndex;
 							$.each(tTypes, function(tTypeIndex, tType) {
-								tID = entryNameToID(value2, tType)
-								if (tID != 0)
+								tIndex = entryNameToIndex(value2, tType)
+								if (tIndex != 0)
 									return;
 							});
 							
 							var tAssociation;
-							if (tID == 0)
+							if (tIndex == 0)
 								tAssociation = value2;
 							else
-								tAssociation = click_text(value2, tID);
+								tAssociation = click_text_from_index(value2, tIndex);
 							
 							if (association_html == "") 
 								association_html = tAssociation;
@@ -789,13 +819,19 @@
 			return click_text(pLink, pEntryData.id);
 	}
 	
-	function click_text(pText, pID)
+	function click_text_from_index(pText, pIndex)
 	{
 		var text;
 		text = '<a href="javascript:void(0)" class="load_entry"';
-		text += ' entryid="'+pID+'"'; 
+		text += ' entryindex="'+pIndex+'"'; 
 		text += '>' + pText + '</a>';
 		return text;
+	}
+		
+	function click_text(pText, pID)
+	{
+		var tIndex = entryIdToIndex(pID);
+		return click_text_from_index(pText, tIndex)
 	}
 	
 	function undo_link_replacement(pText)
@@ -835,7 +871,7 @@
         var entry_id;
         if(pTargetType){
 	        // Know name and type so lookup id
-             entry_id = entryNameToID(pTargetName,pTargetType);
+             entry_id = entryNameToIndex(pTargetName,pTargetType);
         } else {
         	// Work out the type from the reference
 			if(pEntryObject.hasOwnProperty("references")) {
@@ -843,7 +879,7 @@
 					$.each(reference_array, function(reference_index, reference_name) {
 						if (reference_name == pTargetName)
 						{
-							entry_id = entryNameToID(reference_name,reference_type);
+							entry_id = entryNameToIndex(reference_name,reference_type);
 							return;
 						}
 					});
@@ -871,41 +907,42 @@
 		return tData;
 	}
 	
-	function entryNameToID(pName,pType){
-		var tID = 0;
+	function entryNameToIndex(pName,pType){
+		var tIndex = 0;
 	
-		$.each(dataGet(), function( index, value) {
+		$.each(dataGet(), function(index, value) {
 			if((value.name == pName || value["display name"] == pName) && value.type == pType){
-				tID = value.id;
+				tIndex = index;
 				return false;
 			}
 			
 		});
-		return tID;
+		return tIndex;
 	}
 	
-	function entryIDToArrayKey(pID){
-		var tID = 0;
-		$.each(dataGet(), function( index, value) {
-			if(value.id == pID){
-				tID = index;
+	function entryIdToIndex(pId){
+		var tIndex = 0;
+	
+		$.each(dataGet(), function(index, value) {
+			if(value.id == pId){
+				tIndex = index;
 				return false;
 			}
 			
 		});
-		return tID;
-	} 
+		return tIndex;
+	}
 	
 	function breadcrumb_draw()
 	{
 		var tHistory = tState.history.list;
 		
-		if (tState.history.selected > 0) 
+		if (tState.history.selected_index > 0) 
 			$('#lcdoc_history_back').removeClass('disabled');
 		else
 			$('#lcdoc_history_back').addClass('disabled');
 		
-		if (tState.history.selected < tHistory.length - 1) 
+		if (tState.history.selected_index < tHistory.length - 1) 
 			$('#lcdoc_history_forward').removeClass('disabled');
 		else
 			$('#lcdoc_history_forward').addClass('disabled');
@@ -921,7 +958,7 @@
 		var tHistoryList = '';	
 		$.each(tHistory, function(index, value) 
 		{
-			if (index == tState.history.selected)
+			if (index == tState.history.selected_index)
 				tHistoryList += '<li class="active"><a href="#">';
 			else
 			{
@@ -1005,12 +1042,12 @@
 	
 	function history_selected_entry()
 	{
-		return tState.history.list[tState.history.selected];
+		return tState.history.list[tState.history.selected_index];
 	}
 	
 	function history_add(pEntryObject)
 	{	
-		if (tState.history.selected != -1)
+		if (tState.history.selected_index != -1)
 		{
 			// If this is the currently selected item, don't do anything
 			if (history_selected_entry().id == pEntryObject.id)
@@ -1035,22 +1072,22 @@
 		tNewHistory.push(tObject);
 		
 		tState.history.list = tNewHistory;
-		tState.history.selected = tNewHistory . length - 1;
+		tState.history.selected_index = tNewHistory . length - 1;
 	}
 	
 	function history_back()
 	{
-		go_history(tState.history.selected - 1);
+		go_history(tState.history.selected_index - 1);
 	}
 	
 	function history_forward()
 	{
-		go_history(tState.history.selected + 1);
+		go_history(tState.history.selected_index + 1);
 	}
 	
 	function go_history(pHistoryID)
 	{
-		tState.history.selected = pHistoryID
+		tState.history.selected_index = pHistoryID
 		displayEntry(history_selected_entry().id);
 	}
 	
@@ -1081,15 +1118,21 @@
 			{
 				tState.selected_api_id = pLibraryID;
 				$.session.set("selected_api_id", pLibraryID);
-				tState.selected = ""
-				tState.history = {list:[], selected:-1};
-				tState.searched = {};
+				var tIndex = 1;
+				if (tState.selected_entry_index.hasOwnProperty(pLibraryID))
+				{
+					tIndex = tState.selected_entry_index[pLibraryID];
+				}
+				
+				tState.history = {list:[], selected_index:-1};
+				tState.cached_search_data = {};
 				tState.filters= {};
 				tState.filtered_data = [];
 				tState.data = "";
-			
+				tState.selected_entry_index[pLibraryID] = "";
+				
 				dataFilter();
-				displayEntry(1);
+				displayEntryAtIndex(tIndex);
 			}
 		}
 	}
@@ -1146,10 +1189,10 @@
 		var tLibraryID = library_name_to_id(pLibraryName);
 		library_set(tLibraryID);
 		
-		var tID = entryNameToID(pEntryName, pEntryType);
+		var tID = entryNameToIndex(pEntryName, pEntryType);
 		if (tID == 0)
 			tID = 1;
-		displayEntry(tID);
+		displayEntryAtIndex(tID);
 	}
 	
 	function isRunningInLiveCodeBrowser()
@@ -1178,14 +1221,23 @@
 				window.location.href = 'https://livecode.com/products/livecode-platform/pricing/';
 			}
  		});
-				
+
 		$('#ui_filer').keyup(function() {
 		  displayEntryListGrep(this.value);
+		  if(tState.cached_search_data.data.hasOwnProperty(0))
+		  	   displayEntry(tState.cached_search_data.data[0]["id"]);
 		})
-		
+
 		$("body").on( "click", ".load_entry", function() {
-			var tEntryID = $(this).attr("entryid");
-			displayEntry(tEntryID);
+			var tEntryIndex = $(this).attr("entryindex");
+			if (typeof tEntryIndex !== typeof undefined && tEntryIndex !== false) {
+				displayEntryAtIndex(tEntryIndex);
+			}
+
+			var tEntryId = $(this).attr("entryid");			
+			if (typeof tEntryId !== typeof undefined && tEntryId !== false) {
+				displayEntry(tEntryId);
+			}
 		});
 		
 		$("body").on("click", ".list_sort", function() {

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -492,6 +492,17 @@
 	    displayEntryAtIndex(tIndex);
 	}
 	
+	function syntax_to_string(pSyntax)
+	{
+	    var tHtml = '';
+	    $.each(pSyntax, function(index, value) {
+	        if (index > 0)
+	            tHtml += '<br>';
+	        tHtml += replace_link_placeholders_with_param(value).replace(/[\n\r]/g, '<br>');
+	    });
+	    return tHtml;
+	}
+	
 	function displayEntryAtIndex(pIndex)
 	{
 		var tEntryObject = tState.data[pIndex];
@@ -715,7 +726,7 @@
 					tHTML += '<tr>';
 					tHTML += '<td>' + click_text_from_entry_data('', entry_data) +'</a></td>';
 					tHTML += '<td>'+replace_link_placeholders_with_param(entry_data.summary)+'</td>';
-					tHTML += '<td>'+replace_link_placeholders_with_param(entry_data.syntax[0])+'</td>';
+					tHTML += '<td>'+syntax_to_string(entry_data.syntax)+'</td>';
 					tHTML += '</tr>';
 				});
 				tHTML += '</tbody></table>';

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -548,9 +548,12 @@
 		tHTML += '</h1><div class="row">';
 	
 		$.each(tEntryObject, function(index, value) {
-			if(index == "id" || index == "name") return;
-			
 			switch(index){
+				case "id":
+				case "name":
+				case "library":
+				// These are for 'meta' information, not for display
+					return;
 				case "examples":
 					tHTML += '<div class="col-md-2 lcdoc_section_title">'+index+'</div><div class="col-md-10" style="margin-bottom:10px">';	
 					if($.isArray(value)){

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -162,6 +162,18 @@ private function ideDocsFetchData pAPI, pLibraryName, pEntryName
 end ideDocsFetchData
 
 /* 
+Fetch the data for LCS entries with name <pEntryName>, including extensions
+
+Returns:
+A numerically keyed array, each element of which is the array
+of data 
+pertaining to a LiveCode Script API entry with the given name.
+*/
+function ideDocsFetchScriptData pEntryName
+   return ideDocsFetchData("livecode_script", "", pEntryName)
+end ideDocsFetchScriptData
+
+/* 
 Fetch the data for LiveCode script dictionary entries with name <pEntryName>
 
 Returns:

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -72,9 +72,9 @@ private function __fetchDocsData pAPI, pLibraryName, pEntryName, pType
       end if
    end if
    
-   local tRecordSet, tData, tDataSet, tParamCount
+   local tRecordSet, tDataSet, tParamCount
    
-   put "SELECT entry_data from dictionary_data" into tSQL
+   put "SELECT entry_data, library_name FROM dictionary_data" into tSQL
    
    local tWhere
    if pAPI is not empty then
@@ -111,12 +111,16 @@ private function __fetchDocsData pAPI, pLibraryName, pEntryName, pType
    end if
    
    # Get the docs data from the record set
-   local tCount, tMoreRecords
+   local tCount, tMoreRecords, tData, tLibrary
    put true into tMoreRecords
    repeat while tMoreRecords
-      add 1 to tCount
       get revDatabaseColumnNamed(tRecordSet, "entry_data", "tData")
-      put tData into tDataSet[tCount]
+      if tData is not empty then 
+         get revDatabaseColumnNamed(tRecordSet, "library_name", "tLibrary")
+         add 1 to tCount
+         put tData into tDataSet[tCount]["data"]
+         put tLibrary into tDataSet[tCount]["library"]
+      end if
       revMoveToNextRecord tRecordSet
       put the result into tMoreRecords
    end repeat
@@ -129,19 +133,17 @@ end __fetchDocsData
 
 private function __ideDocsFetchData pAPI, pLibraryName, pEntryName, pType
    # Fetch the data
-   local tData
-   put __fetchDocsData(pAPI, pLibraryName, pEntryName, pType) into tData
+   local tDataA
+   put __fetchDocsData(pAPI, pLibraryName, pEntryName, pType) into tDataA
    
-   if tData[1] is empty then
-      return empty
-   end if
-   
-   repeat for each key tCount in tData
-      put arrayDecode(tData[tCount]) into tData[tCount]
+   local tDecodedDataA
+   repeat for each key tCount in tDataA
+      put arrayDecode(tDataA[tCount]["data"]) into tDecodedDataA[tCount]
+      put tDataA[tCount]["library"] into tDecodedDataA[tCount]["library"]
    end repeat
    
    # Return the decoded array
-   return tData
+   return tDecodedDataA
 end __ideDocsFetchData
 
 private function ideDocsFetchElementOfType pAPI, pLibraryName, pEntryName, pType, pElement

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -50,7 +50,7 @@ command ideDocsInitialize pDistributed
    return tConnection
 end ideDocsInitialize
 
-private function __fetchDocsData pEntryName, pLibraryName, pType
+private function __fetchDocsData pAPI, pLibraryName, pEntryName, pType
    # Ensure we have a connection
    local tConnection
    try
@@ -60,20 +60,15 @@ private function __fetchDocsData pEntryName, pLibraryName, pType
       return tError
    end try
    
-   # Find the library id
-   local tSQL, tLibraryID, tResult
-   if pLibraryName is not empty then
-      # Get the library's escaped name
-      local tLibName
-      dispatch function "revDocsModifyForUrl" to stack "revDocsParser" with pLibraryName
-      put the result into tLibName
-      
-      put "SELECT library_id FROM libraries WHERE library_name = :1" into tSQL
-      put revDataFromQuery(comma, return, sConnection, tSQL, "tLibName") into tLibraryID
+   # Find the api id
+   local tSQL, tAPIID, tResult
+   if pAPI is not empty then
+      put "SELECT api_id FROM apis WHERE api_name = :1" into tSQL
+      put revDataFromQuery(comma, return, tConnection, tSQL, "pAPI") into tAPIID
       
       put the result into tResult
       if tResult is not a number then
-         return "error finding library id for" && pLibraryName & return & tResult
+         return "error finding api id for" && pAPI & return & tResult
       end if
    end if
    
@@ -82,36 +77,37 @@ private function __fetchDocsData pEntryName, pLibraryName, pType
    put "SELECT entry_data from dictionary_data" into tSQL
    
    local tWhere
-   if pEntryName is not empty then
-      put "entry_name" into tWhere[1]
-   end if
-   if pType is not empty then
-      put "entry_type" into tWhere[2]
+   if pAPI is not empty then
+      put "api_id" into tWhere[1]
    end if
    if pLibraryName is not empty then
-      put "library_id" into tWhere[3]
+      put "library_name" into tWhere[2]
+   end if
+   if pEntryName is not empty then
+      put "entry_name" into tWhere[3]
+   end if
+   if pType is not empty then
+      put "entry_type" into tWhere[4]
    end if
    
    local tWhereString
-   repeat with x = 1 to 3
+   repeat with x = 1 to 4
       if tWhere[x] is not empty then
          if tWhereString is empty then
             put " WHERE" && tWhere[x] & "=:" & x into tWhereString
          else
             put " AND" && tWhere[x] & "=:" & x after tWhereString
          end if
+         put " COLLATE NOCASE" after tWhereString
       end if
    end repeat
    
    put tWhereString after tSQL
-   
-   local tEntryName
-   put tolower(pEntryName) into tEntryName
-   
+
    # Execute the query, keeping the record set ID.
-   put revQueryDatabase(sConnection, tSql, "tEntryName", "pType", "tLibraryID") into tRecordSet
+   put revQueryDatabase(tConnection, tSql, "tAPIID", "pLibraryName", "pEntryName", "pType") into tRecordSet
    if the result is not a number then
-      return "entry" && tEntryName && "not found" & return & the result
+      return "entry" && pEntryName && "not found" & return & the result
    end if
    
    # Get the docs data from the record set
@@ -131,10 +127,10 @@ private function __fetchDocsData pEntryName, pLibraryName, pType
    return tDataSet
 end __fetchDocsData
 
-private function __ideDocsFetchData pEntryName, pLibraryName, pType
+private function __ideDocsFetchData pAPI, pLibraryName, pEntryName, pType
    # Fetch the data
    local tData
-   put __fetchDocsData(pEntryName, pLibraryName, pType) into tData
+   put __fetchDocsData(pAPI, pLibraryName, pEntryName, pType) into tData
    
    if tData[1] is empty then
       return empty
@@ -148,21 +144,21 @@ private function __ideDocsFetchData pEntryName, pLibraryName, pType
    return tData
 end __ideDocsFetchData
 
-private function ideDocsFetchElementOfType pEntryName, pLibraryName, pType, pElement
+private function ideDocsFetchElementOfType pAPI, pLibraryName, pEntryName, pType, pElement
    local tDataA
-   put __ideDocsFetchData(pEntryName, pLibraryName, pType) into tDataA
+   put __ideDocsFetchData(pAPI, pLibraryName, pEntryName, pType) into tDataA
    
    return tDataA[1][pElement]
 end ideDocsFetchElementOfType
 
-private function ideDocsFetchDataOfType pEntryName, pLibraryName, pType
+private function ideDocsFetchDataOfType pAPI, pLibraryName, pEntryName, pType
    local tDataA
-   put  __ideDocsFetchData(pEntryName, pLibraryName, pType) into tDataA
+   put  __ideDocsFetchData(pAPI, pLibraryName, pEntryName, pType) into tDataA
    return tDataA[1]
 end ideDocsFetchDataOfType
 
-private function ideDocsFetchData pEntryName, pLibraryName
-   return __ideDocsFetchData(pEntryName, pLibraryName)
+private function ideDocsFetchData pAPI, pLibraryName, pEntryName
+   return __ideDocsFetchData(pAPI, pLibraryName, pEntryName)
 end ideDocsFetchData
 
 /* 
@@ -174,7 +170,7 @@ of data
 pertaining to a  LiveCode script dictionary entry with the given name.
 */
 function ideDocsFetchLCSData pEntryName
-   return ideDocsFetchData(pEntryName, "LiveCode Script")
+   return ideDocsFetchData("livecode_script", "LiveCode Script", pEntryName)
 end ideDocsFetchLCSData
 
 /* 
@@ -187,7 +183,7 @@ of data pertaining to the unique LiveCode script dictionary entry with the
 given name and type.
 */
 function ideDocsFetchLCSDataOfType pEntryName, pType
-   return ideDocsFetchDataOfType(pEntryName, "LiveCode Script", pType)
+   return ideDocsFetchDataOfType("livecode_script", "LiveCode Script", pEntryName, pType)
 end ideDocsFetchLCSDataOfType
 
 /* 
@@ -200,7 +196,7 @@ of data describing the element of the array of data
 pertaining to the LiveCode script dictionary entry with the given name and type.
 */
 function ideDocsFetchLCSElementOfType pEntryName, pType, pElement
-   return ideDocsFetchElementOfType(pEntryName, "LiveCode Script", pType, pElement)
+   return ideDocsFetchElementOfType("livecode_script", "LiveCode Script", pEntryName, pType, pElement)
 end ideDocsFetchLCSElementOfType
 
 /* 
@@ -211,7 +207,7 @@ A numerically keyed array of data, each element of which is an array of data
 pertaining to a LiveCode script dictionary entry with the given type.
 */
 function ideDocsFetchLCSElementsOfType pType
-   return __ideDocsFetchData("", "LiveCode Script", pType)
+   return __ideDocsFetchData("livecode_script", "LiveCode Script", "", pType)
 end ideDocsFetchLCSElementsOfType
 
 /* 
@@ -223,7 +219,7 @@ of data
 pertaining to a LiveCode builder dictionary entry with the given name.
 */
 function ideDocsFetchLCBData pEntryName
-   return ideDocsFetchData(pEntryName, "LiveCode Builder")
+   return ideDocsFetchData("livecode_builder", "LiveCode Builder", pEntryName)
 end ideDocsFetchLCBData
 
 /* 
@@ -236,7 +232,7 @@ of data pertaining to the unique LiveCode builder dictionary entry with the
 given name and type.
 */
 function ideDocsFetchLCBDataOfType pEntryName, pType
-   return ideDocsFetchDataOfType(pEntryName, "LiveCode Builder", pType)
+   return ideDocsFetchDataOfType("livecode_builder", "LiveCode Builder", pEntryName, pType)
 end ideDocsFetchLCBDataOfType
 
 /* 
@@ -249,7 +245,7 @@ of data describing the element of the array of data
 pertaining to the LiveCode builder dictionary entry with the given name and type.
 */
 function ideDocsFetchLCBElementOfType pEntryName, pType, pElement
-   return ideDocsFetchElementOfType(pEntryName, "LiveCode Builder", pType, pElement)
+   return ideDocsFetchElementOfType("livecode_builder", "LiveCode Builder", pEntryName, pType, pElement)
 end ideDocsFetchLCBElementOfType
 
 /* 
@@ -260,7 +256,7 @@ A numerically keyed array of data, each element of which is an array of data
 pertaining to a LiveCode builder dictionary entry with the given type.
 */
 function ideDocsFetchLCBElementsOfType pType
-   return __ideDocsFetchData("", "LiveCode Builder", pType)
+   return __ideDocsFetchData("livecode_builder", "LiveCode Builder", "", pType)
 end ideDocsFetchLCBElementsOfType
 
 /* 
@@ -272,9 +268,10 @@ of data
 pertaining to an entry in the API for the given extension with the given name.
 */
 function ideDocsFetchExtensionData pID, pEntryName
-   local tLibraryName
+   local tLibraryName, tAPI
    put revIDEExtensionProperty(pID, "title") into tLibraryName
-   return ideDocsFetchData(pEntryName, tLibraryName)
+   put revIDEExtensionProperty(pID, "api") into tAPI
+   return ideDocsFetchData(tAPI, tLibraryName, pEntryName)
 end ideDocsFetchExtensionData
 
 /* 
@@ -287,9 +284,10 @@ of data pertaining to the unique entry in the API for the given extension with t
 given name and type.
 */
 function ideDocsFetchExtensionDataOfType pID, pEntryName, pType
-   local tLibraryName
+   local tLibraryName, tAPI
    put revIDEExtensionProperty(pID, "title") into tLibraryName
-   return ideDocsFetchDataOfType(pEntryName, tLibraryName, pType)
+   put revIDEExtensionProperty(pID, "api") into tAPI
+   return ideDocsFetchDataOfType(tAPI, tLibraryName, pEntryName, pType)
 end ideDocsFetchExtensionDataOfType
 
 /* 
@@ -302,9 +300,10 @@ of data describing the element of the array of data
 pertaining to the entry in the API for the given extension with the given name and type.
 */
 function ideDocsFetchExtensionElementOfType pID, pEntryName, pType, pElement
-   local tLibraryName
-   put revIDEExtensionProperty(pID, "title") into tLibraryName	
-   return ideDocsFetchElementOfType(pEntryName, tLibraryName, pType, pElement)
+   local tLibraryName, tAPI
+   put revIDEExtensionProperty(pID, "title") into tLibraryName
+   put revIDEExtensionProperty(pID, "api") into tAPI
+   return ideDocsFetchElementOfType(tAPI, tLibraryName, pEntryName, pType, pElement)
 end ideDocsFetchExtensionElementOfType
 
 /* 
@@ -315,9 +314,10 @@ A numerically keyed array of data, each element of which is an array of data
 pertaining to a LiveCode script dictionary entry with the given type.
 */
 function ideDocsFetchExtensionElementsOfType pID, pType
-   local tLibraryName
+   local tLibraryName, tAPI
    put revIDEExtensionProperty(pID, "title") into tLibraryName
-   return __ideDocsFetchData("", tLibraryName, pType)
+   put revIDEExtensionProperty(pID, "api") into tAPI
+   return __ideDocsFetchData(tAPI, tLibraryName, "", pType)
 end ideDocsFetchExtensionElementsOfType
 
 /*
@@ -334,8 +334,8 @@ function ideDocsFetchLibraryNames
    end try
    
    local tRecordSet, tData, tDataSet, tSQL
-   put "SELECT library_name FROM libraries" into tSQL
-   put revQueryDatabase(sConnection, tSQL) into tRecordSet
+   put "SELECT library_name FROM dictionary_data" into tSQL
+   put revQueryDatabase(tConnection, tSQL) into tRecordSet
    if the result is not a number then
       return "error fetching library names" & return & the result
    end if

--- a/Toolset/libraries/revidedocumentationlibrary.livecodescript
+++ b/Toolset/libraries/revidedocumentationlibrary.livecodescript
@@ -18,31 +18,44 @@ private on ideDocsEnsureDatabase pLocation
    end if
 end ideDocsEnsureDatabase
 
-local sConnection
-on ideDocsInitialize
-   if sConnection is among the items of revOpenDatabases() then
-      exit ideDocsInitialize
+local sConnectionsA
+command ideDocsInitialize pDistributed
+   If pDistributed is true and revEnvironmentIsInstalled() then
+      ideThrow "can't write to installed IDE"
+      return empty
    end if
    
-   local tCopyLocation
-   put revIDESpecialFolderPath("documentation cache") into tCopyLocation
-   ideDocsEnsureDatabase tCopyLocation
+   local tConnection, tLocation, tKey
+   if pDistributed is true then
+      put "ide" into tKey
+      put revIDESpecialFolderPath("API") into tLocation
+   else
+      put "cache" into tKey
+      put revIDESpecialFolderPath("documentation cache") into tLocation
+      ideDocsEnsureDatabase tLocation
+   end if
+   put sConnectionsA[tKey] into tConnection
    
-   local tConnection
-   dispatch "revDocsOpenAPIDatabase" to stack "revDocsParser" with revIDESpecialFolderPath("documentation cache")
+   if tConnection is among the items of revOpenDatabases() then
+      return tConnection
+   end if
+   
+   dispatch "revDocsOpenAPIDatabase" to stack "revDocsParser" with tLocation
    put the result into tConnection
    if tConnection is not a number then
       ideThrow "unable to open database", tConnection
    end if
    
-   put tConnection into sConnection
-   return empty
+   put tConnection into sConnectionsA[tKey]
+   return tConnection
 end ideDocsInitialize
 
 private function __fetchDocsData pEntryName, pLibraryName, pType
    # Ensure we have a connection
+   local tConnection
    try
       ideDocsInitialize
+      put the result into tConnection
    catch tError
       return tError
    end try
@@ -312,8 +325,10 @@ Returns a list of library names, one per line, which have API entries in the dic
 */
 function ideDocsFetchLibraryNames
    # Ensure we have a connection
+   local tConnection
    try
       ideDocsInitialize
+      put the result into tConnection
    catch tError
       return tError
    end try
@@ -380,24 +395,31 @@ of data
 pertaining to an entry in the API for the given extension.
 */
 function ideDocsFetchExtensionEntries pID
-   local tLibraryName
-   put revIDEExtensionProperty(pID, "title") into tLibraryName	
-   return ideDocsFetchLibraryEntries(tLibraryName)
+   local tLibraryName, tAPI
+   put revIDEExtensionProperty(pID, "title") into tLibraryName
+   put revIDEExtensionProperty(pID, "api") into tAPI
+   return ideDocsFetchLibraryEntries(tAPI, tLibraryName)
 end ideDocsFetchExtensionEntries
 
-on ideDocsUpdateDatabase pLibraryA
-   ideDocsInitialize
+on ideDocsUpdateDatabase pAPI, pLibraryA, pDistributed
+   if pDistributed is true and revEnvironmentIsInstalled() then
+      exit ideDocsUpdateDatabase
+   end if
+   
+   local tConnection
+   ideDocsInitialize pDistributed
+   put the result into tConnection
    
    local tResult
-   revExecuteSQL sConnection,"BEGIN TRANSACTION"
-   dispatch "revDocsUpdateDatabase" to stack "revDocsParser" with sConnection, pLibraryA
+   revExecuteSQL tConnection,"BEGIN TRANSACTION"
+   dispatch "revDocsUpdateDatabase" to stack "revDocsParser" with tConnection, pAPI, pLibraryA
    put the result into tResult
    
    if tResult is not empty then
-      revExecuteSQL sConnection,"ROLLBACK"
+      revExecuteSQL tConnection,"ROLLBACK"
       return tResult
    end if
-    
-   revExecuteSQL sConnection, "COMMIT"
+   
+   revExecuteSQL tConnection, "COMMIT"
    return empty
 end ideDocsUpdateDatabase

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -143,6 +143,10 @@ function revIDEExtensionProperty pKind, pProperty
    local tExtensionID
    put __extensionCacheID("name", pKind) into tExtensionID
    
+   if pProperty is "api" then
+      return __TypeToAPI(__extensionPropertyGet(tExtensionID, "type"))
+   end if
+   
    return __extensionPropertyGet(tExtensionID, pProperty)
 end revIDEExtensionProperty
 
@@ -1126,18 +1130,18 @@ end extensionUpdateDataReceived
 
 -- At the moment, if the extension is of type module then assume
 -- it provides an LCB API, and otherwise it provides an LCS API.
-function __TypeToAPI pType
+private function __TypeToAPI pType
    switch pType
       case "module"
-         return "lcb"
+         return "livecode_builder"
          break
       case "plugin"
-         return "ide"
+         return "livecode_ide"
          break
       case "library"
       case "widget"
       default
-         return "lcs"
+         return "livecode_script"
          break
    end switch
 end __TypeToAPI

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -1124,11 +1124,33 @@ end __extensionManifestValueFromFile
 on extensionUpdateDataReceived
 end extensionUpdateDataReceived
 
-function revIDEExtensionDocsData
+-- At the moment, if the extension is of type module then assume
+-- it provides an LCB API, and otherwise it provides an LCS API.
+function __TypeToAPI pType
+   switch pType
+      case "module"
+         return "lcb"
+         break
+      case "plugin"
+         return "ide"
+         break
+      case "library"
+      case "widget"
+      default
+         return "lcs"
+         break
+   end switch
+end __TypeToAPI
+
+function revIDEExtensionDocsData pForAPI
    local tExtensionsA
    put revIDEExtensions("", "installed", true) into tExtensionsA
    local tDataA, tCount
    repeat for each element tExtension in tExtensionsA
+      if pForAPI is not empty and \
+            __TypeToAPI(tExtension["type"]) is not pForAPI then
+         next repeat
+      end if
       add 1 to tCount
       put tExtension["install_path"] into tDataA[tCount]["folder"]
       put tExtension["title"] into tDataA[tCount]["title"]

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4123,7 +4123,7 @@ Example:
 local tIDEFolder
 put revIDESpecialFolderPath("IDE") into tIDEFolder
 */
-function revIDESpecialFolderPath pKey
+function revIDESpecialFolderPath pKey, pParam
    local tPath
    set the itemdel to "/"
    switch pKey
@@ -4191,10 +4191,11 @@ function revIDESpecialFolderPath pKey
          revIDEEnsurePath tPath
          return tPath
          break
-      case "api-ide"
-      case "api-lcs"
-      case "api-lcb"
+      case "api"
       case "guide"
+         if pParam is not empty then
+            put "_" & pParam after pKey
+         end if
          put item 1 to -3 of the filename of stack "home" & "/Documentation/html_viewer/resources/data/" & tolower(pKey) into tPath
          if not revEnvironmentIsInstalled() then
             revIDEEnsurePath tPath
@@ -10664,14 +10665,19 @@ private function revIDEGetBaseDocsData pWhich
    local tData
    
    local tAPIPath, tLibs
-   put revIDESpecialFolderPath("api-" & pWhich) into tAPIPath
+   put revIDESpecialFolderPath("api", pWhich) into tAPIPath
    put files(tAPIPath) into tLibs
    filter tLibs with "*.js"
+   local tDoc
    repeat for each line tLibraryJS in tLibs
-      put revIDEUTF8FileContents(tAPIPath & slash & tLibraryJS) \
-            & comma after tData
+      put revIDEUTF8FileContents(tAPIPath & slash & tLibraryJS) into tDoc
+      if tData is empty then
+         put tDoc into tData
+      else
+         put comma & tDoc after tData
+      end if
    end repeat
-   delete the last char of tData
+   
    return tData
 end revIDEGetBaseDocsData 
 
@@ -10763,7 +10769,7 @@ private function revIDEGetDocsAPIData pWhich
    local tData, tExtensions
    put revIDEGetBaseDocsData(pWhich) into tData
    put revIDEGetExtensionDocsData(pWhich) into tExtensions
-   if tExtensions is not empty then 
+   if tExtensions is not empty then
       put comma & tExtensions after tData
    end if
    return tData
@@ -10843,35 +10849,35 @@ on revIDERegenerateBuiltGuides
    revIDESetUTF8FileContents tDocsCache & slash & "built_guide.js", tData
 end revIDERegenerateBuiltGuides
 
+constant kAPIs = "LiveCode Script,livecode_script|LiveCode Builder,livecode_builder|LiveCode IDE,livecode_ide"
 on revIDERegenerateBuiltAPIs
    local tData, tAPIData
-   put "var dictionary_data =" & CR & "{" & CR & tab & quote & "docs" & quote & ":[" after tData
-   
-   put revIDEGetDocsAPIData("lcs") into tAPIData
-   
-   dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
-         with "LiveCode Script", "livecode_script", "", tAPIData
-   put the result after tData
-   
-   put revIDEGetDocsAPIData("lcb") into tAPIData
-   
-   dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
-         with "LiveCode Builder", "livecode_builder", "", tAPIData
-   put comma & the result after tData
-   
-   if not revEnvironmentIsInstalled() then
-      put revIDEGetDocsAPIData("ide") into tAPIData
+   set the lineDelimiter to "|"
+   repeat for each line tAPI in kAPIs
+      -- For now, the IDE API is BFS only
+      if item 2 of tAPI is "livecode_ide" and revEnvironmentIsInstalled() then
+         next repeat
+      end if
       
+      put revIDEGetDocsAPIData(item 2 of tAPI) into tAPIData
       dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
-            with "LiveCode IDE", "livecode_ide", "", tAPIData    
-      put comma & the result after tData
-   end if
+            with item 1 of tAPI, item 2 of tAPI, "", tAPIData
+      if tData is empty then
+         put the result into tData
+      else
+         put comma & the result after tData
+      end if
+   end repeat
    
-   put CR & tab & "]" & CR & "}" after tData
+   local tDictionaryData
+   put "var dictionary_data =" & return & "{" & return & \
+         tab & quote & "docs" & quote & ":[" & \
+         tData & return & tab & "]" & return & "}" \
+         into tDictionaryData
    
    local tDocsCache
    put revIDESpecialFolderPath("documentation cache") into tDocsCache
-   revIDESetUTF8FileContents tDocsCache & slash & "built_api.js", tData
+   revIDESetUTF8FileContents tDocsCache & slash & "built_api.js", tDictionaryData
 end revIDERegenerateBuiltAPIs
 
 on revIDERegenerateBuiltDictionaryData
@@ -10945,7 +10951,7 @@ private command revIDEGenerateDistributedAPI
    put the effective filename of stack "revDocsParser" into tInputs[0]
    put tDocsFolder & slash & "dictionary" into tInputs[1]
    put tDocsFolder & slash & "glossary" into tInputs[2]
-   put revIDESpecialFolderPath("api-lcs") & slash & "script.js" into tOutput
+   put revIDESpecialFolderPath("api", "livecode_script") & slash & "script.js" into tOutput
    
    put revIDEIsFilesetStale(tInputs, tOutput, true, tError) into tNeedUpdate
    
@@ -10960,11 +10966,11 @@ private command revIDEGenerateDistributedAPI
       put revDocsParseDictionaryToLibraryArray(tDocsFolder) into tScriptA["doc"]
       
       # Update the database
-      ideDocsUpdateDatabase tScriptA
+      ideDocsUpdateDatabase "livecode_script", tScriptA, true
       
       local tJSON
       put revDocsFormatLibraryDocArrayAsJSON("livecode_script", tScriptA["doc"]) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcs") & slash & "script.js", \
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api", "livecode_script") & slash & "script.js", \
             tJSON
    end if
    
@@ -10974,7 +10980,7 @@ private command revIDEGenerateDistributedAPI
    
    set the itemdelimiter to slash
    put empty into tInputs
-   put revIDESpecialFolderPath("api-lcb") & slash & "builder.js" into tOutput
+   put revIDESpecialFolderPath("api", "livecode_builder") & slash & "builder.js" into tOutput
    put the effective filename of stack "revDocsParser" into tInputs[0]
    local tCount
    put 1 into tCount
@@ -11018,16 +11024,16 @@ private command revIDEGenerateDistributedAPI
       put "dictionary" into tBuilderA["type"]
       
       # Update the database
-      ideDocsUpdateDatabase tBuilderA
+      ideDocsUpdateDatabase "livecode_builder", tBuilderA, true
       
       put revDocsFormatLibraryDocArrayAsJSON("livecode_builder", tBuilderA["doc"]) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcb") & slash & "builder.js", \
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api", "livecode_builder") & slash & "builder.js", \
             tJSON
    end if
    
    # Check to see if we need to regenerate the datagrid docs
    put empty into tInputs
-   put revIDESpecialFolderPath("api-lcs") & slash & "dg.js" into tOutput
+   put revIDESpecialFolderPath("api", "livecode_script") & slash & "dg.js" into tOutput
    put the effective filename of stack "revDocsParser" into tInputs[0]
    local tDatagridDoc, tFolder
    put revIDESpecialFolderPath("Documentation") &"/dictionary" into tFolder
@@ -11039,9 +11045,9 @@ private command revIDEGenerateDistributedAPI
       put revDocsParseDocFileToLibraryArray(tFolder & slash & "datagrid.lcdoc", "Data Grid", "LiveCode") into tLibA
 
       # Update the database
-      ideDocsUpdateDatabase tLibA
+      ideDocsUpdateDatabase "livecode_script", tLibA, true
       put revDocsFormatLibraryDocArrayAsJSON("datagrid", tLibA["doc"]) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcs") & slash & "dg.js", \
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api", "livecode_script") & slash & "dg.js", \
             tJSON
    end if
    
@@ -11054,7 +11060,7 @@ private command revIDEGenerateDistributedAPI
    put the effective filename of stack "revDocsParser" into tInputs[0]
    put tIdeSupportFolder into tInputs[1]
    put tIDELibsFolder into tInputs[2]
-   put revIDESpecialFolderPath("api-ide") & slash & "ide.js" into tOutput
+   put revIDESpecialFolderPath("api", "livecode_ide") & slash & "ide.js" into tOutput
    
    put revIDEIsFilesetStale(tInputs, tOutput, true, tError) into tNeedUpdate
    # Regenerate dictionary if necessary
@@ -11090,10 +11096,10 @@ private command revIDEGenerateDistributedAPI
       put "dictionary" into tIDELibraryA["type"]
       
       # Update the database
-      ideDocsUpdateDatabase tIDELibraryA
+      ideDocsUpdateDatabase "livecode_ide", tIDELibraryA, true
       
       put revDocsFormatLibraryDocArrayAsJSON("livecode_ide", tIDELibraryA["doc"]) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api-ide") & slash & "ide.js", \
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api", "livecode_ide") & slash & "ide.js", \
             tJSON
    end if
    
@@ -11109,7 +11115,7 @@ private command revIDEGenerateDistributedAPI
    repeat for each line tFile in tFiles
       # Check to see if we need to regenerate the docs
       put empty into tInputs
-      put revIDESpecialFolderPath("api-lcs") & slash & toLower(item 1 to -2 of tFile) & ".js" into tOutput
+      put revIDESpecialFolderPath("api", "livecode_script") & slash & toLower(item 1 to -2 of tFile) & ".js" into tOutput
       put the effective filename of stack "revDocsParser" into tInputs[0]
       put tExtractedDocsFolder & slash & tFile into tInputs[1]
       put revIDEIsFilesetStale(tInputs, tOutput, false, tError) into tNeedUpdate
@@ -11117,7 +11123,7 @@ private command revIDEGenerateDistributedAPI
       if tNeedUpdate then
          put revDocsParseDocFileToLibraryArray(tExtractedDocsFolder & slash & tFile, item -2 of tFile, "LiveCode") into tLibA
          # Update the database
-         ideDocsUpdateDatabase tLibA
+         ideDocsUpdateDatabase "livecode_script", tLibA, true
          put revDocsFormatLibraryDocArrayAsJSON(tLibA["name"], tLibA["doc"]) into tJSON
          revIDESetUTF8FileContents tOutput, tJSON
       end if

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4191,7 +4191,9 @@ function revIDESpecialFolderPath pKey
          revIDEEnsurePath tPath
          return tPath
          break
-      case "api"
+      case "api-ide"
+      case "api-lcs"
+      case "api-lcb"
       case "guide"
          put item 1 to -3 of the filename of stack "home" & "/Documentation/html_viewer/resources/data/" & tolower(pKey) into tPath
          if not revEnvironmentIsInstalled() then
@@ -10658,12 +10660,24 @@ private function __getLCBSourceFile pFolder
    return tSource
 end __getLCBSourceFile
 
-private function revIDEGetDocsAPIData 
+private function revIDEGetDocsAPIData pWhich
    local tData
    
-   local tAPIPath
-   put revIDESpecialFolderPath("API") into tAPIPath
-   put revIDEUTF8FileContents(tAPIPath & slash & "distributed_api.js") into tData
+   local tAPIPath, tLibs
+   put revIDESpecialFolderPath("api-" & pWhich) into tAPIPath
+   put files(tAPIPath) into tLibs
+   filter tLibs with "*.js"
+   repeat for each line tLibraryJS in tLibs
+      put revIDEUTF8FileContents(tAPIPath & slash & tLibraryJS) \
+            & comma after tData
+   end repeat
+   delete the last char of tData
+   return tData
+end revIDEGetDocsAPIData 
+
+private function revIDEGetLCSDocsAPIData 
+   local tData
+   put revIDEGetDocsAPIData("lcs") into tData
    
    local tExtensionDocsDataA
    put revIDEExtensionDocsData() into tExtensionDocsDataA
@@ -10725,8 +10739,8 @@ private function revIDEGetDocsAPIData
                tExtensionData["author"]
          put the result into tLibraryArray
          
-         dispatch function "revDocsFormatLibraryArrayAsJSON" to stack "revDocsParser" \
-               with tLibraryArray
+         dispatch function "revDocsFormatLibraryDocArrayAsJSON" to stack "revDocsParser" \
+               with tLibraryArray["name"], tLibraryArray["doc"]
          put the result into tExtensionAPI
          
          # Update the dictionary database
@@ -10741,7 +10755,15 @@ private function revIDEGetDocsAPIData
    end repeat
    
    return tData
-end revIDEGetDocsAPIData
+end revIDEGetLCSDocsAPIData
+
+private function revIDEGetLCBDocsAPIData 
+   return revIDEGetDocsAPIData("lcb")
+end revIDEGetLCBDocsAPIData 
+
+private function revIDEGetIDEDocsAPIData 
+   return revIDEGetDocsAPIData("ide")
+end revIDEGetIDEDocsAPIData 
 
 private function revIDEGetDocsGuideData
    local tData
@@ -10799,7 +10821,7 @@ private function revIDEGetDocsGuideData
    return tData
 end revIDEGetDocsGuideData
 
-on revIDEAddGuideAndRegenerate pGuide
+on revIDERegenerateBuiltGuides
    local tData
    
    # Get the location of the distributed guide
@@ -10810,30 +10832,35 @@ on revIDEAddGuideAndRegenerate pGuide
    
    put revIDEGetDocsGuideData() after tData
    
-   if pGuide is not empty then
-      put comma & pGuide after tData
-   end if
-   
    put CR & tab & "]" & CR & "}" after tData
    
    local tDocsCache
    put revIDESpecialFolderPath("documentation cache") into tDocsCache
    revIDESetUTF8FileContents tDocsCache & slash & "built_guide.js", tData
-end revIDEAddGuideAndRegenerate
+end revIDERegenerateBuiltGuides
 
-on revIDEAddAPIAndRegenerate pAPI
-   local tData
-   
-   # Get the location of the distributed API
-   local tAPIPath
-   put revIDESpecialFolderPath("API") into tAPIPath
-   
+on revIDERegenerateBuiltAPIs
+   local tData, tAPIData
    put "var dictionary_data =" & CR & "{" & CR & tab & quote & "docs" & quote & ":[" after tData
    
-   put revIDEGetDocsAPIData() after tData
+   put revIDEGetLCSDocsAPIData() into tAPIData
    
-   if pAPI is not empty then
-      put comma & pAPI after tData
+   dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
+      with "LiveCode Script", "livecode_script", "", tAPIData
+   put the result after tData
+   
+   put revIDEGetLCBDocsAPIData() into tAPIData
+   
+   dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
+      with "LiveCode Builder", "livecode_builder", "", tAPIData
+   put comma & the result after tData
+   
+   if not revEnvironmentIsInstalled() then
+      put revIDEGetIDEDocsAPIData() into tAPIData
+
+      dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
+         with "LiveCode IDE", "livecode_ide", "", tAPIData    
+      put comma & the result after tData
    end if
    
    put CR & tab & "]" & CR & "}" after tData
@@ -10841,15 +10868,7 @@ on revIDEAddAPIAndRegenerate pAPI
    local tDocsCache
    put revIDESpecialFolderPath("documentation cache") into tDocsCache
    revIDESetUTF8FileContents tDocsCache & slash & "built_api.js", tData
-end revIDEAddAPIAndRegenerate
-
-on revIDERegenerateBuiltAPIs
-   revIDEAddAPIAndRegenerate
 end revIDERegenerateBuiltAPIs
-
-on revIDERegenerateBuiltGuides
-   revIDEAddGuideAndRegenerate
-end revIDERegenerateBuiltGuides
 
 on revIDERegenerateBuiltDictionaryData
    revIDERegenerateBuiltAPIs
@@ -10922,7 +10941,7 @@ private command revIDEGenerateDistributedAPI
    put the effective filename of stack "revDocsParser" into tInputs[0]
    put tDocsFolder & slash & "dictionary" into tInputs[1]
    put tDocsFolder & slash & "glossary" into tInputs[2]
-   put revIDESpecialFolderPath("api") & slash & "script.js" into tOutput
+   put revIDESpecialFolderPath("api-lcs") & slash & "script.js" into tOutput
    
    put revIDEIsFilesetStale(tInputs, tOutput, true, tError) into tNeedUpdate
    
@@ -10940,8 +10959,8 @@ private command revIDEGenerateDistributedAPI
       ideDocsUpdateDatabase tScriptA
       
       local tJSON
-      put revDocsFormatLibraryArrayAsJSON(tScriptA) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api") & slash & "script.js", \
+      put revDocsFormatLibraryDocArrayAsJSON(tScriptA["name"], tScriptA["doc"]) into tJSON
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcs") & slash & "script.js", \
             tJSON
    end if
    
@@ -10951,7 +10970,7 @@ private command revIDEGenerateDistributedAPI
    
    set the itemdelimiter to slash
    put empty into tInputs
-   put revIDESpecialFolderPath("api") & slash & "builder.js" into tOutput
+   put revIDESpecialFolderPath("api-lcb") & slash & "builder.js" into tOutput
    put the effective filename of stack "revDocsParser" into tInputs[0]
    local tCount
    put 1 into tCount
@@ -10997,14 +11016,14 @@ private command revIDEGenerateDistributedAPI
       # Update the database
       ideDocsUpdateDatabase tBuilderA
       
-      put revDocsFormatLibraryArrayAsJSON(tBuilderA) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api") & slash & "builder.js", \
+      put revDocsFormatLibraryDocArrayAsJSON(tBuilderA["name"], tBuilderA["doc"]) into tJSON
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcb") & slash & "builder.js", \
             tJSON
    end if
    
    # Check to see if we need to regenerate the datagrid docs
    put empty into tInputs
-   put revIDESpecialFolderPath("api") & slash & "dg.js" into tOutput
+   put revIDESpecialFolderPath("api-lcs") & slash & "dg.js" into tOutput
    put the effective filename of stack "revDocsParser" into tInputs[0]
    local tDatagridDoc, tFolder
    put revIDESpecialFolderPath("Documentation") &"/dictionary" into tFolder
@@ -11013,24 +11032,92 @@ private command revIDEGenerateDistributedAPI
    # Regenerate if necessary
    if tNeedUpdate then
       local tLibA
-      put revDocsParseDocFileToLibraryArray(tFolder & slash & tDatagridDoc, "Data Grid", "LiveCode") into tLibA
+      put revDocsParseDocFileToLibraryArray(tFolder & slash & "datagrid.lcdoc", "Data Grid", "LiveCode") into tLibA
+
       # Update the database
       ideDocsUpdateDatabase tLibA
-      put revDocsFormatLibraryArrayAsJSON(tLibA) into tJSON
-      revIDESetUTF8FileContents revIDESpecialFolderPath("api") & slash & "dg.js", \
+      put revDocsFormatLibraryDocArrayAsJSON(tLibA["name"], tLibA["doc"]) into tJSON
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcs") & slash & "dg.js", \
             tJSON
    end if
    
-   local tDictionaryData
-   put revIDEUTF8FileContents(revIDESpecialFolderPath("api") \ 
-         & slash & "script.js") into tDictionaryData
-   put comma & revIDEUTF8FileContents(revIDESpecialFolderPath("api") \ 
-         & slash & "builder.js") after tDictionaryData
-   put comma & revIDEUTF8FileContents(revIDESpecialFolderPath("api") \ 
-         & slash & "dg.js") after tDictionaryData
+   local tIDELibsFolder, tIdeSupportFolder
+   put tRepoPath & "/ide-support" into tIdeSupportFolder
+   put tRepoPath & "/ide/Toolset/libraries" into tIDELibsFolder
    
-   revIDESetUTF8FileContents revIDESpecialFolderPath("api") \ 
-         & slash & "distributed_api.js", tDictionaryData
+   # Check to see if we need to regenerate the ide dictionary
+   put empty into tInputs
+   put the effective filename of stack "revDocsParser" into tInputs[0]
+   put tIdeSupportFolder into tInputs[1]
+   put tIDELibsFolder into tInputs[2]
+   put revIDESpecialFolderPath("api-ide") & slash & "ide.js" into tOutput
+   
+   put revIDEIsFilesetStale(tInputs, tOutput, true, tError) into tNeedUpdate
+   # Regenerate dictionary if necessary
+   if tNeedUpdate then
+      local tIDELibs, tIDEA, tIDECount, tIDEParsedA
+      put 1 into tIDECount
+      put revInternal__ListLoadedLibraries() into tIDELibs
+      filter tIDELibs with "rev*"
+      repeat for each line tLine in tIDELibs
+         local tStackName
+         put revInternal__LoadedLibraryStackName(tLine) into tStackName
+         get revDocsGenerateDocsFileFromText(the script of stack tStackName, \
+               the long id of stack tStackName)
+         if it is not empty then
+            put it into tIDEA[tIDECount]
+            add 1 to tIDECount
+         end if
+      end repeat
+      
+      local tIDELibraryA
+      put 1 into tIDECount
+      repeat for each element tElement in tIDEA
+         put revDocsParseDocText(tElement) into tIDEParsedA
+         repeat for each key tEntry in tIDEParsedA["doc"]
+            put tIDEParsedA["doc"][tEntry] into tIDELibraryA["doc"][tIDECount]
+            add 1 to tIDECount
+         end repeat
+         put empty into tIDEParsedA
+      end repeat
+      put "LiveCode IDE" into tIDELibraryA["display name"]
+      put revDocsModifyForUrl(tIDELibraryA["display name"]) into tIDELibraryA["name"]
+      put "LiveCode" into tIDELibraryA["author"]
+      put "dictionary" into tIDELibraryA["type"]
+      
+      # Update the database
+      ideDocsUpdateDatabase tIDELibraryA
+      
+      put revDocsFormatLibraryDocArrayAsJSON(tIDELibraryA["name"], tIDELibraryA["doc"]) into tJSON
+      revIDESetUTF8FileContents revIDESpecialFolderPath("api-ide") & slash & "ide.js", \
+            tJSON
+   end if
+   
+   local tExtractedDocsFolder
+   put revEnvironmentBinariesPath() & slash & "extracted_docs" into tExtractedDocsFolder
+   
+   local tFiles
+   put files(tExtractedDocsFolder) into tFiles
+   filter tFiles with "*.lcdoc"
+   
+   set the itemDelimiter to "."
+   local tFile
+   repeat for each line tFile in tFiles
+      # Check to see if we need to regenerate the docs
+      put empty into tInputs
+      put revIDESpecialFolderPath("api-lcs") & slash & toLower(item 1 to -2 of tFile) & ".js" into tOutput
+      put the effective filename of stack "revDocsParser" into tInputs[0]
+      put tExtractedDocsFolder & slash & tFile into tInputs[1]
+      put revIDEIsFilesetStale(tInputs, tOutput, false, tError) into tNeedUpdate
+      # Regenerate if necessary
+      if tNeedUpdate then
+         put revDocsParseDocFileToLibraryArray(tExtractedDocsFolder & slash & tFile, item -2 of tFile, "LiveCode") into tLibA
+         # Update the database
+         ideDocsUpdateDatabase tLibA
+         put revDocsFormatLibraryDocArrayAsJSON(tLibA["name"], tLibA["doc"]) into tJSON
+         revIDESetUTF8FileContents tOutput, tJSON
+      end if
+   end repeat
 end revIDEGenerateDistributedAPI
 
 on revIDEEnsureDictionaryUrl pWhich

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10743,7 +10743,7 @@ private function revIDEGetExtensionDocsData pAPI
          put the result into tExtensionAPI
          
          # Update the dictionary database
-         ideDocsUpdateDatabase tLibraryArray
+         ideDocsUpdateDatabase pAPI, tLibraryArray, false
          
          revIDESetUTF8FileContents tAPIJS, tExtensionAPI
       end if

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10660,7 +10660,7 @@ private function __getLCBSourceFile pFolder
    return tSource
 end __getLCBSourceFile
 
-private function revIDEGetDocsAPIData pWhich
+private function revIDEGetBaseDocsData pWhich
    local tData
    
    local tAPIPath, tLibs
@@ -10673,7 +10673,7 @@ private function revIDEGetDocsAPIData pWhich
    end repeat
    delete the last char of tData
    return tData
-end revIDEGetDocsAPIData 
+end revIDEGetBaseDocsData 
 
 private function revIDEGetExtensionDocsData pAPI
    local tExtensionDocsDataA
@@ -10759,26 +10759,15 @@ private function revIDEGetExtensionDocsData pAPI
    return tData
 end revIDEGetExtensionDocsData
 
-private function revIDEGetLCSDocsAPIData 
-   local tData
-   put revIDEGetDocsAPIData("lcs") into tData
-   put comma & revIDEGetExtensionDocsData("lcs") after tData
+private function revIDEGetDocsAPIData pWhich
+   local tData, tExtensions
+   put revIDEGetBaseDocsData(pWhich) into tData
+   put revIDEGetExtensionDocsData(pWhich) into tExtensions
+   if tExtensions is not empty then 
+      put comma & tExtensions after tData
+   end if
    return tData
-end revIDEGetLCSDocsAPIData
-
-private function revIDEGetLCBDocsAPIData 
-   local tData
-   put revIDEGetDocsAPIData("lcb") into tData
-   put comma & revIDEGetExtensionDocsData("lcb") after tData
-   return tData
-end revIDEGetLCBDocsAPIData 
-
-private function revIDEGetIDEDocsAPIData 
-   local tData
-   put revIDEGetDocsAPIData("ide") into tData
-   put comma & revIDEGetExtensionDocsData("ide") after tData
-   return tData
-end revIDEGetIDEDocsAPIData 
+end revIDEGetDocsAPIData 
 
 private function revIDEGetDocsGuideData
    local tData
@@ -10858,23 +10847,23 @@ on revIDERegenerateBuiltAPIs
    local tData, tAPIData
    put "var dictionary_data =" & CR & "{" & CR & tab & quote & "docs" & quote & ":[" after tData
    
-   put revIDEGetLCSDocsAPIData() into tAPIData
+   put revIDEGetDocsAPIData("lcs") into tAPIData
    
    dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
-      with "LiveCode Script", "livecode_script", "", tAPIData
+         with "LiveCode Script", "livecode_script", "", tAPIData
    put the result after tData
    
-   put revIDEGetLCBDocsAPIData() into tAPIData
+   put revIDEGetDocsAPIData("lcb") into tAPIData
    
    dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
-      with "LiveCode Builder", "livecode_builder", "", tAPIData
+         with "LiveCode Builder", "livecode_builder", "", tAPIData
    put comma & the result after tData
    
    if not revEnvironmentIsInstalled() then
-      put revIDEGetIDEDocsAPIData() into tAPIData
-
+      put revIDEGetDocsAPIData("ide") into tAPIData
+      
       dispatch function "revDocsCreateAPIJSON" to stack "revDocsParser" \
-         with "LiveCode IDE", "livecode_ide", "", tAPIData    
+            with "LiveCode IDE", "livecode_ide", "", tAPIData    
       put comma & the result after tData
    end if
    
@@ -10974,7 +10963,7 @@ private command revIDEGenerateDistributedAPI
       ideDocsUpdateDatabase tScriptA
       
       local tJSON
-      put revDocsFormatLibraryDocArrayAsJSON(tScriptA["name"], tScriptA["doc"]) into tJSON
+      put revDocsFormatLibraryDocArrayAsJSON("livecode_script", tScriptA["doc"]) into tJSON
       revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcs") & slash & "script.js", \
             tJSON
    end if
@@ -11031,7 +11020,7 @@ private command revIDEGenerateDistributedAPI
       # Update the database
       ideDocsUpdateDatabase tBuilderA
       
-      put revDocsFormatLibraryDocArrayAsJSON(tBuilderA["name"], tBuilderA["doc"]) into tJSON
+      put revDocsFormatLibraryDocArrayAsJSON("livecode_builder", tBuilderA["doc"]) into tJSON
       revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcb") & slash & "builder.js", \
             tJSON
    end if
@@ -11051,7 +11040,7 @@ private command revIDEGenerateDistributedAPI
 
       # Update the database
       ideDocsUpdateDatabase tLibA
-      put revDocsFormatLibraryDocArrayAsJSON(tLibA["name"], tLibA["doc"]) into tJSON
+      put revDocsFormatLibraryDocArrayAsJSON("datagrid", tLibA["doc"]) into tJSON
       revIDESetUTF8FileContents revIDESpecialFolderPath("api-lcs") & slash & "dg.js", \
             tJSON
    end if
@@ -11103,7 +11092,7 @@ private command revIDEGenerateDistributedAPI
       # Update the database
       ideDocsUpdateDatabase tIDELibraryA
       
-      put revDocsFormatLibraryDocArrayAsJSON(tIDELibraryA["name"], tIDELibraryA["doc"]) into tJSON
+      put revDocsFormatLibraryDocArrayAsJSON("livecode_ide", tIDELibraryA["doc"]) into tJSON
       revIDESetUTF8FileContents revIDESpecialFolderPath("api-ide") & slash & "ide.js", \
             tJSON
    end if

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10675,15 +10675,14 @@ private function revIDEGetDocsAPIData pWhich
    return tData
 end revIDEGetDocsAPIData 
 
-private function revIDEGetLCSDocsAPIData 
-   local tData
-   put revIDEGetDocsAPIData("lcs") into tData
-   
+private function revIDEGetExtensionDocsData pAPI
    local tExtensionDocsDataA
-   put revIDEExtensionDocsData() into tExtensionDocsDataA
+   put revIDEExtensionDocsData(pAPI) into tExtensionDocsDataA
    
    local tFolder, tCachedDataFolder
    set the itemdelimiter to slash
+   
+   local tData
    repeat for each element tExtensionData in tExtensionDocsDataA
       local tExtensionAPI
       put tExtensionData["folder"] into tFolder
@@ -10694,7 +10693,7 @@ private function revIDEGetLCSDocsAPIData
       # Check if the lcdoc file is out of date
       put revEnvironmentUserDocsPath() & slash & the last item of tFolder into tCachedDataFolder
       revIDEEnsurePath tCachedDataFolder
-
+      
       local tInputs
       put tFolder & slash & tSource into tInputs[1]
       
@@ -10750,19 +10749,35 @@ private function revIDEGetLCSDocsAPIData
       end if
       
       if tExtensionAPI is not empty then
-         put comma & tExtensionAPI after tData
+         if tData is not empty then
+            put comma & tExtensionAPI after tData
+         else
+            put tExtensionAPI into tData
+         end if
       end if
    end repeat
-   
+   return tData
+end revIDEGetExtensionDocsData
+
+private function revIDEGetLCSDocsAPIData 
+   local tData
+   put revIDEGetDocsAPIData("lcs") into tData
+   put comma & revIDEGetExtensionDocsData("lcs") after tData
    return tData
 end revIDEGetLCSDocsAPIData
 
 private function revIDEGetLCBDocsAPIData 
-   return revIDEGetDocsAPIData("lcb")
+   local tData
+   put revIDEGetDocsAPIData("lcb") into tData
+   put comma & revIDEGetExtensionDocsData("lcb") after tData
+   return tData
 end revIDEGetLCBDocsAPIData 
 
 private function revIDEGetIDEDocsAPIData 
-   return revIDEGetDocsAPIData("ide")
+   local tData
+   put revIDEGetDocsAPIData("ide") into tData
+   put comma & revIDEGetExtensionDocsData("ide") after tData
+   return tData
 end revIDEGetIDEDocsAPIData 
 
 private function revIDEGetDocsGuideData

--- a/Toolset/palettes/script editor/behaviors/revsedocumentationpanebehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsedocumentationpanebehavior.livecodescript
@@ -316,7 +316,7 @@ private function renderDocDictionary pTag, pType
    local tResult, tData
    
    # Get the required info from the doc
-   put ideDocsFetchLCSData(pTag) into tData
+   put ideDocsFetchScriptData(pTag) into tData
 
    if pType is empty then
       put sTypesA[pTag] into pType

--- a/Toolset/palettes/script editor/behaviors/revsedocumentationpanebehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsedocumentationpanebehavior.livecodescript
@@ -1,7 +1,7 @@
 ﻿script "revSEDocumentationPaneBehavior"
 # String representing the last searched for doc, this is what the cDoc was last set to
 local sDoc = ""
-local sTypesA
+local sTypesA, sLibsA
 # String returned by the last Documentation search, this can be used to reload the last doc.
 local sLastFoundDoc = ""
 
@@ -135,6 +135,9 @@ private function renderDocDataShort pData, pIndex
    put tData["display name"] into tName
    put tData["syntax"] into tSyntax
    put tData["summary"] into tSummary
+   if tSummary is empty then
+      put tData["description"] into tSummary
+   end if
    put tData["type"] into tType
    
    local tResult
@@ -273,7 +276,7 @@ private function renderDocData pData, pIndex, pFull
    return tHtml
 end renderDocData
 
-private command renderDoc pType
+private command renderDoc pType, pLib
    if sLastFoundDoc is empty or sDoc is empty then
       renderEmpty
       exit renderDoc
@@ -281,7 +284,7 @@ private command renderDoc pType
    
    # Documentation library: Retrieve the summary from the docs database
    local tHTML
-   put renderDocDictionary(sDoc, pType) into tHTML
+   put renderDocDictionary(sDoc, pType, pLib) into tHTML
    set the htmlText of field "View" of me to tHTML
    
    scrollbarCheck
@@ -312,27 +315,33 @@ private function removeAngleBrackets pText, pIsSyntax
 end removeAngleBrackets
 
 # Returns HTML of that doc in the form required for this component
-private function renderDocDictionary pTag, pType
+private function renderDocDictionary pTag, pType, pLib
    local tResult, tData
    
    # Get the required info from the doc
    put ideDocsFetchScriptData(pTag) into tData
-
+   
    if pType is empty then
       put sTypesA[pTag] into pType
    end if
-   
-   put pType into sTypesA[pTag]
-   
-   if pType is not empty then
-      repeat for each key tIndex in tData
-         if tData[tIndex]["type"] is pType then
-            return renderDocEntry(tData, tIndex)
-         end if
-      end repeat
+   if pLib is empty then
+      put sLibsA[pTag] into pLib
    end if
    
+   put pType into sTypesA[pTag]
+   put pLib into sLibsA[pTag]
+   
+   repeat for each key tIndex in tData
+      if pType is not empty and \
+            tData[tIndex]["type"] is pType and \
+            pLib is not empty and \
+            tData[tIndex]["library"] is pLib then
+         return renderDocEntry(tData, tIndex)
+      end if
+   end repeat
+   
    put tData[1]["type"] into sTypesA[pTag]
+   put tData[1]["library"] into sLibsA[pTag]
    return renderDocEntry(tData, 1)
 end renderDocDictionary 
 
@@ -345,13 +354,18 @@ private function renderDocEntry pData, pIndex
 end renderDocEntry
 
 function renderDocAlternatives pAlternatives, pCurIndex
-   local tFormattedAlternatives, tAlternative
-   repeat for each key tAlternativeIndex in pAlternatives
+   local tFormattedAlternatives, tAlternative, tAlternativeIndices
+   put the keys of pAlternatives into tAlternativeIndices
+   sort tAlternativeIndices by pAlternatives[each]["type"]
+   sort tAlternativeIndices by pAlternatives[each]["library"]
+   repeat for each line tAlternativeIndex in tAlternativeIndices
       if tAlternativeIndex is pCurIndex then
          next repeat
       end if
       
-      put "<a>" & pAlternatives[tAlternativeIndex]["type"] & "</a>" into tAlternative
+      put "<a>" & pAlternatives[tAlternativeIndex]["library"] && \
+            "-" && pAlternatives[tAlternativeIndex]["type"] & "</a>" \
+            into tAlternative
       
       if tFormattedAlternatives is empty then
          put tAlternative into tFormattedAlternatives
@@ -372,7 +386,8 @@ private command scrollbarCheck
 end scrollbarCheck
 
 on linkClicked pLink
-   renderDoc pLink
+   set the itemdelimiter to "-"
+   renderDoc word 1 to -1 of item 2 of pLink, word 1 to -1 of item 1 of pLink
 end linkClicked
 
 function prefGet pTag
@@ -390,7 +405,7 @@ on mouseUp
          break
          
       case "LaunchDocs"
-         revIDEGoToLCSDictionaryEntry sDoc, sTypesA[sDoc]
+         revIDEGoToLCSDictionaryEntry sDoc, sTypesA[sDoc], sLibsA[sDoc]
          break
    end switch
 end mouseUp

--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -863,7 +863,7 @@ command sePanesUpdate
    # OK-2008-09-11 : Refactored to prevent direct interaction with the Documentation pane. This needs further work
    # as it will soon be possible to have multiple panes open.
    if tToken is not empty then
-      if ideDocsFetchLCSData(tToken) is not empty then
+      if ideDocsFetchScriptData(tToken) is not empty then
          sePrefSet "documentation,lastLoadedDoc", tToken
          sePrefSet "documentation,lastMatchingSearch", tToken
          sePrefSet "documentation,lastLoadedAlternativeDocs", tToken

--- a/notes/feature-dictionary_apis.md
+++ b/notes/feature-dictionary_apis.md
@@ -1,0 +1,5 @@
+# Dictionary APIs
+The dictionary now includes extension APIs in the section of the
+dictionary to which they are applicable. Library and widget APIs
+appear in the LiveCode Script dictionary, and module APIs in the
+LiveCode Builder dictionary.


### PR DESCRIPTION
This patch modifies the construction of the built docs json file,
adding all entries that are livecode script syntax to the lcs
api, and similarly for livecode builder. IDE syntax is put in a
separate api since it cannot be included in a standalone.