### PR TITLE
[[ Bug 21232 ]] Fix wandering breakpoints

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -1018,7 +1018,7 @@ end textReplaceRawInVariable
 #   This is the raw replacement operation that performs a mutation on the script field without
 #   saving any undo information. This should be called only from inside textReplace, when doing an undo or a redo
 #   and when setting the script when a new object is loaded.
-private command textReplaceRaw pOffset, @pOldText, @pNewText, pDontUpdateBreakpoints
+private command textReplaceRaw pOffset, @pOldText, @pNewText, pDontUpdateBreakpoints, pUpdateBreakpointsNow
    lock screen
    lock messages
    
@@ -1044,14 +1044,13 @@ private command textReplaceRaw pOffset, @pOldText, @pNewText, pDontUpdateBreakpo
          add 1 to tNewLines
       end if
    end if
+   unlock messages
    
    if pDontUpdateBreakpoints then
-      updateGutterRequest empty, empty, tOldLines, tNewLines, false, false
+      updateGutterRequest empty, empty, tOldLines, tNewLines, false, false, false, pUpdateBreakpointsNow
    else
-      updateGutterRequest pOffset, tSelectedLine, tOldLines, tNewLines, true, false
+      updateGutterRequest pOffset, tSelectedLine, tOldLines, tNewLines, true, false, false, pUpdateBreakpointsNow
    end if
-   
-   unlock messages
    
    # OK-2008-09-10 : Bug 7132 - Update the panes  and handler list everytime the text of the field is changed.
    # OK-2009-01-19 : Don't do this here as it slows down the script editor on OS X. Instead do it in the individual
@@ -1086,12 +1085,13 @@ on textUndo
    
    local tOperations
    put sTextGroupLengths[sObjectId,sTextGroupIndex[sObjectId]] into tOperations
+   
    lock screen
    repeat with tIndex = sTextOperationIndex[sObjectId] down to sTextOperationIndex[sObjectId] - tOperations + 1
       local tNewText, tOldText
       put sTextOperationNewTexts[sObjectId,tIndex] into tNewText
       put sTextOperationOldTexts[sObjectId,tIndex] into tOldText
-      textReplaceRaw sTextOperationOffsets[sObjectId,tIndex], tNewText, tOldText
+      textReplaceRaw sTextOperationOffsets[sObjectId,tIndex], tNewText, tOldText, false, true
    end repeat
    unlock screen
    
@@ -1123,7 +1123,7 @@ on textRedo
       local tNewText, tOldText
       put sTextOperationOldTexts[sObjectId,tIndex] into tOldText
       put sTextOperationNewTexts[sObjectId,tIndex] into tNewText
-      textReplaceRaw sTextOperationOffsets[sObjectId,tIndex], tOldText, tNewText
+      textReplaceRaw sTextOperationOffsets[sObjectId,tIndex], tOldText, tNewText, false, true
    end repeat
    unlock screen
    
@@ -1235,6 +1235,12 @@ end getUpdateGutterRequestDetails
 #  mutable objects (the breakpoint / compilation error images). These are show again when the update is
 #  actually carried out.
 command updateGutterRequest pOffset, pSelectedLine, pOldLines, pNewLines, pTextChanged, pUpdateCompilationErrors, pForceBreakpointRedraw, pNow
+   if sGutterUpdateRequestDetails["offset"] is not empty and \
+         pOffset is not sGutterUpdateRequestDetails["offset"] then
+      -- if the offset is different we can't merge
+      updateGutterDo
+   end if
+   
    updateGutterMergeRequestDetails pOffset, pSelectedLine, pOldLines, pNewLines, pTextChanged, pUpdateCompilationErrors, pForceBreakpointRedraw
    if sGutterUpdateRequest is not empty then
       cancel sGutterUpdateRequest
@@ -1248,7 +1254,7 @@ command updateGutterRequest pOffset, pSelectedLine, pOldLines, pNewLines, pTextC
       set the vScroll of field "Numbers" of group "Gutter" to the vScroll of field "Script" of me
    end if
    
