### PR TITLE
[Bug 20725] Show red breakpoint dot immediately when using popUp in SE

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -1119,7 +1119,7 @@ on menuPick pItemName
             
             revDebuggerAddBreakpoint getObjectID(), tLineNumber
             revDebuggerActivateBreakpoint getObjectID(), tLineNumber
-            updateGutterRequest empty, empty, empty, empty, false, false
+            updateGutterRequest empty, empty, empty, empty, false, false, true
          end if
          break
          

--- a/notes/bugfix-20725.md
+++ b/notes/bugfix-20725.md
@@ -1,0 +1,1 @@
+# Show red breakpoint dot immediately when set via popUp in SE


### PR DESCRIPTION
show red breakpoint dot immediately when setting breakpoint via popUp in ScriptEditor
http://quality.livecode.com/show_bug.cgi?id=20725