### PR TITLE
Ensure a handler can be chosen from the SE's "continue" button more than once

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -2080,25 +2080,16 @@ command actionDebugRun
       revSEGetCurrentObject
       put the result into tObject
       
-      local tHandler
-      put revMetadataGet(tObject, "general", "debugEntryHandler") into tHandler
-      
-      local tHandlerList
-      revSEGetHandlerList
-      put the result into tHandlerList
-      
-      if tHandler is empty or (lineOffset((item 1 of tHandler & space & item 2 of tHandler), tHandlerList) = 0) then
-         actionEditDebugEntry
-         if the result is "cancelled" then
-            exit actionDebugRun
-         end if
+      actionEditDebugEntry
+      if the result is "cancelled" then
+         exit actionDebugRun
       end if
       
       # When clicking the run button, the user will expect the "browse" tool to be selected,
       # as otherwise the debugger won't trigger even if there are breakpoints
       choose browse tool
       
-      local tParameters
+      local tHandler, tParameters
       put revMetadataGet(tObject, "general", "debugEntryHandler") into tHandler
       put revMetadataGet(tObject, "general", "debugParameters") into tParameters
       

--- a/notes/bugfix-17297.md
+++ b/notes/bugfix-17297.md
@@ -1,0 +1,1 @@
+# Ensure a handler can be triggered from the Script Editor's "continue" button


### PR DESCRIPTION
The `actionEditDebugEntry` command shows a dialog that allows you to choose a handler (and specify params) when pressing the "continue" button of the script editor.

This worked as expected the very first time, but then the dialog was not shown, because `"debugEntryHandler"` was already set (and thus `actionEditDebugEntry` was not called). This was not correct, since one should be able to change the `"debugEntryHandler"` as often as they like.

This patch ensures that `actionEditDebugEntry` is called in any case.