### PR TITLE
add 2 missing lines to updateGutterDo

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -885,6 +885,9 @@ command updateGutterDo
    local tUpdateCompilationErrors
    put tDetails["updateCompilationErrors"] into tUpdateCompilationErrors
    
+   local tForceBreakpointRedraw
+   put tDetails["forceBreakpointRedraw"] into tForceBreakpointRedraw
+   
    send "update tOffset, tSelectedLine, tOldLines, tNewLines, tTextChanged, tUpdateCompilationErrors, tForceBreakpointRedraw" to group "Gutter" of me
    
    # Once an update has been carried out, we reset the sGutterUpdateRequestDetails array


### PR DESCRIPTION
in the backport from develop to develop 8.2 two lines got left out in updateGutterDo of revSEEditorBehavior

local tForceBreakpointRedraw -- missing in 8.2 DP2
put tDetails["forceBreakpointRedraw"] into tForceBreakpointRedraw -- missing in 8.2 DP2

this became apparent when trying to fix bug 20725 
http://quality.livecode.com/show_bug.cgi?id=20725