### PR TITLE
[[ Bug 20706 ]] Fix Ctrl | Cmd + left in SE

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2374,7 +2374,7 @@ on rawKeyDown pKey
       end if
    else
       # For Mac: Ctrl-Left / Cmd-Left / Ctrl-A (Mac)
-      if (pKey is kKeyUpArrow and \
+      if (pKey is kKeyLeftArrow and \
             (the eventCommandKey is down or \
             the eventControlKey is down) and \
             the eventShiftKey is up and \

--- a/notes/bugfix-20706.md
+++ b/notes/bugfix-20706.md
@@ -1,0 +1,1 @@
+# Ensure Ctrl | Cmd + left arrow moves cursor to beginning of line 


### PR DESCRIPTION
This patch fixes a copy/paste error for the Ctrl | Cmd + left
keyboard shortcut handling in the script editor.