### PR TITLE
[[ CEF ]] Use CEF by default on linux

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -4766,7 +4766,7 @@ private function revIDEPaletteBarHeight pStackID
 end revIDEPaletteBarHeight
 
 function revIDEBrowserWidgetUnavailable
-   return (the platform is "Linux") and ($LIVECODE_USE_CEF is not 1)
+   return (the platform is "Linux") and ($LIVECODE_USE_CEF is 0)
 end revIDEBrowserWidgetUnavailable
 
 /*


### PR DESCRIPTION
The updated version of CEF now works on a significant number of
distributions. This patch will allow CEF to be used by default
unless a user explicitly sets `$LIVECODE_USE_CEF` to `0`.