### PR TITLE
[[ ModuleAssemblies ]] Fix extension functionality for multi-module assemblies

### DIFF
--- a/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
+++ b/Toolset/libraries/revidedeveloperextensionlibrary.livecodescript
@@ -162,40 +162,36 @@ function revIDEDeveloperExtensions
    return tExtensionDetailsA
 end revIDEDeveloperExtensions
 
-private command __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, @rFile, @rType
-   local tExtFile, tType
-   revIDEExtensionFetchSourceFromFolder pFolder, tExtFile, tType
+private command __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, @rFile, @rSupportFiles, @rType
+   local tMainFile, tType, tSupportFiles
+   revIDEExtensionFetchSourceFromFolder pFolder, tMainFile, tSupportFiles, tType
    
-   local tNumExtensions
-   put the number of lines in tExtFile into tNumExtensions
-   
-   # If there are multiple lcb files in one folder, it's an error.
-   if tNumExtensions > 1 then
-      put replaceText(tExtFile, return, ",") into tExtFile
-      __revIDEDeveloperExtensionSendError "multiple lcb files in folder" && pFolder & ":" && tExtFile
-      return empty
+   if the result is not empty then
+      __revIDEDeveloperExtensionSendError the result
    end if
    
-   put tExtFile into rFile
+   put tMainFile into rFile
+   put tSupportFiles into rSupportFiles
    put tType into rType
 end __revIDEDeveloperExtensionFetchExtensionSourceInFolder
 
 function revIDEDeveloperExtensionNoCompile pFolder
-   local tFile, tType
-   __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, tFile, tType
+   local tFile, tType, tSupportFiles
+   __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, tFile, tSupportFiles, tType
    
    if tFile is empty then
       return empty
    end if
    
    if tType is "lcs" then
-      return __revIDEDeveloperExtensionDetailsFromFile(pFolder, tFile, tType)
+      return __revIDEDeveloperExtensionDetailsFromFile(pFolder, tFile, tSupportFiles, tType)
    end if
    
    local tDataA
    revIDEExtensionMetadata pFolder, tFile, tType, tDataA
    if the result is not empty then
       put tFile into tDataA["file"]
+      put tSupportFiles into tDataA["support_files"]
    end if
    return tDataA
 end revIDEDeveloperExtensionNoCompile
@@ -217,14 +213,14 @@ command revIDEDeveloperExtensionsActiveFolders pFolders
 end revIDEDeveloperExtensionsActiveFolders
 
 function revIDEDeveloperExtension pFolder
-   local tFile, tType
-   __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, tFile, tType
+   local tFile, tType, tSupportFiles
+   __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, tFile, tSupportFiles, tType
    
    if tFile is empty then
       return empty
    end if
    
-   return __revIDEDeveloperExtensionDetailsFromFile(pFolder, tFile, tType)
+   return __revIDEDeveloperExtensionDetailsFromFile(pFolder, tFile, tSupportFiles, tType)
 end revIDEDeveloperExtension
 
 private function __revIDEDeveloperExtensionFetchFolderDetails pFolder, pFile
@@ -360,11 +356,12 @@ private function __revIDEDeveloperExtensionListResourcesRecursive pFolder, pPref
    return tResources
 end __revIDEDeveloperExtensionListResourcesRecursive
 
-private function __revIDEDeveloperExtensionDetailsFromFile pFolder, pFile, pType
+private function __revIDEDeveloperExtensionDetailsFromFile pFolder, pFile, pSupportFiles, pType
    local tDetailsA
    put __revIDEDeveloperExtensionFetchFolderDetails(pFolder, pFile) into tDetailsA
    
-   put pFile into tDetailsA["file"]      
+   put pFile into tDetailsA["file"]  
+   put pSupportFiles into tDetailsA["support_files"]    
    if pType is "lcb" then
       if not __revIDEDeveloperExtensionShouldRecompile(pFolder, pFile) then
          
@@ -380,7 +377,7 @@ private function __revIDEDeveloperExtensionDetailsFromFile pFolder, pFile, pType
       else
          # The compiled module or manifest is not up to date, so compile.
          __revIDEDeveloperExtensionLog "Compiling module" && pFolder & slash & pFile
