### PR TITLE
[[Bug 17287]] Image filename property is not relativized with the PI

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
@@ -56,6 +56,13 @@ on mouseUp pButton
       put the result into tResult
       
       if there is a file tResult then
+         if the cImageFileRelative of stack "revPreferences" is not false then
+            local tStackPath, tFilePath
+            set the itemDelimiter to "/"
+            put item 1 to -2 of the filename of stack revTargetStack(line 1 of (the selObj)) into tStackPath
+            put revCalculateRelativePath(tStackPath, tResult) into tFilePath
+            if there is a file (tStackPath & slash & tFilePath) then put tFilePath into tResult
+         end if
          put tResult into field 1 of me
          valueChanged
       end if

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
@@ -56,12 +56,15 @@ on mouseUp pButton
       put the result into tResult
       
       if there is a file tResult then
-         if the cImageFileRelative of stack "revPreferences" is not false then
+         if revIDEGetPreference("cImageFileRelative") is not false then
             local tStackPath, tFilePath
             set the itemDelimiter to "/"
-            put item 1 to -2 of the filename of stack revTargetStack(line 1 of (the selObj)) into tStackPath
-            put revCalculateRelativePath(tStackPath, tResult) into tFilePath
-            if there is a file (tStackPath & slash & tFilePath) then put tFilePath into tResult
+            put item 1 to -2 of the filename of stack revTargetStack(line 1 of the cSelectedObjects of this stack) into tStackPath
+            if tStackPath is not empty then
+               put revCalculateRelativePath(tStackPath, tResult) into tFilePath
+               if tFilePath begins with "./" then delete char 1 to 2 of tFilePath
+               if there is a file (tStackPath & slash & tFilePath) then put tFilePath into tResult
+            end if
          end if
          put tResult into field 1 of me
          valueChanged

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
@@ -63,7 +63,12 @@ on mouseUp pButton
             if tStackPath is not empty then
                put revCalculateRelativePath(tStackPath, tResult) into tFilePath
                if tFilePath begins with "./" then delete char 1 to 2 of tFilePath
-               if there is a file (tStackPath & slash & tFilePath) then put tFilePath into tResult
+               if tFilePath ends with tResult then
+                  --full path contained in relative path, likely a different volume
+                  --in any case, need to return absolute path
+               else if there is a file (tStackPath & slash & tFilePath) then
+                  put tFilePath into tResult
+               end if
             end if
          end if
          put tResult into field 1 of me

--- a/notes/bugfix-17287.md
+++ b/notes/bugfix-17287.md
@@ -1,0 +1,1 @@
+# Image filename property is not relativized with the PI


### PR DESCRIPTION
There is an option in preferences to "always use absolute file paths for images" but the PI does not change how it operates based on that setting.  This change modifies the file behavior to convert paths to relative if that setting is not made to use absolute.  It will impact both images and other media (anything in the PI that uses the file behavior).