### PR TITLE
[[ Bug 21202 ]] Fix deselection of next find after replace

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -846,7 +846,7 @@ end textReplaceNewGroupNeeded
 #   This is the point through which all standard editing operations on scripts are sent through.
 #   Any change made via this function will be added to the undo system. This is called when the
 #   user types keys, formats text, cuts, pastes etc.
-command textReplace pOffset, pOldText, pNewText, pObject, pDontGroup
+command textReplace pOffset, pOldText, pNewText, pObject, pDontGroup, pDontSelect
    lock screen
    
    local tObject
@@ -943,27 +943,33 @@ command textReplace pOffset, pOldText, pNewText, pObject, pDontGroup
          end repeat
          put true into sPlaceholders[sEditPlaceholder]["edited"]
          
-         if tSelection is not empty then
-            select tSelection
-         else if pNewText is empty then
-            select char pOffset to pOffset-1 of field "script" of me
-         else if the length of pNewText is 1 then
-            select char pOffset+1 to pOffset of field "script" of me
-         else if tBracketCompletionType is "pair" then
-            select after char pOffset of field "script" of me
+         if not pDontSelect then
+            if tSelection is not empty then
+               select tSelection
+            else if pNewText is empty then
+               select char pOffset to pOffset-1 of field "script" of me
+            else if the length of pNewText is 1 then
+               select char pOffset+1 to pOffset of field "script" of me
+            else if tBracketCompletionType is "pair" then
+               select after char pOffset of field "script" of me
+            end if
          end if
       else
          -- clear highlighted bracket background color
          __ClearHighlights
          textReplaceRaw pOffset, pOldText, pNewText
-         if tSelection is not empty then
-            select tSelection
-         else if tBracketCompletionType is "pair" then
-            select after char pOffset of field "script" of me
+         if not pDontSelect then
+            if tSelection is not empty then
+               select tSelection
+            else if tBracketCompletionType is "pair" then
+               select after char pOffset of field "script" of me
+            end if
          end if
       end if
       
-      selectionUpdateRequest
+      if not pDontSelect then
+         selectionUpdateRequest
+      end if
       
       -- when formatting or pasting we don't want autocomplete to pop up
       if the number of lines of pNewText <= 1 then
@@ -3455,6 +3461,10 @@ end __UpdateAutoCompleteList
 
 private command __ClearCurrentPlaceholder pForce
    if not pForce then
+      if the selectedField is empty or \
+            the long id of the selectedField is not the long id of field "script" of me then
+         exit __ClearCurrentPlaceholder
+      end if
       local tChunk
       put the selectedChunk into tChunk
       if exists(tChunk) then

--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -2203,7 +2203,7 @@ command replaceOnce pString
    put tFrom into tAt
    
    textBeginGroup "Replace"
-   textReplace tAt, char tFrom to tTo of textGetScript(), pString
+   textReplace tAt, char tFrom to tTo of textGetScript(), pString, , , true
    
    # OK-2009-02-16 : Bug 7712 - Return information about the replaced text so that in a the context of replaceOnceAndFind, we can ensure
    # that the replaced text does not get searched.

--- a/notes/bugfix-21202.md
+++ b/notes/bugfix-21202.md
@@ -1,0 +1,1 @@
+# Fix deselection of next find after replace in Script Editor


### PR DESCRIPTION
This patch adds a method to replace text in the script editor without
calling selection update or chaging the selection at all. The current
selection update request was causing find results to be cleared between
replace and go to next and the subsequent replace.