### PR TITLE
[[ Bug 20991 ]] Use win32 for code library path

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -1196,7 +1196,7 @@ private command __MapCodeLibraryForIDE pFolder
             filter tCodeFolders with "*-mac*"
             break
          case "Win32"
-            filter tCodeFolders with "*-win*"
+            filter tCodeFolders with "*-win32*"
             break
          default
             filter tCodeFolders with "*-"& toLower(the platform) & "*"


### PR DESCRIPTION
This patch ensures that windows code library paths conform
to the platform ID spec.