### PR TITLE
[[ Bug 19946 ]] Add active extension folders preference

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -58,7 +58,7 @@ end __revIDEDeveloperExtensionShouldRecompile
 
 private command __revIDEDeveloperExtensionRemoveFolder pFolder
    local tDeveloperExtensionsFolders
-   put revIDEGetPreference("cDeveloperExtensionsFolders") into tDeveloperExtensionsFolders
+   put revIDEDeveloperExtensionsFolders() into tDeveloperExtensionsFolders
    
    set the itemdelimiter to slash
    local tRootFolder
@@ -68,13 +68,13 @@ private command __revIDEDeveloperExtensionRemoveFolder pFolder
    put lineOffset(tRootFolder, tDeveloperExtensionsFolders) into tLine
    if tLine is not 0 then
       delete line tLine of tDeveloperExtensionsFolders
-      revIDESetPreference "cDeveloperExtensionsFolders", tDeveloperExtensionsFolders
+      revIDEDeveloperExtensionsSetFolders tDeveloperExtensionsFolders
    end if
 end __revIDEDeveloperExtensionRemoveFolder
 
 private command __revIDEDeveloperExtensionAddFolder pFolder
    local tDeveloperExtensionsFolders
-   put revIDEGetPreference("cDeveloperExtensionsFolders") into tDeveloperExtensionsFolders
+   put revIDEDeveloperExtensionsFolders() into tDeveloperExtensionsFolders
    
    set the itemdelimiter to slash
    local tRootFolder
@@ -87,7 +87,7 @@ private command __revIDEDeveloperExtensionAddFolder pFolder
       end if
    end if
    
