### PR TITLE
[[ Bug 20583 ]] Fix dictionary search

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -111,7 +111,7 @@
 		// Escape RegExp special characters:  \ ^ $ [
 		// A leading space will enable full RegExp support
 		var tTerm = '';
-		if(pTerm.startsWith(' '))
+		if(pTerm.charAt(0) == ' ')
 			tTerm = pTerm.trim();
 		else
 			tTerm = RegExp.escape(pTerm);


### PR DESCRIPTION
`startsWith` was only introduced in ECMAScript 6, and thus does
not have full browser support. Replace it with `charAt(0) ==`