### PR TITLE
[[ Bug 20672 ]] Update property inspector once for multiple objects

### DIFF
--- a/Toolset/palettes/inspector/revinspectortemplate.livecodescript
+++ b/Toolset/palettes/inspector/revinspectortemplate.livecodescript
@@ -122,7 +122,15 @@ on lockInspector
    end if
 end lockInspector
 
+local sPropertyChangedMsg
+
 on idePropertyChanged
+   cancel sPropertyChangedMsg
+   send "__IdePropertyChanged" to me in 200 milliseconds
+   put the result into sPropertyChangedMsg
+end idePropertyChanged
+
+on __IdePropertyChanged
    lock screen
    # Check if the object 'types' have been changed via PI
    local tNewTypes
@@ -135,7 +143,7 @@ on idePropertyChanged
       inspectorTitleUpdate
    end if
    unlock screen
-end idePropertyChanged
+end __IdePropertyChanged
 
 on inspectorTreeMenuDisplay
    local tObjects, tStack, tDefaultStack

--- a/notes/bugfix-20672.md
+++ b/notes/bugfix-20672.md
@@ -1,0 +1,1 @@
+# Fix very slow arrow key nudge of multiple objects


### PR DESCRIPTION
Previously `idePropertyChanged` would be sent for each of the selected objects
causing the property inspector to be updated for each. This patch will ensure
it is only updated once for multiple objects.