### PR TITLE
Do not palete revRulers if not necessary

### DIFF
--- a/Toolset/libraries/revrulersscriptlibrary.livecodescript
+++ b/Toolset/libraries/revrulersscriptlibrary.livecodescript
@@ -92,12 +92,9 @@ on resumeStack
     pass resumeStack
   else
     put false into lPaused
-    if not the visible of stack "revRulersH" then
+    if not the visible of stack "revRulersH" and "revRulersH" is among the lines of the openstacks then
       show stack "revRulersH"
       show stack "revRulersV"
-    else
-      palette "revRulersV"
-      palette "revRulersH"
     end if
     revPartCalculateRulers
     unlock messages


### PR DESCRIPTION
This fixes the problem of the rulers reappearing incorrectly in the following use-case (note this affects LC 7.x as well):

1. Open LC and ensure you are on Edit mode
2. Create new stack
3. Check View-> Rulers  (Rulers are showing)

4. Switch to Run mode (Rulers are hiding, as expected)

5. Switch to Edit mode and click on the stack to give focus (Rulers are showing, as expected)

6. Uncheck View -> Rulers (Rulers are hiding, as expected)

7. Now click on the Tools stack (to remove the focus from the main stack), and click back to the main stack (to give it back the focus).

OBSERVED RESULT: The rulers are showing again, even though you had turned them off in step 6