### PR TITLE
Merge develop 8.1 15.12.2017

### DIFF
--- a/Toolset/palettes/dictionary/behaviors/revdictionarybehavior.livecodescript
+++ b/Toolset/palettes/dictionary/behaviors/revdictionarybehavior.livecodescript
@@ -83,3 +83,12 @@ end navigateToEntry
 on linkClicked pLink
    launch url pLink
 end linkClicked
+
+# bug 17819 enable cmd+c in dictionary
+on commandKeyDown pWhich
+   if pWhich is "C" then
+      copy
+   else
+      pass commandKeyDown
+   end if
+end commandKeyDown

--- a/notes/bugfix-17819.md
+++ b/notes/bugfix-17819.md
@@ -1,0 +1,1 @@
+# Enable cmd+c in dictionary


### PR DESCRIPTION
Conflicts in `revdictionarybehavior.livecodescript`:

<img width="772" alt="screen shot 2017-12-15 at 09 16 59" src="https://user-images.githubusercontent.com/5111835/34035156-08c03e6e-e179-11e7-9aab-f7be1028c613.png">

Resolution: Kept both changes.