### PR TITLE
[[ Bug 21206 ]] Fix error opening msg box from SE

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -2144,6 +2144,10 @@ command actionAutocompleteSnippetManager
    modeless "com.livecode.palette.autocomplete-pro"
 end actionAutocompleteSnippetManager
 
+command actionLaunchMessageBox
+   revIDEOpenPalette "Message Box"
+end actionLaunchMessageBox
+
 ################################################################################
 #
 # Keyboard shortcut handling

--- a/notes/bugfix-21206.md
+++ b/notes/bugfix-21206.md
@@ -1,0 +1,1 @@
+# Fix execution error opening message box from script editor via Cmd/Ctrl+M


### PR DESCRIPTION
This patch adds `actionLaunchMessageBox` to the script editor stack
behavior so that the Cmd+M shortcut does not cause an execution error.