### PR TITLE
bug # 20868 -- enable/disable button "replace" based on search location

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsefindmaincardbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsefindmaincardbehavior.livecodescript
@@ -118,6 +118,8 @@ command updateButtonStates
       enable button "Replace one" of me
       enable button "Find all" of me
       enable button "Replace all" of me
+      enable button "Replace" of me
+      select item 1 of button "replace"   
    else
       enable button "Find all" of me
       
@@ -127,6 +129,8 @@ command updateButtonStates
       
       disable button "Find Next" of me
       disable button "Replace one" of me
+      disable button "Replace" of me
+      set the label of button "replace" of me to empty
    end if
 end updateButtonStates
 


### PR DESCRIPTION
Replacing of found items in Script Editor is only available when Location option is 'Current Tab' or 'All Tabs' so the button "replace" of stack "revSEFind">Stack "main" should only be enabled then.  For all other Locations the "replace" button should be disabled.   Also when replace is not available and disabled the label of the button should be set to empty.  It can be set back to item 1 when the user changes back to location 'Current Tab' or 'All Tabs'.