### PR TITLE
[[ Emscripten ]] Add com.livecode.emscripten to list of builtin extensions

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -827,6 +827,7 @@ private function __extensionIsBuiltin pID
       case "com.livecode.typeconvert"
       case "com.livecode.extensions.libbrowser"
       case "com.livecode.java"
+      case "com.livecode.emscripten"
       case "com.livecode.objc"
       case "com.livecode.commercial.license"
          return true


### PR DESCRIPTION
This is required for the standalone builder to work with stacks that use this module