-         __revIDEDeveloperCompileModule pFolder & slash & pFile, pFolder
+         __revIDEDeveloperCompileModule pFolder & slash & pFile, pSupportFiles, pFolder
          if the result is not empty then
             # This may be better as a warning, and try to parse info direct from the file.
             __revIDEDeveloperExtensionSendError the result
@@ -681,8 +678,8 @@ private command __revIDEDeveloperExtensionEditLCBScript pFile
 end __revIDEDeveloperExtensionEditLCBScript
 
 on revIDEDeveloperExtensionOpen pFolder
-   local tFile, tType
-   __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, tFile, tType
+   local tFile, tType, tSupportFiles
+   __revIDEDeveloperExtensionFetchExtensionSourceInFolder pFolder, tFile, tSupportFiles, tType
    if tFile is empty then
       exit revIDEDeveloperExtensionOpen
    end if
@@ -737,8 +734,8 @@ private function __fetchMetadatum pXmlId, pKey
    return textDecode(revXMLNodeContents(pXmlId, tNode), "utf-8")
 end __fetchMetadatum
 
-private command __revIDEDeveloperCompileModule pFile, pTargetFolder
-   revIDEExtensionCompile pFile, pTargetFolder
+private command __revIDEDeveloperCompileModule pFile, pSupportFiles, pTargetFolder
+   revIDEExtensionCompile pFile, pSupportFiles, pTargetFolder
    
    if the result is not empty then
       __revIDEDeveloperCompilationError the result
@@ -892,9 +889,12 @@ private command __revIDEDeveloperExtensionBuildPackage pFolder, pTargetFolder, @
       put empty into tEditors
    end if
    
+   local tSupportFiles
+   put tDetailsA["support_files"] into tSupportFiles
+
    if tError is empty then
       put __revIDEDeveloperExtensionAddSpecifiedFilesToPackage(\
-            tFullPath, pFolder, tArchive, pFolder & slash & "module.lcm", \
+            tFullPath, tSupportFiles, pFolder, tArchive, pFolder & slash & "module.lcm", \
             tIcon, tRetinaIcon, tGuide, tDocs, tResources, tCode, \
             tSamples, tInterfaceFile, tDefaultScript, tEditors) \
             into tError
@@ -918,10 +918,10 @@ private command __revIDEDeveloperExtensionBuildPackage pFolder, pTargetFolder, @
 end __revIDEDeveloperExtensionBuildPackage
 
 private function __revIDEDeveloperExtensionAddSpecifiedFilesToPackage \
-      pSource, pFolder, pArchive, pModule, pIcon, pRetinaIcon, pGuide, \
-      pDocs, pResourcesFolder, pCodeFolder, pSamplesFolder, \
-      pInterfaceFile, pDefaultScript, pEditors
-      
+      pSource, pSupportFiles, pFolder, pArchive, pModule, pIcon,  \
+      pRetinaIcon, pGuide, pDocs, pResourcesFolder, pCodeFolder, \
+      pSamplesFolder, pInterfaceFile, pDefaultScript, pEditors
+   
    local tError
    
    set the itemdelimiter to slash
@@ -931,6 +931,16 @@ private function __revIDEDeveloperExtensionAddSpecifiedFilesToPackage \
    if the result begins with "ziperr" then
       put "couldn't add source" into tError
    end if
+   
+   # Add support files into package
+   repeat for each line tSupport in pSupportFiles
+      put pFolder & slash & tSupport into tSupport
+      revZipAddItemWithFile pArchive, item -1 of tSupport, tSupport
+      
+      if the result begins with "ziperr" then
+         put "couldn't add support file" && tSupport into tError
+      end if
+   end repeat
    
    # Add module into package
    revZipAddItemWithFile pArchive, "module.lcm", pModule
@@ -951,10 +961,10 @@ private function __revIDEDeveloperExtensionAddSpecifiedFilesToPackage \
    # Add user guide
    if tError is empty then
       // AL-2015-03-03: [[ Bug 14781 ]] If there is no guide, warn and don't try to add a file
