### PR TITLE
Line Ending Conversion Correction

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5012,9 +5012,10 @@ end arrayRecurse
 private function __escapeStringAndConvertLineEndings pString
    replace "\" with "\\" in pString
    replace quote with ("\" & quote) in pString
-   replace (numToChar(13) & CR) with (CR & numToChar(13)) in pString
-   replace (CR & numToChar(13)) with CR in pString
-   replace CR with "\n" in pString
+   replace (numToCodepoint(13) & LF) with (LF & numToCodepoint(13)) in pString
+   replace (LF & numToCodepoint(13)) with LF in pString
+   replace numToCodepoint(13) with LF in pString
+   replace LF with "\n" in pString
    return (quote & pString & quote)
 end __escapeStringAndConvertLineEndings
 
@@ -10679,10 +10680,11 @@ private function escape pString, pConvertLineEndings
    replace quote with ("\" & quote) in pString
    
    if pConvertLineEndings is true then
-      replace (numToChar(13) & CR) with (CR & numToChar(13)) in pString
-      replace (CR & numToChar(13)) with CR in pString
+      replace (numToCodepoint(13) & LF) with (LF & numToCodepoint(13)) in pString
+      replace (LF & numToCodepoint(13)) with LF in pString
+      replace numToCodepoint(13) with LF in pString
    end if
-   replace CR with "\n" in pString
+   replace LF with "\n" in pString
    //replace "<" with "&lt;" in pString
    //replace ">" with "&gt;" in pString
    replace tab with "\t" in pString

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10683,6 +10683,7 @@ private function escape pString, pConvertLineEndings
       replace numToCodepoint(13) with "\n" in pString
    end if
    replace LF with "\n" in pString
+   replace numToCodepoint(13) with "\r" in pString
    //replace "<" with "&lt;" in pString
    //replace ">" with "&gt;" in pString
    replace tab with "\t" in pString

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5012,9 +5012,8 @@ end arrayRecurse
 private function __escapeStringAndConvertLineEndings pString
    replace "\" with "\\" in pString
    replace quote with ("\" & quote) in pString
-   replace (numToCodepoint(13) & LF) with (LF & numToCodepoint(13)) in pString
-   replace (LF & numToCodepoint(13)) with LF in pString
-   replace numToCodepoint(13) with LF in pString
+   replace CRLF with "\n" in pString
+   replace numToCodepoint(13) with "\n" in pString
    replace LF with "\n" in pString
    return (quote & pString & quote)
 end __escapeStringAndConvertLineEndings
@@ -10680,9 +10679,8 @@ private function escape pString, pConvertLineEndings
    replace quote with ("\" & quote) in pString
    
    if pConvertLineEndings is true then
-      replace (numToCodepoint(13) & LF) with (LF & numToCodepoint(13)) in pString
-      replace (LF & numToCodepoint(13)) with LF in pString
-      replace numToCodepoint(13) with LF in pString
+      replace CRLF with "\n" in pString
+      replace numToCodepoint(13) with "\n" in pString
    end if
    replace LF with "\n" in pString
    //replace "<" with "&lt;" in pString


### PR DESCRIPTION
Native Mac line endings are not being converted (CRLF and LFCR are converted to LF but CR was not touched).
Changed to use the LF constant to make it more readable.
Also changed numToChar to numToCodepoint since the former function is deprecated.