### PR TITLE
[Bug 21176] Make sure Upgrade Options can always be shown

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -1019,7 +1019,11 @@ on mouseUp
          revIDETutorialSkipToNextSkipPoint
       end if
    else if the short name of the owner of the target is "upgrade" then
+      local tStartCenterClassic
+      put revIDEGetPreference("StartCenterClassic") in tStartCenterClassic
+      revIDESetPreference "StartCenterClassic", true
       ideShowUpgradeOptions
+      revIDESetPreference "StartCenterClassic", tStartCenterClassic
    else if the short name of the owner of the target is "toolbar" and the target begins with "button" then
       revMenubarMenuButtonClicked the short name of the target
       setButtonReleased the long id of the target

--- a/notes/bugfix-21176.md
+++ b/notes/bugfix-21176.md
@@ -1,0 +1,1 @@
+# Make sure the Start Center can always show the Upgrade Options


### PR DESCRIPTION
The Upgrade Options are shown in a browser widget located in the Start Center Stack. The browser is shown only if the Classic Start Center is shown.