### PR TITLE
[[Bug 20666]] Property Inspector / Geometry: Remove All button

### DIFF
--- a/Toolset/libraries/revgeometrylibrary.livecodescript
+++ b/Toolset/libraries/revgeometrylibrary.livecodescript
@@ -825,6 +825,7 @@ on revCalculateGeometryDistances pWhichNumber
   if lOrigWidth is empty then put the width of this stack into lOrigWidth
   if lOrigHeight is empty then put the height of this stack into lOrigHeight
   repeat for each item tEdge in "left,right,top,bottom"
+    if revGetGeometry("scale" & tEdge) is not true then next repeat
     if revGetGeometry("scale" & tEdge & "Absolute") is false then
       --we need to calculate the distance as it stands as a percentage of card width or height
       get revCalculateScaleDistance(tEdge)
@@ -844,6 +845,7 @@ on revCalculateGeometryDistances pWhichNumber
     end if
   end repeat
   repeat for each item tDimension in "h,v"
+    if revGetGeometry("move" & tDimension) is not true then next repeat
     if revGetGeometry("move" & tDimension & "Absolute") is false then
       --we need to calculate the distance as it stands as a percentage of card width or height
       get revCalculateMoveDistance(tDimension)
@@ -1101,3 +1103,40 @@ function revUniqueIDToName pWhich
     end if
   end repeat
 end revUniqueIDToName
+
+# Clears any extra keys from the current profile's geometry settings.  If no settings
+# are found, removes the key for the profile.
+command revClearExtraGeometrySettings
+   local tProfileName
+   put the cREVGeneral["profile"] of lGeometryObject into tProfileName
+   if tProfileName is empty or tProfileName is the cREVGeneral["masterName"] of lGeometryObject \
+         then put "Master" into tProfileName
+   
+   local tGeometry, tKeys, tSettingsUsed
+   put the customProperties["cRevGeometry"] of lGeometryObject into tGeometry
+   put the keys of tGeometry into tKeys
+   put 0 into tSettingsUsed
+   
+   local tExtraKeys
+   repeat for each item tSetting in "moveH,moveV,scaleLeft,scaleRight,scaleTop,scaleBottom"
+      --check to see if each geometry setting is used
+      if tGeometry[tProfileName & "," & tSetting] then
+         add 1 to tSettingsUsed
+         next repeat
+      end if
+      --since the setting is not used, clear associated keys
+      filter tKeys with (tProfileName & "," & tSetting & "*") into tExtraKeys
+      repeat for each line tKey in tExtraKeys
+         delete variable tGeometry[tKey]
+      end repeat
+   end repeat
+   if tSettingsUsed is 0 then
+      --no geometry settings are used, clear everything else
+      delete variable tGeometry[tProfileName]
+      filter tKeys with (tProfileName & ",*") into tExtraKeys
+      repeat for each line tKey in tExtraKeys
+         delete variable tGeometry[tKey]
+      end repeat
+   end if
+   set the customProperties["cRevGeometry"] of lGeometryObject to tGeometry
+end revClearExtraGeometrySettings

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11262,6 +11262,7 @@ on revIDESetGeometry pObject, pProperty, pGeometryArray
    repeat for each key tKey in pGeometryArray["geometry"]
       revSetGeometry tKey, pGeometryArray["geometry"][tKey]
    end repeat
+   revClearExtraGeometrySettings
 end revIDESetGeometry
 
 function revIDEGetGeometry pObject, pProperty

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.geometry.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.geometry.behavior.livecodescript
@@ -220,7 +220,7 @@ on mouseUp pButton
          answer warning "Really remove all Geometry from the selected object?" with "No" or "Yes"
          if it is "Yes" then
             put empty into tValue
-            setValue tValue
+            setValue tValue, "all"
          end if
          break
       default
@@ -458,6 +458,9 @@ on setValue pValue, pKey
          break
       case "moveV"
          put "scaleTop,scaleBottom" into tTurnOffGeometries
+         break
+      case "all"
+         put "moveH,moveV,scaleLeft,scaleRight,scaleTop,scaleBottom" into tTurnOffGeometries
          break
    end switch
    repeat for each item tItem in tTurnOffGeometries

--- a/notes/bugfix-20666.md
+++ b/notes/bugfix-20666.md
@@ -1,0 +1,1 @@
+# Property Inspector / Geometry: Remove All button does not work


### PR DESCRIPTION
The "Remove All" button on the Geometry tab of the Property Inspector currently has no effect.

The first change adds a parameter to the setValue call (where the button click is handled) to remove all geometries and expands that handler to match (depends on an earlier PR that is merged already).

The second change is to add a command to clear geometry keys that are not needed.  If no geometry sides are set, then the other associated settings are removed.  This new command is called from the revIDESetGeometry handler.

The third change is to add checks to prevent the revCalculateGeometryDistances from calculating distances for sides that are not needed.