### PR TITLE
[bug 17819] enable cmd+c in dictionary enhanced

### DIFF
--- a/Toolset/palettes/dictionary/behaviors/revdictionarybehavior.livecodescript
+++ b/Toolset/palettes/dictionary/behaviors/revdictionarybehavior.livecodescript
@@ -93,9 +93,5 @@ end showUpgradeOptions
 
 # bug 17819 enable cmd+c in dictionary
 on commandKeyDown pWhich
-   if pWhich is "C" then
-      copy
-   else
-      pass commandKeyDown
-   end if
+   if pWhich is not "C" then pass commandKeyDown
 end commandKeyDown


### PR DESCRIPTION
blocking command+c in revDictionaryBehavior completely fixes the bug by letting the system take care of copying