### PR TITLE
[[ Dictionary ]] Tweak filter list layout

### DIFF
--- a/Documentation/html_viewer/css/lcdoc.css
+++ b/Documentation/html_viewer/css/lcdoc.css
@@ -264,10 +264,16 @@ div.business:before {
 	overflow-y: scroll;
 }
 
-#filters_options td {
-	padding-right: 10px;
+#filters_options td:nth-child(1) {
+	padding-right: 5px;
+}
+#filters_options td:nth-child(2) {
+	padding-left: 5px;
 }
 
+#filters_options td {
+	width: 50%;
+}
 #filters_options .category {
 	padding-top: 10px;
 }

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -249,10 +249,13 @@
 		return Object.keys(obj).sort();
 	}
 	
-	function filter_cell(pCategory, pValue)
+	function filter_cell(pCategory, pValue, pSpan)
 	{
 		var tHTML = '';
-		tHTML += '<td><a href="#" class="apply_filter" ';
+		tHTML += '<td';
+		if (pSpan)
+			tHTML += ' colspan="2"';
+		tHTML += '><a href="#" class="apply_filter" ';
 		tHTML += 'filter_category="'+pCategory+'" ';
 		tHTML += 'filter_value="'+pValue+'">';
 		tHTML += pValue;
@@ -276,17 +279,31 @@
 				tDisplayedFilters.push(value);
 		});
 		
-		// Display them in alphabetical order going down the table,
-		// rather than across
-		var tRowCount = Math.ceil(tDisplayedFilters.length / 2);
-		var tOddNumber = tDisplayedFilters.length % 2 == 1;
-		for (i = 1; i <= tRowCount; i++)
+		if (pCategory == 'associations')
 		{
-			tHTML += '<tr>'
-			tHTML += filter_cell(pCategory, tDisplayedFilters[i-1]);
-			if (i != tRowCount || !tOddNumber)
-				tHTML += filter_cell(pCategory, tDisplayedFilters[i - 1 + tRowCount]);
-			tHTML += '</tr>';
+			// Display associations one per line
+			for (i = 1; i <= tDisplayedFilters.length; i++)
+			{
+				tHTML += '<tr>'
+				tHTML += filter_cell(pCategory, tDisplayedFilters[i-1], true);
+				tHTML += '<td></td>';
+				tHTML += '</tr>';
+			}
+		}
+		else
+		{
+			// Display them in alphabetical order going down the table,
+			// rather than across
+			var tRowCount = Math.ceil(tDisplayedFilters.length / 2);
+			var tOddNumber = tDisplayedFilters.length % 2 == 1;
+			for (i = 1; i <= tRowCount; i++)
+			{
+				tHTML += '<tr>'
+				tHTML += filter_cell(pCategory, tDisplayedFilters[i-1], false);
+				if (i != tRowCount || !tOddNumber)
+					tHTML += filter_cell(pCategory, tDisplayedFilters[i - 1 + tRowCount], false);
+				tHTML += '</tr>';
+			}
 		}
 		tHTML += '</tbody>';
 		

--- a/notes/bugfix-20560.md
+++ b/notes/bugfix-20560.md
@@ -1,0 +1,1 @@
+# Improve layout of dictionary filter list


### PR DESCRIPTION
This patch forces the two columns in the filter list to be 50% of
the container width. It also changes the associations list to be
one per line instead of two, since they can be quite long and
it looks bad with huge gaps on one side.