### PR TITLE
[[ ExtensionDocs ]] Don't manually update docs on extension install

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -318,55 +318,13 @@ on __extensionInstallExtract pCacheIndex
    revZipCloseArchive tExtensionPackageFile
    
    # Next step
-   send "__extensionInstallGuide" && pCacheIndex to me in 0 milliseconds
+   send "__extensionInstallMakeLive" && pCacheIndex to me in 500 milliseconds
 end __extensionInstallExtract
-
-# Install the guide into the IDE
-on __extensionInstallGuide pCacheIndex
-   # Update progress
-   __extensionSendProgressUpdate pCacheIndex, "Adding user guide to documentation", 30
-   
-   # Path to user guide
-   local tUserGuideFolder
-   put revIDESpecialFolderPath("temp extensions") & slash & __extensionPropertyGet(pCacheIndex, "type_id") & slash & "docs/guide" into tUserGuideFolder
-   
-   # Get the name and author required by user guide install function
-   local tExtensionName, tExtensionAuthor
-   put __extensionPropertyGet(pCacheIndex, "name") into tExtensionName
-   put __extensionPropertyGet(pCacheIndex, "author") into tExtensionAuthor
-   
-   # Install user guide into the IDE
-   revIDEInstallUserGuide tUserGuideFolder, tExtensionName, tExtensionAuthor
-   
-   send "__extensionInstallAPI" && pCacheIndex to me in 500 milliseconds
-end __extensionInstallGuide
-
-# Install the extension API into the IDE
-on __extensionInstallAPI pCacheIndex
-   # Update progress
-   __extensionSendProgressUpdate pCacheIndex, "Adding API to documentation", 45
-   
-   # Path to user guide
-   local tUserAPIFolder
-   put revIDESpecialFolderPath("temp extensions") & slash & __extensionPropertyGet(pCacheIndex, "type_id") & slash & "docs/api" into tUserAPIFolder
-   
-   # Get the name and author required by API install function
-   local tExtensionName, tExtensionAuthor
-   put __extensionPropertyGet(pCacheIndex, "name") into tExtensionName
-   put __extensionPropertyGet(pCacheIndex, "author") into tExtensionAuthor
-   
-   # Install API into the IDE
-   // revIDEInstallAPI tUserAPIFolder, tExtensionName, tExtensionAuthor
-   revIDEInstallAPI tUserAPIFolder, tExtensionName, tExtensionAuthor
-   
-   # Next step
-   send "__extensionInstallMakeLive" && pCacheIndex to me in 0 milliseconds
-end __extensionInstallAPI
 
 # Moves to temp extracted files into their final live location
 on __extensionInstallMakeLive pCacheIndex
    # Update progress
-   __extensionSendProgressUpdate pCacheIndex, "Copying extension into install location", 60
+   __extensionSendProgressUpdate pCacheIndex, "Copying extension into install location", 50
    
    # Get path the directories
    local tTempInstallPath, tFinalPath
@@ -509,18 +467,8 @@ on __extensionUninstallUnload pCacheIndex
    revIDEExtensionUnload tName
    
    # Next step
-   send "__extensionUninstallDocs" && pCacheIndex to me in 0 milliseconds
-end __extensionUninstallUnload
-
-# Remove the guide from the IDE
-on __extensionUninstallDocs pCacheIndex
-   # Update progress
-   __extensionSendProgressUpdate pCacheIndex, "Removing API and user guide from documentation", 80
-   
-   revIDERegenerateBuiltDictionaryData
-   
    send "__extensionUninstallComplete" && pCacheIndex to me in 0 milliseconds
-end __extensionUninstallDocs
+end __extensionUninstallUnload
 
 on __extensionUninstallComplete pCacheIndex
    # Notify IDE uninstallation complete

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -31,6 +31,7 @@ on revUnloadLibrary
    if the target is me then
       remove the script of me from back
    end if
+   revIDEFinaliseIDELibrary
 end revUnloadLibrary
 
 #############
@@ -1491,6 +1492,10 @@ function __unescapeString pString
    return pString
 end __unescapeString
 
+on revIDEFinaliseIDELibrary
+   revIDEUnsubscribeAll
+end revIDEFinaliseIDELibrary
+
 on revIDEInitialiseIDELibrary
    # Load fonts
    local tFonts
@@ -1513,7 +1518,13 @@ on revIDEInitialiseIDELibrary
    
    ## Initialise property library
    revIDEPropertyLibraryInitialise
+   
+   ideSubscribe "ideExtensionsChanged"
 end revIDEInitialiseIDELibrary
+
+on ideExtensionsChanged
+   revIDERegenerateBuiltDictionaryData
+end ideExtensionsChanged
 
 #############
 # Subscription


### PR DESCRIPTION
This patch adds a subscription to ideExtensionsChanged to the ide
library, which when received causes the built dictionary data to
be regenerated.