### PR TITLE
[[Bug 21323]] syntax for DG2 new props incorrect

### DIFF
--- a/Documentation/dictionary/datagrid.lcdoc
+++ b/Documentation/dictionary/datagrid.lcdoc
@@ -2697,7 +2697,7 @@ Type: property
 Associations: datagrid, datagrid general properties
 
 Syntax: set the dgProp["edit mode action control"] of group "Data Grid" to
-<control id>
+the long id of <control(glossary)>
 
 Summary: Set the action control to display when the data grid is in edit mode.
 
@@ -2722,7 +2722,7 @@ Type: property
 Associations: datagrid, datagrid general properties
 
 Syntax: set the dgProp["edit mode action select control"] of group "Data Grid"
-to <control id>
+to the long id of <control(glossary)>
 
 Summary: Set the action select control to display when the data grid is in edit
 mode.
@@ -2748,7 +2748,7 @@ Type: property
 Associations: datagrid, datagrid general properties
 
 Syntax: set the dgProp["edit mode reorder control"] of group "Data Grid" to
-<control id>
+the long id of <control(glossary)>
 
 Summary: Set the reorder control to display when the data grid is in edit mode.
 
@@ -2773,8 +2773,8 @@ Type: property
 
 Associations: datagrid, datagrid general properties
 
-Syntax: set the dgProp["left swipe control"] of group "Data Grid" to <control
-id>
+Syntax: set the dgProp["left swipe control"] of group "Data Grid" to the long 
+id of <control(glossary)>
 
 Summary: Set the control to display when a data grid row is dragged to the right.
 
@@ -2798,8 +2798,8 @@ Type: property
 
 Associations: datagrid, datagrid general properties
 
-Syntax: set the dgProp["right swipe control"] of group "Data Grid" to <control
-id>
+Syntax: set the dgProp["right swipe control"] of group "Data Grid" to the long 
+id of <control(glossary)>
 
 Summary: Set the control to display when a data grid row is dragged to the left.
 

--- a/notes/bugfix-21323
+++ b/notes/bugfix-21323
@@ -1,1 +1,0 @@
-correction to syntax for DG2's new props

--- a/notes/bugfix-21323
+++ b/notes/bugfix-21323
@@ -1,0 +1,1 @@
+correction to syntax for DG2's new props

--- a/notes/bugfix-21323.md
+++ b/notes/bugfix-21323.md
@@ -1,0 +1,1 @@
+# correction to syntax for DG2's new props


### PR DESCRIPTION
Replace <control id> with "the long id of control"