-   	  if pGuide is empty then
-   	    __revIDEDeveloperExtensionSendWarning "no user guide found"
-   	  else
-	    revZipAddItemWithFile pArchive, "docs/guide/guide.md", pGuide
+      if pGuide is empty then
+         __revIDEDeveloperExtensionSendWarning "no user guide found"
+      else
+         revZipAddItemWithFile pArchive, "docs/guide/guide.md", pGuide
       end if
       if the result begins with "ziperr" then
          put "couldn't add guide" into tError

--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -908,41 +908,72 @@ function revIDEExtensionsOrderByDependency pExtensions
    return __dependencyOrder(tDependencies, pExtensions)
 end revIDEExtensionsOrderByDependency
 
-command revIDEExtensionFetchSourceFromFolder pFolder, @rSource, @rType
+private function __RegexPatternForSource pType
+   switch pType
+      case "lcb"
+         return "^.*\.lcb$"
+         break
+      case "lcs"
+         return "^.*\.livecode(script)?$"
+         break
+   end switch
+end __RegexPatternForSource
+
+command revIDEExtensionFetchSourceFromFolder pFolder, @rSource, @rSupportFiles, @rType
    local tFiles
    put files(pFolder) into tFiles
    
-   local tExtFile, tType
-   filter tFiles with "*.lcb" into tExtFile
+   local tExtFiles, tType
+   filter tFiles with regex pattern \
+         __RegexPatternForSource("lcb") into tExtFiles
    if there is a file (pFolder & slash & "module.lcm") \
-         or tExtFile is not empty then
+         or tExtFiles is not empty then
       put "lcb" into tType
    end if
+   
    if tType is empty then
-      filter tFiles with regex pattern ".*\.livecode(script)?$" into tExtFile
-      if tExtFile is not empty then
+      filter tFiles with regex pattern \
+            __RegexPatternForSource("lcs") into tExtFiles
+      if tExtFiles is not empty then
          put "lcs" into tType
       end if
+   end if
+   
+   -- Try and separate main source from support
+   local tFoundCount, tSupport, tMainFile
+   put the number of lines in tExtFiles into tFoundCount
+   if tFoundCount > 1 then
+      set the itemdelimiter to "."
+      repeat for each line tTry in tExtFiles
+         filter tExtFiles with item 1 to -2 of tTry & "-*" into tSupport
+         if the number of lines in tSupport is tFoundCount - 1 then
+            put tTry into tMainFile
+            exit repeat
+         end if
+         put empty into tSupport
+      end repeat
+      if tSupport is empty then
+         return "Invalid extension folder" && pFolder & return & \
+               "Must have one main module, with all support modules named" && \
+               "<main-name>-<support-name>."
+      end if
+   else
+      put tExtFiles into tMainFile 
    end if
    
    if tType is empty then
       put "none" into tType
    end if 
    
-   put tExtFile into rSource
+   put tMainFile into rSource
+   put tSupport into rSupportFiles
    put tType into rType
+   return empty
 end revIDEExtensionFetchSourceFromFolder
 
 private command __FindExtensionsInFolderRecursive pFolder, pIsUserFolder, @xDataA
-   local tExtSource, tArray, tFiles, tExtFile, tType
-   revIDEExtensionFetchSourceFromFolder pFolder, tExtFile, tType
-   
-   local tNumExtensions
-   put the number of lines in tExtFile into tNumExtensions
-   if tNumExtensions > 1 then
-      get __revIDEError("Invalid extension folder" && pFolder & ": require exactly one extension per folder")
-      exit __FindExtensionsInFolderRecursive
-   end if
+   local tExtSource, tArray, tFiles, tMainSource, tSupportFiles, tType
+   revIDEExtensionFetchSourceFromFolder pFolder, tMainSource, tSupportFiles, tType
    
    -- If we found no extensions, recurse
    if tType is "none" then
@@ -955,12 +986,13 @@ private command __FindExtensionsInFolderRecursive pFolder, pIsUserFolder, @xData
    end if
    
    if tType is "lcb" then
-      put __fetchModuleData(pFolder, tExtFile) into tArray
+      put __fetchModuleData(pFolder, tMainSource) into tArray
    else