-   revIDESetPreference "cDeveloperExtensionsFolders", tDeveloperExtensionsFolders
+   revIDEDeveloperExtensionsSetFolders tDeveloperExtensionsFolders
 end __revIDEDeveloperExtensionAddFolder
 
 /*
@@ -122,7 +122,7 @@ function revIDEDeveloperExtensions
    
    # Look for extension examples in previously selected user folders.
    local tUserFolders
-   put revIDEGetPreference("cDeveloperExtensionsFolders") into tUserFolders
+   put revIDEDeveloperExtensionsActiveFolders() into tUserFolders
    repeat for each line tLine in tUserFolders
       if tLine is among the lines of tFolders then next repeat
       
@@ -199,6 +199,22 @@ function revIDEDeveloperExtensionNoCompile pFolder
    end if
    return tDataA
 end revIDEDeveloperExtensionNoCompile
+
+function revIDEDeveloperExtensionsFolders
+   return revIDEGetPreference("cDeveloperExtensionsFolders")
+end revIDEDeveloperExtensionsFolders
+
+command revIDEDeveloperExtensionsSetFolders pFolders
+   revIDESetPreference "cDeveloperExtensionsFolders", pFolders
+end revIDEDeveloperExtensionsSetFolders
+
+function revIDEDeveloperExtensionsActiveFolders
+   return revIDEGetPreference("cDeveloperExtensionsActiveFolders")
+end revIDEDeveloperExtensionsActiveFolders
+
+command revIDEDeveloperExtensionsActiveFolders pFolders
+   revIDESetPreference "cDeveloperExtensionsActiveFolders", pFolders
+end revIDEDeveloperExtensionsActiveFolders
 
 function revIDEDeveloperExtension pFolder
    local tFile, tType

--- a/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revpalettebehavior.livecodescript
@@ -210,9 +210,13 @@ private on appendMenuItem pNavItem, @xMenuArray
             if pNavItem["value_type"] is "enum" then
                put tValue is tPreferenceValue into tChecked
             else
-        	   put tValue is among the items of tPreferenceValue into tChecked
+               if the number of lines in tPreferenceValue > 1 then
+                  put tValue is among the lines of tPreferenceValue into tChecked
+               else
+                  put tValue is among the items of tPreferenceValue into tChecked
+               end if
             end if
-
+            
             if tChecked then
                put true into tMenuItemA["menu"][tItemCount]["checked"]
             else

--- a/Toolset/palettes/extension builder/revextensionbuilderbehavior.livecodescript
+++ b/Toolset/palettes/extension builder/revextensionbuilderbehavior.livecodescript
@@ -5,16 +5,8 @@ on preOpenStack
    dispatch "setAsBehavior" to revIDEFrameBehavior() with the long id of this me
    
    ### Header
-   --addFrameItem "add","header", "action", "Create a new extension", "plus sign", "plus sign","headerActionNewExtension", the long id of me
-   addFrameItem "open","header", "action", "Open an existing extension", "folder open", "folder open","headerActionOpenExtension", the long id of me
-   addFrameItem "edit source", "header", "action", "Edit extension source code", "lc-edit-script", "lc-edit-script", "headerActionEditSource", the long id of me
-   
-   addFrameItem "package","footer", "action", "Package", "archive", "archive","footerActionPackage", the long id of me
-   addFrameItem "uninstall","footer", "action", "Uninstall", "remove circle", "remove circle","footerActionUninstall", the long id of me
-   addFrameItem "install","footer", "action", "Install", "plus sign", "plus sign","footerActionInstall", the long id of me
-   addFrameItem "stop testing","footer", "action", "Stop testing extension", "stop circle", "stop circle","footerActionStopTesting", the long id of me
-   addFrameItem "test","footer", "action", "Test extension", "play circle", "play circle","footerActionTest", the long id of me
-   
+   generateExtensionFrame
+    
    put "No API entries found" into field "message_api" of me
    put "No user guide found" into field "message_guide" of me
    
@@ -31,7 +23,61 @@ on preOpenStack
    revIDESubscribe "ideExtensionLog"
    revIDESubscribe "ideExtensionStatusChanged"
    revIDESubscribe "ideExtensionsChanged"
+   revIDESubscribe "idePreferenceChanged:cDeveloperExtensionsFolders"
+   revIDESubscribe "idePreferenceChanged:cDeveloperExtensionsActiveFolders"
 end preOpenStack
+
+private function FolderPathForMenu pFolder
+   local tFolder
+   put pFolder into tFolder
+   replace "!" with "\!" in pFolder
+   if the platform is "MacOS" then 
+      replace "/" with "\/" in pFolder
+      replace "(" with "\(" in pFolder
+   else
+      replace "/" with "//" in pFolder
+   end if
+   return tFolder & ":" & pFolder
+end FolderPathForMenu
+
+command generateExtensionFrame
+   clearFrameData
+   
+   local tFolders, tMenuItem, tOptions
+   put revIDEDeveloperExtensionsFolders() into tFolders
+   repeat for each line tLine in tFolders
+      put FolderPathForMenu(tLine) into tMenuItem
+      if tOptions is empty then
+         put tMenuItem into tOptions
+      else
+         put comma & tMenuItem after tOptions
+      end if
+   end repeat
+   
+   addFrameItem "cDeveloperExtensionsActiveFolders", "header", "preference", "Folders to search for extensions", "set", tOptions, "togglePreference", the long id of me
+   
+   --addFrameItem "add","header", "action", "Create a new extension", "plus sign", "plus sign","headerActionNewExtension", the long id of me
+   addFrameItem "open","header", "action", "Open an existing extension", "folder open", "folder open","headerActionOpenExtension", the long id of me
+   addFrameItem "edit source", "header", "action", "Edit extension source code", "lc-edit-script", "lc-edit-script", "headerActionEditSource", the long id of me
+   
+   addFrameItem "package","footer", "action", "Package", "archive", "archive","footerActionPackage", the long id of me
+   addFrameItem "uninstall","footer", "action", "Uninstall", "remove circle", "remove circle","footerActionUninstall", the long id of me
+   addFrameItem "install","footer", "action", "Install", "plus sign", "plus sign","footerActionInstall", the long id of me
+   addFrameItem "stop testing","footer", "action", "Stop testing extension", "stop circle", "stop circle","footerActionStopTesting", the long id of me
+   addFrameItem "test","footer", "action", "Test extension", "play circle", "play circle","footerActionTest", the long id of me
+   
+end generateExtensionFrame
+
+on idePreferenceChanged pPref
+   switch pPref
+      case "cDeveloperExtensionsFolders"
+      case "cDeveloperExtensionsActiveFolders"
+         --Refresh the header list
+         generateExtensionFrame
+         populateExtensionList
+         break
+   end switch
+end idePreferenceChanged
 
 on closeStackRequest
    if there is folder sLoadedExtension then
@@ -73,6 +119,26 @@ private on consoleScrollbarUpdate
       set the vscrollbar of field "console" to false
    end if
 end consoleScrollbarUpdate
+
+on togglePreference pPreference, pValue
+   switch pPreference
+      case "cDeveloperExtensionsActiveFolders"
+         local tCurrentPreferenceValue, tPreferencePosition, tLineOffset
+         put revIDEGetPreference("cDeveloperExtensionsActiveFolders") into tCurrentPreferenceValue
+         put lineOffset(pValue, tCurrentPreferenceValue) into tLineOffset
+         if tLineOffset is not 0 then
+            delete line tLineOffset of tCurrentPreferenceValue
+         else
+            if tCurrentPreferenceValue is empty then
+               put pValue into tCurrentPreferenceValue
+            else
+               put return & pValue after tCurrentPreferenceValue
+            end if
+         end if
+         revIDESetPreference "cDeveloperExtensionsActiveFolders", tCurrentPreferenceValue
+         break
+   end switch
+end togglePreference
 
 on headerActionNewExtension
 end headerActionNewExtension

--- a/notes/bugfix-19946.md
+++ b/notes/bugfix-19946.md
@@ -1,0 +1,9 @@
+# Add extension search folders preference
+Any folder containing a folder containing an extension selected for 
+loading by the user is added to the `cDeveloperExtensionsFolders` 
+preference. There is now a new preference 
+`cDeveloperExtensionsActiveFolders` which controls which of the 
+folders are actually searched for extensions in the extension 
+builder. This preference can be set using the cog at the top-right 
+of the extension builder stack.
+


### PR DESCRIPTION
Any folder containing a folder containing an extension selected
for loading by the user is added to the cDeveloperExtensionsFolders
preference. This patch adds a cDeveloperExtensionsActiveFolders
preference which controls which of the above folders are actually
searched for extensions in the extension builder. This preference
can be set using the cog at the top-right of the extension builder
stack.