### PR TITLE
Fix initial setting of LCB editor pref

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -593,7 +593,7 @@ on revIDEDeveloperExtensionEditScript pFolder
       end if
    end if
    
-   if tResult is "no association" or the result is "request failed" then
+   if tResult is "no association" or tResult is "request failed" then
       answer file "Select text editor..."
       if it is not empty then
          launch tFile with it

--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -593,19 +593,21 @@ on revIDEDeveloperExtensionEditScript pFolder
       end if
    end if
    
-   if tResult is "no association" or tResult is "request failed" then
+   if tResult is "no association" or tResult is "request failed" \
+         or tResult is "no such program" then
       answer file "Select text editor..."
-      if it is not empty then
-         launch tFile with it
+      put it into tEditor
+      if tEditor is not empty then
+         launch tFile with tEditor
          put the result into tResult
          if tResult is empty then
             # AL-2015-04-01: [[ Bug 15130 ]] If the new text editor launch was successful, set the preference
-            revIDESetPreference "LCB_textEditor", it
+            revIDESetPreference "LCB_textEditor", tEditor
          end if
       end if
    end if
    
-   if tResult is not empty then
+   if tResult is not empty and tResult is not tEditor then
       __revIDEDeveloperExtensionSendError "Could not open" && tFile & ":" && tResult
    end if
 end revIDEDeveloperExtensionEditScript

--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -577,28 +577,31 @@ on revIDEDeveloperExtensionUninstall pPath
 end revIDEDeveloperExtensionUninstall
 
 on revIDEDeveloperExtensionEditScript pFolder
-   local tFile
+   local tFile, tResult
    put pFolder & slash & __revIDEDeveloperExtensionFetchModuleInFolder(pFolder) into tFile
    
    # AL-2015-04-01: [[ Bug 15130 ]] First check to see if there is an existing association
    launch document tFile
-   if the result is not empty then
+   put the result into tResult
+   if tResult is not empty then
       # AL-2015-04-01: [[ Bug 15130 ]] Check to see if the text editor preference is set
       local tEditor
       put revIDEGetPreference("LCB_textEditor") into tEditor
       if tEditor is not empty then
          launch tFile with tEditor
+         put the result into tResult
       end if
    end if
    
-   if the result is "no association" or the result is "request failed" then
+   if tResult is "no association" or the result is "request failed" then
       answer file "Select text editor..."
       if it is not empty then
          launch tFile with it
+         put the result into tResult
       end if
    end if
    
-   if the result is not empty then
+   if tResult is not empty then
       __revIDEDeveloperExtensionSendError "Could not open" && tFile & ":" && the result
    else if it is not empty then
       # AL-2015-04-01: [[ Bug 15130 ]] If the new text editor launch was successful, set the preference

--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -602,7 +602,7 @@ on revIDEDeveloperExtensionEditScript pFolder
    end if
    
    if tResult is not empty then
-      __revIDEDeveloperExtensionSendError "Could not open" && tFile & ":" && the result
+      __revIDEDeveloperExtensionSendError "Could not open" && tFile & ":" && tResult
    else if it is not empty then
       # AL-2015-04-01: [[ Bug 15130 ]] If the new text editor launch was successful, set the preference
       revIDESetPreference "LCB_textEditor", it

--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -598,14 +598,15 @@ on revIDEDeveloperExtensionEditScript pFolder
       if it is not empty then
          launch tFile with it
          put the result into tResult
+         if tResult is empty then
+            # AL-2015-04-01: [[ Bug 15130 ]] If the new text editor launch was successful, set the preference
+            revIDESetPreference "LCB_textEditor", it
+         end if
       end if
    end if
    
    if tResult is not empty then
       __revIDEDeveloperExtensionSendError "Could not open" && tFile & ":" && tResult
-   else if it is not empty then
-      # AL-2015-04-01: [[ Bug 15130 ]] If the new text editor launch was successful, set the preference
-      revIDESetPreference "LCB_textEditor", it
    end if
 end revIDEDeveloperExtensionEditScript
 


### PR DESCRIPTION
The `revIDEDeveloperExtensionEditScript` handler will open an LCB file in the default editor.  It uses `the result` to catch failures to open with a default editor and set a pref.  The problem is that after evaluating the next `put` (getting the editor pref), the original value is lost.  This means that if the pref has not already been set, then the file won't get opened.

This change implements a new variable `tResult` to carry forward the result though the function.