### PR TITLE
[[ Bug 21122 ]] Update windowBoundingRect

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -1349,6 +1349,7 @@ on revIDEInitialiseIDELibrary
    revIDEPropertyLibraryInitialise
    
    ideSubscribe "ideExtensionsChanged"
+   ideSubscribe "ideDesktopChanged"
 end revIDEInitialiseIDELibrary
 
 on ideExtensionsChanged
@@ -9678,8 +9679,9 @@ command revIDESuspendDevelopmentTools
    put tClosedStacksList into gREVRestore["stacks"]
    
    -- Reset the windowBoundingRect
-   put the windowBoundingRect into gREVRestore["windowBoundingRect"]
-   set the windowBoundingRect to 0,0,item 3 to 4 of the windowBoundingRect
+   local tWindowRect
+   put revIDEStackScreenRect(the short name of the topStack, true) into tWindowRect
+   set the windowBoundingRect to tWindowRect
    
    -- Show the restore dialog
    lock recent
@@ -9746,7 +9748,7 @@ command revIDERestoreDevelopmentTools
    set the defaultMenuBar to the long id of group "revMenuBar" of stack revIDEPaletteToStackName("menubar")
    set the width of stack "revMenuBar" to the width of stack "revMenuBar" + 1 -- bug 1806
    set the width of stack "revMenuBar" to the width of stack "revMenuBar" - 1
-   set the windowBoundingRect to gREVRestore["windowBoundingRect"]
+   ideSetWindowBoundingRect
    choose gREVRestore["tool"]
    
    -- Restore the script debug mode
@@ -12222,3 +12224,42 @@ end ideShouldShowUpgradeOptions
 private function hasConnection
    return url("http://google.com/") is not empty
 end hasConnection
+
+on ideDesktopChanged
+   ideSetWindowBoundingRect
+end ideDesktopChanged
+
+/**
+
+Update the window bounding rect for the current IDE palette layout
+
+*/
+
+command ideSetWindowBoundingRect
+   local tMenuBar
+   put revIDEPaletteToStackName("menubar") into tMenuBar
+   
+   local tTools
+   put revIDEPaletteToStackName("tools") into tTools
+   
+   local tToolsSlop
+   put the width of stack tTools + 50 into tToolsSlop
+   
+   local tWindowRect
+   put revIDEStackScreenRect(tMenuBar, true) into tWindowRect
+   if tWindowRect is not empty then
+      if the screen of stack tTools is the screen of stack tMenubar then
+         if the right of stack tTools < (item 1 of tWindowRect + tToolsSlop) then 
+            put the right of stack tTools + 5 into item 1 of tWindowRect
+         else if the left of stack tTools > (item 3 of tWindowRect - tToolsSlop) then
+            put the left of stack tTools - 5 into item 3 of tWindowRect
+         end if
+      end if
+      
+      -- revMenubar may not be visible on macOS with text and icons off
+      if the visible of stack tMenubar then
+         put the bottom of stack tMenuBar + 5 into item 2 of tWindowRect
+      end if
+      set the windowBoundingRect to tWindowRect
+   end if
+end ideSetWindowBoundingRect

--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -219,6 +219,8 @@ on moveStack
       set the topLeft of this stack to item 1 to 2 of tScreenRect
    end if
    revIDESetPaletteRectPreference the short name of me
+   ideSetWindowBoundingRect
+   
    pass moveStack
 end moveStack
 
@@ -282,15 +284,9 @@ on idePreferenceChanged pPreference
       case "cToolbarIcons"
          lock screen
          show me
-         local tAlterBounding
-         if abs(item 2 of the windowBoundingRect - the bottom of me) < 10 then 
-            put true into tAlterBounding
-         end if
          updateMenubarPreference
          layoutMenu
-         if tAlterBounding then
-            set the windowBoundingRect to item 1 of the windowBoundingRect,the bottom of me + 25, item 3 to 4 of the windowBoundingRect
-         end if
+         ideSetWindowBoundingRect
          unlock screen
          break
    end switch
@@ -2443,8 +2439,7 @@ function revListMenuHandlers pObject, pSort, pIndentationLevel
 end revListMenuHandlers
 
 on unIconifyStack
-   global gREVBackDropRestore, gREVRestore
-   if gREVRestore["windowBoundingRect"] is empty then pass unIconifyStack
+   global gREVBackDropRestore
    set cursor to watch
    lock messages
    set the iconic of stack "revMenubar" to false

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -1251,3 +1251,8 @@ on revToolsConfigurePolygon pTool
    end if
    revToolsConfigurePaint
 end revToolsConfigurePolygon
+
+on moveStack
+   ideSetWindowBoundingRect
+   pass moveStack
+end moveStack

--- a/notes/bugfix-21122.md
+++ b/notes/bugfix-21122.md
@@ -1,0 +1,1 @@
+# Fix user stacks opening offscreen when last opened on a different monitor


### PR DESCRIPTION
This patch ensures that the windowBoundingRect is updated when the screen
configurations change and when the menubar and tools palette are moved. It
also ensures that script editors are resized to fit within the window when
the screens change.