### PR TITLE
[[ Bug 21095 ]] Load required extensions on startup

### DIFF
--- a/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -1066,7 +1066,8 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
    put pAdditionalInfoA["support_files"] into tSupportFiles
    local tLoadOnStartup
    if pError is empty then
-      put revIDEExtensionGetLoadOnStartup(pID) into tLoadOnStartup
+      put pAdditionalInfoA["_ide"] is true or \
+            revIDEExtensionGetLoadOnStartup(pID) into tLoadOnStartup
    end if
    if not pIsStartup or tLoadOnStartup is not false then
       __LoadExtension tCacheIndex, "lcb", pSourceFile, pFolder, pStatus, pError

--- a/Toolset/palettes/extension manager/revideextensionmanagerrowbehavior.livecodescript
+++ b/Toolset/palettes/extension manager/revideextensionmanagerrowbehavior.livecodescript
@@ -124,12 +124,14 @@ private function __MenuActionsForRow pDataA
       put tShow after tActions
    end if
    
-   local tLoadOnStartup
-   put "Load on startup/|Toggle Load" & return into tLoadOnStartup
-   if revIDEExtensionGetLoadOnStartup(pDataA["name"]) is not false then
-      put "!c" before tLoadOnStartup
+   if not pDataA["_ide"] then
+      local tLoadOnStartup
+      put "Load on startup/|Toggle Load" & return into tLoadOnStartup
+      if revIDEExtensionGetLoadOnStartup(pDataA["name"]) is not false then
+         put "!c" before tLoadOnStartup
+      end if
+      put tLoadOnStartup after tActions
    end if
-   put tLoadOnStartup after tActions
    
    local tSampleList
    if pDataA["samples"] is not empty then

--- a/notes/bugfix-21095.md
+++ b/notes/bugfix-21095.md
@@ -1,0 +1,1 @@
+# Ensure extensions required by the IDE load on startup


### PR DESCRIPTION
This patch both ensures that the menu option to not load an extension
on startup in the extension manager is removed from IDE dependencies and
also that IDE dependencies will be loaded regardless of the setting if it
happened to be set in another way or a widget becomes a dependency in a
new version.