-   if pNow then
+   if pNow or (pOldLines is not 1 or pNewLines is not 1) then
       updateGutterDo
    else
       send "updateGutterDo" to me in 200 milliseconds
@@ -2071,7 +2077,7 @@ on scrollBarDrag
    lock screen
    put tVScroll into sVScroll
    
-   updateGutterRequest empty, empty, empty, empty, false, true, empty, true
+   updateGutterRequest empty, empty, empty, empty, false, true, false, true
    unlock screen
 end scrollBarDrag
 

--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2884,7 +2884,7 @@ command scriptComment
    delete the last char of tCommentedText
    
    # Apply the mutation to the field
-   textMark "Insert"
+   textBeginGroup "Comment"
    textReplace tStartChar, tText, tCommentedText
    
    # Restore the selection
@@ -2897,8 +2897,9 @@ command scriptComment
    put __GetPreference("editor,autoformat", true) into tAutoFormat
    
    if tAutoFormat then
-      scriptFormat "handler"
+      scriptFormat "handler", true
    end if
+   textEndGroup
    
    unlock screen
 end scriptComment
@@ -2947,7 +2948,7 @@ command scriptUncomment
    delete the last char of tUncommentedText
    
    # Apply the mutation to the field
-   textMark "Insert"
+   textBeginGroup "Uncomment"
    textReplace tStartChar, tText, tUncommentedText
    
    # Restore the selection
@@ -2960,8 +2961,9 @@ command scriptUncomment
    put __GetPreference("editor,autoformat", true) into tAutoFormat
    
    if tAutoFormat then
-      scriptFormat "handler"
+      scriptFormat "handler", true
    end if
+   textEndGroup
    
    unlock screen
 end scriptUncomment

--- a/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsegutterbehavior.livecodescript
@@ -54,7 +54,7 @@ command update pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, pUp
       put tContext["object"] into sLastObject
    end if
    
-   updateBreakpoints pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, tContext
+   updateBreakpoints pOffset, pOldNumber, pNewNumber, pTextChanged, tContext
    updateLineNumbers pTextChanged, pOldNumber, pNewNumber, tContext
    updateCurrentLine tContext
    
@@ -390,12 +390,12 @@ end updateCompilationErrors
 
 # Parameters
 #   pObject : reference to the object to update breakpoint positions for
-#   pLine : the current line number
+#   pOffset : the offset of text replacement
 #   pOldNumber : the number of lines previously in the script
 #   pNewNumber : the number of lines now in the script
 # Description
 #   Updates the the positions of breakpoints in response to the script being changed.
-private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, pNewNumber   
+private command updateBreakpointPositions pObject, pOffset, pOldNumber, pNewNumber   
    local tNumber, tInsertion
    
    if pOldNumber = pNewNumber then
@@ -405,12 +405,12 @@ private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, p
    local tBreakpoints
    put revDebuggerListBreakpoints(pObject) into tBreakpoints
    
+   local tLineIndex
+   put the lineIndex of char pOffset of getScriptField() into tLineIndex
+   
    if pOldNumber < pNewNumber then
       repeat for each line tBreakpoint in tBreakpoints
-         if item -1 of tBreakpoint = pLine then
-            local tLineIndex
-            put the lineIndex of char pOffset of getScriptField() into tLineIndex
-            
+         if item -1 of tBreakpoint = tLineIndex then
             local tCharIndex
             put the charIndex of line tLineIndex of getScriptField() into tCharIndex
             
@@ -428,13 +428,13 @@ private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, p
          end if
          
          # If the line that contained the breakpoint was above the added text, leave it where it is
-         if item -1 of tBreakpoint < pLine then
+         if item -1 of tBreakpoint < tLineIndex then
             next repeat
          end if
          
          
          # If the line that contained the breakpoint was below the added text, move the breakpoint down by the number of lines added.
