### PR TITLE
Amend .gitignore to exclude dictionary data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ environment_log.txt
 
 # Documentation #
 #################
-Documentation/html_viewer/resources/data/api/*.js
+Documentation/html_viewer/resources/data/api*/*.js
 Documentation/html_viewer/resources/data/guide/*.js
 
 # Additional externals #


### PR DESCRIPTION
New releases add several additional `api_livecode_*` directories which show as additional files to commit.  By adding a `*` after `api` these `js` files no longer show.