-      put __fetchScriptLibraryData(pFolder, tExtFile) into tArray
+      put __fetchScriptLibraryData(pFolder, tMainSource) into tArray
    end if
    
-   put tExtFile into tArray["source_file"]
+   put tMainSource into tArray["source_file"]
+   put tSupportFiles into tArray["support_files"]
    put tType into tArray["source_type"]
    put not pIsUserFolder into tArray["ide"]
    
@@ -1201,6 +1233,8 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
       __extensionPropertySet tCacheIndex, "install_path", pFolder
    end if
    
+   local tSupportFiles
+   put pAdditionalInfoA["support_files"] into tSupportFiles
    local tLoadOnStartup
    if pError is empty then
       put revIDEExtensionGetLoadOnStartup(pID) into tLoadOnStartup
@@ -1210,7 +1244,7 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
       -- If we have an error loading, try to recompile the extension
       if pError is not empty then
          if not pIsIDEExtension and pSourceFile is not empty then
-            revIDEExtensionCompile pFolder & slash & pSourceFile, pFolder
+            revIDEExtensionCompile pFolder & slash & pSourceFile, tSupportFiles, pFolder
             if the result is empty then
                local tNewError
                __LoadExtension tCacheIndex, "lcb", pSourceFile, pFolder, pStatus, tNewError
@@ -1228,6 +1262,7 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
    __extensionPropertySet tCacheIndex, "ide", pIsIDEExtension
    __extensionPropertySet tCacheIndex, "source_file", pSourceFile
    __extensionPropertySet tCacheIndex, "source_type", "lcb"
+   __extensionPropertySet tCacheIndex, "support_files", tSupportFiles
    
    # Check for sample stacks
    __extensionPropertySet tCacheIndex, "samples", __extensionSampleStacks(pID,pFolder)
@@ -1337,6 +1372,7 @@ private command __revIDELCSExtensionLoad pFullPath, pFolder, pVersion, pStatus, 
    __extensionPropertySet tCacheIndex, "source_type", "lcs"
    __extensionPropertySet tCacheIndex, "type", "library"
    __extensionPropertySet tCacheIndex, "uservisible", true
+   __extensionPropertySet tCacheIndex, "support_files", pAdditionalInfoA["support_files"]
    
    # Store the extension's property metadata
    --  revIDEExtensionSetInfo pID
@@ -1598,7 +1634,7 @@ private function shellFormat pArg, pSwitch
    return tOutput & quote & pArg & quote & " "
 end shellFormat
 
-command revIDEExtensionCompile pFile, pTargetFolder
+command revIDEExtensionCompile pFile, pSupportFiles, pTargetFolder
    # The manifest is currently always generated from the source
    if there is a file (pTargetFolder & slash & "manifest.xml") then
       delete file (pTargetFolder & slash & "manifest.xml")
@@ -1622,6 +1658,11 @@ command revIDEExtensionCompile pFile, pTargetFolder
    
    # The output
    put shellFormat(pTargetFolder & slash & "module.lcm", "output") after tShellCommand
+   
+   # Support files must be dependency-ordered
+   repeat for each line tSupport in revIDEExtensionsOrderByDependency(pSupportFiles)
+      put shellFormat(pTargetFolder & slash &tSupport) after tShellCommand
+   end repeat
    
    # The target .lcb file
    put shellFormat(pFile) after tShellCommand

--- a/notes/bugfix-20862.md
+++ b/notes/bugfix-20862.md
@@ -1,0 +1,16 @@
+# Fix multi-module assembly support
+The extension builder now supports multi-module assemblies properly.
+An extension folder can contain a main module, eg main.lcb, and any
+number of support modules, named <main name>-<suffix>.lcb, which are
+then compiled together into one bytecode file. 
+
+For example, it is useful when building cross-platform extensions to
+put the platform-specific code in a support module, so the extension
+folder would contain for example
+
+	button.lcb
+	button-android.lcb
+	button-ios.lcb
+	...
+etc
+


### PR DESCRIPTION
A single lcm bytecode file can be an assembly of multiple module files. This
patch adjusts the extensions API, the extension builder's packager and module
compilation to account for this possibility. We also relax the restriction on
a single source file per extension folder to account for the possibility of
multi-module extensions.