### PR TITLE
[[ Tests ]] Wrap indentation tests in handlers

### DIFF
--- a/tests/scripteditor/_indentation_tests/if.livecodescript
+++ b/tests/scripteditor/_indentation_tests/if.livecodescript
@@ -1,36 +1,57 @@
-if foo() then
-   -- code
-else if bar() then
-   -- code
-else
-   -- code
-end if
+on foo
+   if foo() then
+      -- code
+   else if bar() then
+      -- code
+   else
+      -- code
+   end if
+   -- comment
+end foo
 
-if foo()
-then -- code
-else if bar() then
-   -- code
-else
-   -- code
-end if
+on foo
+   if foo()
+   then -- code
+   else if bar() then
+      -- code
+   else
+      -- code
+   end if
+   -- comment
+end foo
 
-if foo()
-then code
-else if bar() then
-   -- code
-else code
+on foo
+   if foo()
+   then code
+   else if bar() then
+      -- code
+   else code
+   -- comment
+end foo
 
-if foo()
-then code
-else code
+on foo
+   if foo()
+   then code
+   else code
+   -- comment
+end foo
 
-if foo() then code else code
+on foo
+   if foo() then code else code
+   -- comment
+end foo
 
-if foo() then 
-   if bar() then code else code
-else 
-   code 
-end if
+on foo
+   if foo() then 
+      if bar() then code else code
+   else 
+      code 
+   end if
+   -- comment
+end foo
 
-if foo()
-then code else code
+on foo
+   if foo()
+   then code else code
+   -- comment
+end foo

--- a/tests/scripteditor/_indentation_tests/repeat.livecodescript
+++ b/tests/scripteditor/_indentation_tests/repeat.livecodescript
@@ -1,47 +1,83 @@
-repeat forever
-   -- code
-end repeat
+on foo
+   repeat forever
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat while foo()
-   -- code
-end repeat
+on foo
+   repeat while foo()
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat until foo()
-   -- code
-end repeat
+on foo
+   repeat until foo()
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat 3
-   -- code
-end repeat
+on foo
+   repeat 3
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat for 3
-   -- code
-end repeat
+on foo
+   repeat for 3
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat for 3 times
-   -- code
-end repeat
+on foo
+   repeat for 3 times
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat 3 times
-   -- code
-end repeat
+on foo
+   repeat 3 times
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat with X = 1 to 5
-   -- code
-end repeat
+on foo
+   repeat with X = 1 to 5
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat with X = 1 to 5 step 2
-   -- code
-end repeat
+on foo
+   repeat with X = 1 to 5 step 2
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat with X = 5 down to 1
-   -- code
-end repeat
+on foo
+   repeat with X = 5 down to 1
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat with X = 5 down to 1 step 2
-   -- code
-end repeat
+on foo
+   repeat with X = 5 down to 1 step 2
+      -- code
+   end repeat
+   -- comment
+end foo
 
-repeat for each line tLine in tFoo
-   -- code
-end repeat
+on foo
+   repeat for each line tLine in tFoo
+      -- code
+   end repeat
+   -- comment
+end foo

--- a/tests/scripteditor/_indentation_tests/switch.livecodescript
+++ b/tests/scripteditor/_indentation_tests/switch.livecodescript
@@ -1,17 +1,23 @@
-switch tFoo
-   case "foo"
-      -- code
-      break
-   default
-      -- code
-      break
-end switch
+on foo
+   switch tFoo
+      case "foo"
+         -- code
+         break
+      default
+         -- code
+         break
+   end switch
+   -- comment
+end foo
 
-switch
-   case tFoo begins with "foo"
-      -- code
-      break
-   default
-      -- code
-      break
-end switch
+on foo
+   switch
+      case tFoo begins with "foo"
+         -- code
+         break
+      default
+         -- code
+         break
+   end switch
+   -- comment
+end foo

--- a/tests/scripteditor/_indentation_tests/try.livecodescript
+++ b/tests/scripteditor/_indentation_tests/try.livecodescript
@@ -1,7 +1,10 @@
-try
-   -- code
-catch tError
-   -- code
-finally
-   -- code
-end try
+on foo
+   try
+      -- code
+   catch tError
+      -- code
+   finally
+      -- code
+   end try
+   -- comment
+end foo


### PR DESCRIPTION
This patch wraps the indentation tests in handlers with a comment after
the structure to test that the indentation after the structure is correct.

@BerndN noticed the tests wouldn't pick up one of the issues he recently fixed. This patch should make sure it would be picked up in the future. The issue was the test:

```
if foo()
then code else code
```
Did not pick up the previous behavior of:
```
on foo
   if foo()
   then code else code
-- comment
end foo
```