### PR TITLE
[[ Bug 20094 ]] Execute msg box if it compiles

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11512,7 +11512,11 @@ command ideExecuteScript pScript, pObject, pDebugMode, @rValidScript
    end if
    
    if tValidScript is empty then
-      return tOriginalCompileError for error
+      if tOriginalCompileError is not empty then
+         return tOriginalCompileError for error
+      else
+         put pScript into tValidScript
+      end if
    end if
    unlock screen
    

--- a/notes/bugfix-20094.md
+++ b/notes/bugfix-20094.md
@@ -1,0 +1,1 @@
+# Fix multi-line message box not executing if the first line is a comment

--- a/tests/messagebox/execution.livecodescript
+++ b/tests/messagebox/execution.livecodescript
@@ -319,10 +319,28 @@ on TestReferenceControlOnActiveStack
 	create stack
 	set the defaultStack to the short name of it
 	
-	local tToExecute
+	local tToExecute, tValidScript
 	put "put bar into field 1" into tToExecute
 	ideExecuteScript tToExecute, tStack, false, tValidScript
 	
 	TestAssert "intelligence object command two params result", the text of tField is "bar"
 	TestAssert "intelligence object command two params executed", tValidScript is tToExecute
 end TestReferenceControlOnActiveStack
+
+-- bug 20084
+on TestMutilineWithCommentOnFirstLine
+	local tStack, tField
+	create stack
+	put it into tStack
+
+	set the defaultStack to the short name of tStack
+	
+	create field
+	put it into tField
+	
+	local tToExecute, tValidScript
+	put "-- foo" & return & "put bar into field 1" into tToExecute
+	ideExecuteScript tToExecute, tStack, false, tValidScript
+	
+	TestAssert "multiline script with comment on first line executes", the text of tField is "bar"
+end TestMutilineWithCommentOnFirstLine


### PR DESCRIPTION
This patch ensures that if the message box script compiles ok and
we fail to find any improvements by autocompleting the script it is
still executed.