### PR TITLE
[[ Bug 21245 ]] SE indent errors with inline block comments

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -334,7 +334,7 @@ end __GetPreference
 
 -- Text Formatting Code
 command textFormatInitialize
-   -- permit use in environment witn no dependencies
+   -- permit use in environment with no dependencies
    local tTabDepth
    put __GetPreference("editor,tabdepth", 3) into tTabDepth
    
@@ -2614,16 +2614,16 @@ end dragEnd
 
 # Description
 ## Returns a line stripped of comments at the end of the line
+## and inline comments ( /* ... */ )
 private function lineStripComments pLine
-   local tLine
+   local tLine, tInComment
    split pLine by quote
    
+   put false into tInComment
    repeat with tIndex = 1 to the number of elements of pLine step 2
-      local tDecommented
-      put __StripComment(pLine[tIndex]) into tDecommented
-      put tDecommented after tLine
-      if pLine[tIndex] is tDecommented and \
-            tIndex is not the number of elements of pLine then
+      put __StripComment(pLine[tIndex], tInComment) after tLine
+      if tInComment then exit repeat
+      if tIndex is not the number of elements of pLine then
          put quote & pLine[tIndex+1] & quote after tLine
       end if
    end repeat
@@ -2631,17 +2631,37 @@ private function lineStripComments pLine
    return tLine
 end lineStripComments
 
-private function __StripComment pLine
+private function __StripComment pLine, @xInComment
    local tOffset
-   repeat for each word tComment in "# -- // /*"
+   repeat for each word tComment in "# -- //"
       put offset(tComment, pLine) into tOffset
       if tOffset is not 0 then
          delete char tOffset to -1 of pLine
+         put true into xInComment
       end if
    end repeat
+
+   put __StripBlockComment(pLine, xInComment) into pLine
    
    return pLine
 end __StripComment
+
+private function __StripBlockComment pline, @xInComment
+   local tOffset, tOffsetEnd
+   put offset("/*", pLine) into tOffset
+   if tOffset is not 0 then
+      put offset("*/", pLine, tOffset) into tOffsetEnd
+      if tOffsetEnd is not 0 then
+         delete char tOffset to tOffset + tOffsetEnd of pLine
+         put __StripBlockComment(pLine, xInComment) into pLine
+      else
+         delete char tOffset to -1 of pLine
+         put true into xInComment
+      end if
+   end if
+
+   return pLine
+end __StripBlockComment
 
 ################################################################################
 

--- a/notes/bugfix-21245.md
+++ b/notes/bugfix-21245.md
@@ -1,0 +1,1 @@
+# SE indent errors with inline block comments and line continuation

--- a/tests/scripteditor/_indentation_tests/bug-21245.livecodescript
+++ b/tests/scripteditor/_indentation_tests/bug-21245.livecodescript
@@ -1,0 +1,10 @@
+command inlineCommentTest \
+      pBasePath,     /* base path for export folders     */ \
+      @xRelativePath /* relative path for folder         */
+   -- code
+end inlineCommentTest
+
+command quoteAfterCommentTest
+   put "test" -- "extra" \
+   put "test"
+end quoteAfterCommentTest


### PR DESCRIPTION
There are 2 related errors in the `lineStripComments` /` __StripComment` handlers in the `revsecommoneditorbehavior.livecodescript` code.

The first error is that "/*" is assumed to run to the end of the current line.  Since it is possible to have multiple inline block comments on a single line, a recursive call to `__StripBlockComment` is used to remove these comments.

The second error is that the loop that goes through the current line does not exit when a true comment to the end of the line is encountered.  The loop uses quotes to ensure that it isn't capturing comment characters in a string, but fails to exit.  Added an additional return value (pass by reference variable) indicating comment status of the current chunk to better facilitate knowing when to exit the loop.