### PR TITLE
remove any generated doc files after running the IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,8 @@ environment_log.txt
 
 # Documentation #
 #################
-Documentation/html_viewer/resources/data/api/*.js
-Documentation/html_viewer/resources/data/guide/*.js
+# Documentation/html_viewer/resources/data/api/*.js
+# Documentation/html_viewer/resources/data/guide/*.js
 Documentation/html_viewer/resources/data/
 
 # Additional externals #

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ environment_log.txt
 #################
 Documentation/html_viewer/resources/data/api/*.js
 Documentation/html_viewer/resources/data/guide/*.js
+Documentation/html_viewer/resources/data/
 
 # Additional externals #
 ########################


### PR DESCRIPTION
After compiling and launching the compiled build, the data directory is generated inside the resources directory. Git is not happy about this, so this patch updates the .gitignore file to ignore the generated files and the directory.
