### PR TITLE
[Bug 21585] Fix graphics size in PI -> Effects

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.graphiceffect.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.graphiceffect.behavior.livecodescript
@@ -119,7 +119,9 @@ on editorResize
    
    local tRect
    put the rect of me into tRect
-   set the rect of graphic 1 of me to the right of button 1 of me, item 2 of tRect + 2, item 3 of tRect - 5, item 4 of tRect - 5
+   set the rect of graphic 1 of me to the right of button 1 of me,  \
+         the top of button 1 of me + 3, item 3 of tRect - 5,  \
+         the bottom of button 1 of me - 3
    unlock messages
    unlock screen
 end editorResize

--- a/notes/bugfix-21585.md
+++ b/notes/bugfix-21585.md
@@ -1,0 +1,1 @@
+# Make height of sample graphics in PI-> Effects stable


### PR DESCRIPTION
This fix references a stable size (button 1) instead of the rect of the group. This gives consistent heights of graphics when resizing or lock/unlocking PI