### PR TITLE
[[Bug 20684]] Inconsistent arrow key behavior in the dictionary

### DIFF
--- a/Documentation/html_viewer/api.html.template
+++ b/Documentation/html_viewer/api.html.template
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    
-    <title>LiveCode Dictionary</title>
-    
-    <link href="[[tDocsCSSFolder]]/bootstrap.min.css" rel="stylesheet">
-    <link href="[[tDocsCSSFolder]]/lcdoc.css" rel="stylesheet">
-    <link href="[[tDocsCSSFolder]]/codestyle.css" rel="stylesheet">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<title>LiveCode Dictionary</title>
+
+	<link href="[[tDocsCSSFolder]]/bootstrap.min.css" rel="stylesheet">
+	<link href="[[tDocsCSSFolder]]/lcdoc.css" rel="stylesheet">
+	<link href="[[tDocsCSSFolder]]/codestyle.css" rel="stylesheet">
 </head>
 <body>
 
@@ -73,63 +73,62 @@
 	<div class="row">
 		<div class="col-md-3">
 			<div class="bs-sidebar" id="lcdoc_sidebar">
-            	<div class="panel panel-default" id="filters_panel">
+				<div class="panel panel-default" id="filters_panel">
 					<div class="panel-heading">Filters</div>
 					<div class="panel-body" id="filters_container">
 						<div id="filters">none</div>
 						<div id="filters_options"></div>
-		  			</div>
+					</div>
 				</div>
 			</div>
-    	</div>
+		</div>
  
-        <div class="col-md-9">
-        	<div id="header_panel_holder">
+		<div class="col-md-9">
+			<div id="header_panel_holder">
 				<div class="panel panel-default" id="lcdoc_list">
 					<div id="table_header">
 						<table class="table table-hover table-condensed" id="table_list_header">
 						</table>
 					</div>
-			  		<div id="table_container">
+					<div id="table_container">
 						<table class="table table-hover table-condensed" id="table_list">
 						</table>
 					</div>
 					<!-- header panel resizer -->
 					<div id="resizer">
-					</div>   
-				</div>            
-            </div>
+					</div>
+				</div>
+			</div>
 
-            <div class="panel panel-default" id="lcdoc_body">
-              <div class="panel-body" id="api_entry">
-              </div>
-              
-            </div>
-        </div>
-   </div>
+			<div class="panel panel-default" id="lcdoc_body">
+				<div class="panel-body" id="api_entry">
+				</div>
+
+			</div>
+		</div>
+	</div>
 </div>
-   
-    <script src="[[tDocsJSFolder]]/jquery-1.11.1.min.js"></script>
-    <script src="[[tDocsJSFolder]]/jquery.session.js"></script>
-    <script src="[[tDocsJSFolder]]/bootstrap.min.js"></script>
-    <script src="[[tDocsJSFolder]]/marked.js"></script>
-    <script src="[[tDocsJSFolder]]/highlight.pack.js"></script>	
-    <script src="[[tDocsJSFolder]]/jquery.mousewheel.min.js"></script>	
-    
-    <script charset="UTF-8" src="[[tDataPath]]"></script>  
-    <script src="[[tDocsJSFolder]]/dictionary_functions.js"></script>	
-    <script>
-	
-    $(document).ready(function(e)
-	{
-      setEdition('[[ the editionType]]');
-		setActions();		
-		dataFilter();		
-		displayLibraryChooser();
-		
-		goEntryName('[[tLibraryName]]', '[[tEntryName]]', '[[tEntryType]]');
-    document.getElementById("ui_filer").focus();
-	});
+
+	<script src="[[tDocsJSFolder]]/jquery-1.11.1.min.js"></script>
+	<script src="[[tDocsJSFolder]]/jquery.session.js"></script>
+	<script src="[[tDocsJSFolder]]/bootstrap.min.js"></script>
+	<script src="[[tDocsJSFolder]]/marked.js"></script>
+	<script src="[[tDocsJSFolder]]/highlight.pack.js"></script>	
+	<script src="[[tDocsJSFolder]]/jquery.mousewheel.min.js"></script>	
+
+	<script charset="UTF-8" src="[[tDataPath]]"></script>  
+	<script src="[[tDocsJSFolder]]/dictionary_functions.js"></script>	
+	<script>
+		$(document).ready(function(e)
+		{
+			setEdition('[[ the editionType]]');
+			setActions();
+			dataFilter();
+			displayLibraryChooser();
+			
+			goEntryName('[[tLibraryName]]', '[[tEntryName]]', '[[tEntryType]]');
+			document.getElementById("ui_filer").focus();
+		});
 	</script>
 </body>
 </html>

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -159,9 +159,9 @@
 			return tMatched;
 		});
 
