### PR TITLE
[[ DatagridDocs ]] Fix some badly parsed docs

### DIFF
--- a/Documentation/dictionary/datagrid.lcdoc
+++ b/Documentation/dictionary/datagrid.lcdoc
@@ -10,10 +10,8 @@ Description:
 The Data Grid enables you to integrate powerful tables and forms into
 your LiveCode projects. Data grids combine LiveCode groups and behaviors
 to provide you with a simple, yet flexible means of displaying your data
-in just about any way you want. See
-http://lessons.livecode.com/m/datagrid/l/7301-what-is-the-data-grid for
-full documentation, lessons, and tutorials.
-
+in just about any way you want. See [the datagrid lessson](http://lessons.livecode.com/m/datagrid/l/7301-what-is-the-data-grid)
+for full documentation, lessons, and tutorials.
 
 Name: Datagrid General Properties
 

--- a/Documentation/dictionary/datagrid.lcdoc
+++ b/Documentation/dictionary/datagrid.lcdoc
@@ -1686,23 +1686,40 @@ false then each item of each line in pText will be named "Label X"
 When retrieving the dgText property, setting the pIncludeColumnNames to true
 will cause the column names to be included in the first line.
 
-Name: dgHilitedIndexes synonyms: dgHilitedIndex type: property
+
+Name: dgHilitedIndexes 
+
+synonyms: dgHilitedIndex 
+
+type: property
+
 Associations: datagrid
 
-syntax: set the dgHilitedIndexes of group "DataGrid" to pIndex summary:
-Returns a comma delimited list of the indexes that are currently
-selected. Description:
+syntax: set the dgHilitedIndexes of group "DataGrid" to pIndex 
+
+summary: Returns a comma delimited list of the indexes that are currently
+selected. 
+
+Description:
 
 Returns a comma delimited list of the indexes that are currently
 selected.
 
 
-Name: dgHilitedLines synonyms: dgHilitedLine type: property
+Name: dgHilitedLines 
+
+synonyms: dgHilitedLine 
+
+type: property
+
 Associations: datagrid
 
-syntax: set the dgHilitedLines of group "DataGrid" to pLine summary:
-Returns a comma delimited list of the line numbers that are currently
-selected. Description:
+syntax: set the dgHilitedLines of group "DataGrid" to pLine 
+
+summary: Returns a comma delimited list of the line numbers that are currently
+selected. 
+
+Description:
 
 Returns a comma delimited list of the line numbers that are currently
 selected.


### PR DESCRIPTION
- Backport faf8881 from develop
- Fix http: being parsed as new element by making it linked text.