### PR TITLE
[[Bug 17287]] Relativize image filename property in the PI

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6386,6 +6386,25 @@ function revIDEGetRectProperty pObject, pProperty
    end switch
 end revIDEGetRectProperty
 
+command revIDESetImageFilename pObjectID, pProperty, pFilename
+   if revIDEGetPreference("cImageFileRelative") is not false then
+      local tStackPath, tFilePath
+      set the itemDelimiter to "/"
+      put item 1 to -2 of the filename of stack revTargetStack(pObjectID) into tStackPath
+      if tStackPath is not empty then
+         put revCalculateRelativePath(tStackPath, pFilename) into tFilePath
+         if tFilePath begins with "./" then delete char 1 to 2 of tFilePath
+         if tFilePath ends with tResult then
+            --full path contained in relative path, likely a different volume
+            --in any case, need to return absolute path
+         else if there is a file (tStackPath & slash & tFilePath) then
+            put tFilePath into pFilename
+         end if
+      end if
+   end if
+   set the filename of pObjectID to pFilename
+end revIDESetImageFilename
+
 #############
 # Standalone Settings
 #############

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Image.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Image.tsv
@@ -4,7 +4,7 @@ title	Image
 												
 -----	-----	-----	-----	-----	-----	-----	-----	-----	-----	-----	-----	-----
 name												
-filename												
+filename::revIDESetImageFilename												
 id												
 tooltip												
 visible							true					

--- a/notes/bugfix-17287.md
+++ b/notes/bugfix-17287.md
@@ -1,0 +1,1 @@
+# Image filename property is not relativized with the PI


### PR DESCRIPTION
There is an option in preferences to "always use absolute file paths for images" but the PI does not change how it operates based on that setting.  This change adds a setter for image filename that will relativize the path unless `cImageFileRelative` is false (default value is unset but shown as true in preferences, so check for it not being false vice checking for true).

Original PR for reference/prior discussion:
https://github.com/livecode/livecode-ide/pull/1817