### PR TITLE
[bug 17819] enable cmd+c in dictionary

### DIFF
--- a/Toolset/libraries/revshortcutslibrary.livecodescript
+++ b/Toolset/libraries/revshortcutslibrary.livecodescript
@@ -156,6 +156,13 @@ on commandKeyDown pWhich
                send "mouseUp" to btn "clear" of stack "revMessageWatcher"
             end if
             break
+         case "C"
+            -- bug 17819 commandkey + c in dictionary not working
+            if revTargetStack(the focusedObject) is "revDictionary" then
+               send "revMenubarEditMenuPick" && quote &"Copy Text" & quote to \
+                     stack "revIDEMessageHandlerLibrary"
+            end if
+            break
          default
             pass commandKeyDown
       end switch

--- a/notes/bugfix-17819.md
+++ b/notes/bugfix-17819.md
@@ -1,0 +1,1 @@
+# Enable cmd+c in dictionary


### PR DESCRIPTION
cmd+c did not work when anything else in IDE was selected, text, objects etc.
http://quality.livecode.com/show_bug.cgi?id=17819