-        // Sort the priority matches to the top
-	tState . cached_search_data . data . sort(function(a, b) 
-        {
+		// Sort the priority matches to the top
+		tState . cached_search_data . data . sort(function(a, b) 
+		{
 			var tNameA, tNameB, tMatchA, tMatchB
 
 			tNameA = a["display name"].toLowerCase();
@@ -1143,7 +1143,7 @@
 			{
 				if (value.type.toLowerCase() != pType)
 				{
-					// Continue loop				
+					// Continue loop
 					return true;
 				}
 			}
@@ -1151,7 +1151,7 @@
 			// Make sure we always 'fall back' to the lcs syntax
 			if (value.library == 'livecode_script')
 			{
-				tIndex = index;		
+				tIndex = index;
 				// If no library was specified, assume lcs syntax
 				if (pPriorityLibrary == '')
 				{
@@ -1160,7 +1160,7 @@
 				}
 				
 				// Otherwise, this index is now a candidate in case
-				// there is no entry found in the given library				
+				// there is no entry found in the given library
 			}
 			
 			if (pPriorityLibrary == '')
@@ -1172,7 +1172,7 @@
 			}
 			else if (value.library.toLowerCase() != pPriorityLibrary)
 			{
-				// Continue loop				
+				// Continue loop
 				return true;
 			}
 			
@@ -1358,8 +1358,25 @@
 		displayEntry(history_selected_entry().id);
 	}
 	
-	function entry_next(){
-		var tSelectedID = tState.selected;
+	function entry_previous()
+	{
+		var tSelectedID = tState.history.list[tState.history.selected_index].id;
+		var tPreviousID = tSelectedID;
+		
+		$.each(tState.filtered_data, function( index, value) {
+			if(value.id == tSelectedID){
+				if(index > 0){
+					tPreviousID = tState.filtered_data[index-1].id;
+				}
+			}
+			
+		});
+		displayEntry(tPreviousID);
+	}
+	
+	function entry_next()
+	{
+		var tSelectedID = tState.history.list[tState.history.selected_index].id;
 		var tNextID = tSelectedID;
 		
 		$.each(tState.filtered_data, function( index, value) {
@@ -1419,21 +1436,6 @@
 			
 		});
 		return tID;
-	}
-	
-	function entry_previous(){
-		var tSelectedID = tState.selected;
-		var tPreviousID = tSelectedID;
-		
-		$.each(tState.filtered_data, function( index, value) {
-			if(value.id == tSelectedID){
-				if(index > 0){
-					tPreviousID = tState.filtered_data[index-1].id;
-				}
-			}
-			
-		});
-		displayEntry(tPreviousID);
 	}
 	
 	function selectedEntryEnsureInView(tEntryID)

--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -1340,12 +1340,16 @@
 	
 	function history_back()
 	{
-		go_history(tState.history.selected_index - 1);
+		if(tState.history.selected_index > 0){
+			go_history(tState.history.selected_index - 1);
+		}
 	}
 	
 	function history_forward()
 	{
-		go_history(tState.history.selected_index + 1);
+		if(tState.history.selected_index < tState.history.list.length - 1){
+			go_history(tState.history.selected_index + 1);
+		}
 	}
 	
 	function go_history(pHistoryID)


### PR DESCRIPTION
Up/down keys were not able to navigate between dictionary entries (always went to $ when they worked).  This was due to the way the `entry_previous` and `entry_next` functions were attempting to get the currently displayed entry ID.  This fix uses the history list to get the current entry ID.

These 2 functions were separated by a bit of code before, but are now consolidated to be together for easier maintenance in the future.

Previously, the up/down keys always navigated the filtered list.  Adjusted the code to check for a search term and use that list if available.

The history functions needed bounds checking to prevent the `tState.history.selected_index` from getting set to invalid values.