### PR TITLE
[[ Bug 21093 ]] Handle thrown errors

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -2071,6 +2071,9 @@ command revDebuggerUpdateScriptEditor pObject, pHandler, pLine, pState, pError
    revGoScriptEditor the name of stack tScriptEditor
    
    if pError is not empty then
+      if the number of items of pError is 1 then
+         put comma & pLine after pError
+      end if
       # OK-2008-07-10 : This needs to be sent in time so that it arrives after the script
       # editor has finished initializing itself.
       send "revSEDisplayExecutionError pError, pObject" to stack tScriptEditor in 0 milliseconds

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11876,7 +11876,14 @@ function revIDELookupError pType, pError
       else if tCode is kExternalHandlerErrorCode then
          return "External handler execution error:" && item 4 to -1 of line 1 of pError
       end if
-      return line tCode of the scriptExecutionErrors
+      
+      if tCode is an integer then
+         get line tCode of the scriptExecutionErrors
+         if it is not empty then
+            return it
+         end if
+      end if
+      return tCode
    else if pType is "warning" then
       return empty
    end if

--- a/notes/bugfix-21093.md
+++ b/notes/bugfix-21093.md
@@ -1,0 +1,1 @@
+# Fix the display of errors thrown by the throw command in the script editor


### PR DESCRIPTION
This patch ensures that thrown errors which do not have a line in the
`scriptExecutionErrors` do not cause an execution error when looking up
the description.

Additionally include line in thrown error description this patch ensures that descriptions of thrown errors in the script editor include the line number they were thrown on.