### PR TITLE
[[Bug 19969]] PI/Geometry Manager 'Left object' alignment issue

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.geometry.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.geometry.behavior.livecodescript
@@ -334,7 +334,7 @@ on mouseDown pButton
             default 
                break
          end switch
-         setValue tValue
+         setValue tValue, tKey
       end if  
    end if
 end mouseDown
@@ -419,7 +419,7 @@ on menuPick pWhich
       put the cCurrentButton of me into tButtonTemp
       set the cObjectList of tButtonTemp to tMenuText
       
-      setValue tValue
+      setValue tValue, tKey
    else if the short name of the target is "Squiggle Type" then
       lock screen
       local tScale
@@ -440,7 +440,30 @@ on menuPick pWhich
    end if
 end menuPick
 
-on setValue pValue
+on setValue pValue, pKey
+   --if move is set, it takes precidence over scale
+   --need to be sure opposite set is not enabled
+   local tTurnOffGeometries
+   switch pKey
+      case "scaleLeft"
+      case "scaleRight"
+         put "moveH" into tTurnOffGeometries
+         break
+      case "scaleTop"
+      case "scaleBottom"
+         put "moveV" into tTurnOffGeometries
+         break
+      case "moveH"
+         put "scaleLeft,scaleRight" into tTurnOffGeometries
+         break
+      case "moveV"
+         put "scaleTop,scaleBottom" into tTurnOffGeometries
+         break
+   end switch
+   repeat for each item tItem in tTurnOffGeometries
+      put false into pValue[tItem]
+   end repeat
+
    local tValue
    put the editorValue["geometry"] of me into tValue
    union pValue with tValue recursively

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.geometry.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.geometry.behavior.livecodescript
@@ -402,8 +402,8 @@ on menuPick pWhich
          --proportional scaling
          put false into tValue[tKey & "Absolute"]
       end if
-      put tSide into tValue[tKey & "ObjectSide"] 
-      put pWhich into tValue[tKey & "ObjectRef"] 
+      put oppositeSide(tSide) into tValue[tKey & "ObjectSide"] 
+      put pWhich into tValue[tKey & "ObjectRef"]
       
       # Adjust menu text
       local tMenuText
@@ -488,3 +488,21 @@ on closeField
    
    setValue tValue
 end closeField
+
+function oppositeSide pSide
+   switch pSide
+      case "Top"
+         return "Bottom"
+         break
+      case "Bottom"
+         return "Top"
+         break
+      case "Right"
+         return "Left"
+         break
+      case "Left"
+      default
+         return "Right"
+         break
+   end switch
+end oppositeSide

--- a/notes/bugfix-19969.md
+++ b/notes/bugfix-19969.md
@@ -1,0 +1,1 @@
+# Geometry Manager 'Left object' alignment issue


### PR DESCRIPTION
The PI for GM currently sets the ObjectSide for alignment to the same name as the side which aligns to the opposite side of the target.  If the target object scales, then the intended relation is not preserved.  The solution is to align the object to the nearest/opposite side.

If Btn A is on the left side of Btn B, then when you align the left side of Btn B to Btn A, it currently is calculated against the left side of Btn A.  When looking at it visually, it makes more sense to calculate against the right side of Btn A since that is the edge nearest to Btn B.

Fix adds a function to return the opposite side and changes the property assignment to use the new function.  This function will also be useful when enabling the proportional scaling of objects against the left side of the card (which the library code supports).