### PR TITLE
Ensure Rulers library is unloaded correctly

### DIFF
--- a/Toolset/libraries/revinitialisationlibrary.livecodescript
+++ b/Toolset/libraries/revinitialisationlibrary.livecodescript
@@ -24,6 +24,11 @@ command revInternal__LoadLibrary pLibrary
          put kLCLibraryPrefix & "." before pLibrary
          send "revLoadLibrary" to stack pLibrary
       end if
+      
+      local tStackName
+      put the name of stack pLibrary into tStackName
+      put tStackName into sLoadedLibraries[pLibrary]
+      
    catch tError
       write ("Error" && tError && "while loading stack:" && pLibrary) & return to stderr
       return "Error loading" && pLibrary


### PR DESCRIPTION
`revInternal__LoadLibrary` did not update sLoadedLibraries, but `revInternal__UnloadLibrary` checks for `sLoadedLibraries` before sending a `revUnloadLibrary`

So `revInternal__UnloadLibrary pLib` did not actually unload `pLib`, if `pLib` was loaded using `revInternal__LoadLibrary`