### PR TITLE
[[ Bug 21172 ]] Fix revMail on mobile

### DIFF
--- a/Toolset/libraries/revcommonlibrary.livecodescript
+++ b/Toolset/libraries/revcommonlibrary.livecodescript
@@ -55,9 +55,10 @@ end revGoPDF
 # should be ussed by people sending unicode characters, the original revMail can be used otherwise
 command revMail pTo, pCC, pSubject, pBody
    if the environment is "mobile" then
-      pass revMail
+      mobileComposeMail pSubject, pTo, pCC, , pBody
+   else
+      revMailUnicode pTo, pCC, uniEncode(pSubject), uniEncode(pBody)
    end if
-   revMailUnicode pTo, pCC, uniEncode(pSubject), uniEncode(pBody)
 end revMail
 
 command revMailUnicode pTo, pCC, pSubject, pBody

--- a/notes/bugfix-21172.md
+++ b/notes/bugfix-21172.md
@@ -1,0 +1,1 @@
+# Fix revMail on mobile


### PR DESCRIPTION
Adding the common library to mobile caused the revMail function to break.
`pass revMail` was added to the handler, but the engine did not support that method.

Replaced the `pass` with a call to `mobileComposeMail` to restore functionality

On iPhone this should be a good solution (looking at the source code).  The calls for revMail are much simpler for Android, but the end result should be the same.