-         if item -1 of tBreakpoint > pLine then
+         if item -1 of tBreakpoint > tLineIndex then
             revDebuggerMoveBreakpoint item 1 to -2 of tBreakpoint, item -1 of tBreakpoint, item 1 to -2 of tBreakpoint, item -1 of tBreakpoint + (pNewNumber - pOldNumber)
          end if
       end repeat
@@ -442,9 +442,9 @@ private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, p
       local tScript
       put textGetScript() into tScript
       repeat for each line tBreakpoint in tBreakpoints
-         if (item -1 of tBreakpoint >= pLine and item -1 of tBreakpoint < (pLine - (pNewNumber - pOldNumber))) and revDebuggerNextAvailableBreakpoint(tScript, item -1 of tBreakpoint - 1 + (pNewNumber - pOldNumber)) <> item -1 of tBreakpoint + (pNewNumber - pOldNumber) then
+         if (item -1 of tBreakpoint >= tLineIndex and item -1 of tBreakpoint < (tLineIndex - (pNewNumber - pOldNumber))) and revDebuggerNextAvailableBreakpoint(tScript, item -1 of tBreakpoint - 1 + (pNewNumber - pOldNumber)) <> item -1 of tBreakpoint + (pNewNumber - pOldNumber) then
             revDebuggerRemoveBreakpoint item 1 to -2 of tBreakpoint, item -1 of tBreakpoint
-         else if item -1 of tBreakpoint > (pLine + pNewNumber - pOldNumber) then
+         else if item -1 of tBreakpoint > (tLineIndex + pNewNumber - pOldNumber) then
             # If the breakpoint was below the removed lines, move it up
             revDebuggerMoveBreakpoint item 1 to -2 of tBreakpoint, item -1 of tBreakpoint, item 1 to -2 of tBreakpoint, item -1 of tBreakpoint + (pNewNumber - pOldNumber)
          end if
@@ -452,7 +452,7 @@ private command updateBreakpointPositions pObject, pOffset, pLine, pOldNumber, p
    end if
 end updateBreakpointPositions
 
-private command updateBreakpoints pOffset, pSelectedLine, pOldNumber, pNewNumber, pTextChanged, pContext
+private command updateBreakpoints pOffset, pOldNumber, pNewNumber, pTextChanged, pContext
    clearMutableObjects
    
    local tObject
@@ -468,7 +468,7 @@ private command updateBreakpoints pOffset, pSelectedLine, pOldNumber, pNewNumber
    end if
    
    if pTextChanged then
-      updateBreakpointPositions tObject, pOffset, pSelectedLine, pOldNumber, pNewNumber
+      updateBreakpointPositions tObject, pOffset, pOldNumber, pNewNumber
    end if
    
    # Get a list of the breakpoints set on the current object using revDebuggerListBreakpoints.
@@ -717,7 +717,7 @@ on gutterMouseUp pTarget, pClickLoc
    
    lock screen
    clearMutableObjects
-   updateBreakpoints 1, 1, 1, 1, false
+   updateBreakpoints 1, 1, 1, false
    # OK-2010-02-26: Avoid delays when updating breakpoints by only updating the breakpoints pane
    --   sePanesUpdate
    seRefreshCurrentPaneIfItsBreakpoints
@@ -757,7 +757,7 @@ on menuPick pItemName
    
    lock screen
    clearMutableObjects
-   updateBreakpoints 1, 1, 1, 1, false
+   updateBreakpoints 1, 1, 1, false
    
    # OK-2010-02-26: Avoid delays when updating breakpoints by only updating the breakpoints pane
    --   sePanesUpdate

--- a/notes/bugfix-21232.md
+++ b/notes/bugfix-21232.md
@@ -1,0 +1,1 @@
+# Fix wandering breakpoints when undoing paste


### PR DESCRIPTION
This patch fixes wandering breakpoints when undoing a paste or rapidly
adding or removing lines via return or delete. It ensures that we
immediately update breakpoints unless the line count as not been changed
by the edit.