### PR TITLE
[[ Bug 21090 ]] Create DG2 template controls with msgs unlocked

### DIFF
--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -10791,7 +10791,7 @@ function DG2_CustomisableControlsGetDefaultEditModeReorderControl
    if there is not a group "DG2 Default Edit Mode Reorder Control"of _TemplateControl() then
       local tMsgsAreLocked
       put the lockMessages into tMsgsAreLocked
-      lock messages
+      unlock messages
 
       reset the templateGroup
       create invisible group "DG2 Default Edit Mode Reorder Control" in _TemplateControl()
@@ -10812,7 +10812,7 @@ function DG2_CustomisableControlsGetDefaultEditModeActionSelectControl
    if there is not a group "DG2 Default Edit Mode Action Select Control" of _TemplateControl() then
       local tMsgsAreLocked
       put the lockMessages into tMsgsAreLocked
-      lock messages
+      unlock messages
 
       reset the templateGroup
       create invisible group "DG2 Default Edit Mode Action Select Control" in _TemplateControl()
@@ -10836,7 +10836,7 @@ function DG2_CustomisableControlsGetDefaultEditModeActionControl
 
       local tMsgsAreLocked
       put the lockMessages into tMsgsAreLocked
-      lock messages
+      unlock messages
 
       reset the templateGroup
       create invisible group "DG2 Default Action Control" in _TemplateControl()
@@ -10866,7 +10866,7 @@ private function DG2_CustomisableControlsGetDefaultSwipeControl pName
 
       local tMsgsAreLocked
       put the lockMessages into tMsgsAreLocked
-      lock messages
+      unlock messages
 
       local tGroup
       reset the templateGroup

--- a/notes/bugfix-21090.md
+++ b/notes/bugfix-21090.md
@@ -1,0 +1,1 @@
+# Ensure project browser updates when DG2 controls are added to the template stack


### PR DESCRIPTION
This patch ensures that the project browser will be updated when the IDE
adds the additional controls to the datagrid template stack required for
DG2