### PR TITLE
[[ Editions ]] Add script_profiler property

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -1896,6 +1896,8 @@ function revEnvironmentEditionProperty pProp, pEdition
             case "autocomplete"
             case "autocomplete_pro"
                return false
+            case "script_profiler"
+               return false
          end switch
          break
       case "communityplus"
@@ -1931,6 +1933,8 @@ function revEnvironmentEditionProperty pProp, pEdition
             case "autocomplete"
                return true
             case "autocomplete_pro"
+               return false
+            case "script_profiler"
                return false
          end switch
          break
@@ -1972,6 +1976,8 @@ function revEnvironmentEditionProperty pProp, pEdition
             case "autocomplete"
             case "autocomplete_pro"
                return true
+            case "script_profiler"
+               return false
          end switch
          break
       case "business"
@@ -2007,6 +2013,8 @@ function revEnvironmentEditionProperty pProp, pEdition
                return "https://livecode.com/products/business-edition/"
             case "autocomplete"
             case "autocomplete_pro"
+               return true
+            case "script_profiler"
                return true
          end switch
          break

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -1967,7 +1967,7 @@ private function revMenubarDevelopmentMenu pContext
    put revMenubarSimulatorSubmenu() after tDevelopment
    put "-" & return after tDevelopment   
    
-   if there is a stack "com.livecode.library.scriptprofiler" then
+   if revEnvironmentEditionProperty("script_profiler") then
       local tProfiler
       put the long id of stack "com.livecode.library.scriptprofiler" into tProfiler
       if tProfiler is among the lines of the backScripts then


### PR DESCRIPTION
This patch just means that when we BFS a commercial edition the IDE doesn't get confused if we aren't running business