### PR TITLE
[Bug 20701] Make manual height in PI consistent

### DIFF
--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -180,12 +180,14 @@ local sManualHeightOfStack, sNewHeight, sOldHeight
 on inspectorLayoutGroups pGroupList, pForceHeight
    
    # store height of stack when manually resizing
-   if pForceHeight <> true and the mouse is down and sNewHeight <> sOldHeight then
+   if pForceHeight is not true and the mouse is "down" and sNewHeight is not sOldHeight then
       put the height of this stack into sManualHeightOfStack
    end if
    
    # reset sManualHeightOfStack to empty if inspector was closed
-   if not the visible of me then put empty into sManualHeightOfStack
+   if not the visible of me then
+      put empty into sManualHeightOfStack
+   end if
    
    lock screen
    # Get the margin, padding
@@ -287,7 +289,7 @@ on inspectorLayoutGroups pGroupList, pForceHeight
    end if
    
    # reset manualHeight if user expands a non-expandable tab to full height
-   if not pForceHeight and not tCanExpand and sManualHeightOfStack = tStackHeight then
+   if not pForceHeight and not tCanExpand and sManualHeightOfStack is tStackHeight then
       put empty into sManualHeightOfStack
    end if
    
@@ -295,7 +297,7 @@ on inspectorLayoutGroups pGroupList, pForceHeight
    local tScreenRect, tNewStackHeight
    put revIDEStackScreenRect(the long id of me, true) into tScreenRect
    
-   if sManualHeightOfStack <> empty then
+   if sManualHeightOfStack is not empty then
       put min(sManualHeightOfStack, tStackHeight) into tNewStackHeight
       set the height of this stack to min(tNewStackHeight, item 4 of tScreenRect - tStackTop)
    else

--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -176,8 +176,17 @@ private function inspectorCalculateLayout pGroupList, pLeft, pTop, pRowWidth, pS
    return tInspectorHeight
 end inspectorCalculateLayout
 
-local sManualHeight
+local sManualHeightOfStack, sNewHeight, sOldHeight
 on inspectorLayoutGroups pGroupList, pForceHeight
+   
+   # store height of stack when manually resizing
+   if pForceHeight <> true and the mouse is down and sNewHeight <> sOldHeight then
+      put the height of this stack into sManualHeightOfStack
+   end if
+   
+   # reset sManualHeightOfStack to empty if inspector was closed
+   if not the visible of me then put empty into sManualHeightOfStack
+   
    lock screen
    # Get the margin, padding
    local tMargin, tPadding
@@ -277,23 +286,41 @@ on inspectorLayoutGroups pGroupList, pForceHeight
       set the maxheight of me to tStackHeight
    end if
    
-   if pForceHeight and not sManualHeight then
-      -- Make stack smaller rather than go offscreen
-      local tScreenRect
-      put revIDEStackScreenRect(the long id of me, true) into tScreenRect
-      set the height of me to min(tStackHeight, item 4 of tScreenRect - tStackTop)
+   # reset manualHeight if user expands a non-expandable tab to full height
+   if not pForceHeight and not tCanExpand and sManualHeightOfStack = tStackHeight then
+      put empty into sManualHeightOfStack
+   end if
+   
+   -- Make stack smaller rather than go offscreen
+   local tScreenRect, tNewStackHeight
+   put revIDEStackScreenRect(the long id of me, true) into tScreenRect
+   
+   if sManualHeightOfStack <> empty then
+      put min(sManualHeightOfStack, tStackHeight) into tNewStackHeight
+      set the height of this stack to min(tNewStackHeight, item 4 of tScreenRect - tStackTop)
+   else
+      set the height of this stack to min(tStackHeight, item 4 of tScreenRect - tStackTop)
    end if
    set the left of me to tStackLeft
    set the top of me to tStackTop
    
+   local tvScrollIsOn, tvScrollChanged
+   put false into tvScrollChanged
+   
    if there is a group "inspector" of me then
-      if the height of me < tStackHeight then
-         put true into sManualHeight
+      put the vScrollbar of group "inspector" of me into tvScrollIsOn
+      if the height of me < tStackHeight - tMargin then
          set the vscrollbar of group "inspector" of me to true
+         if not tvScrollIsOn then
+            put true into tvScrollChanged
+         end if
       else
-         put false into sManualHeight
          set the vscrollbar of group "inspector" of me to false
+         if tvScrollIsOn then 
+            put true into tvScrollChanged
+         end if
       end if
+
       set the rect of group "inspector" of me to \
             item 1 of tContentRect, \ 
             item 2 of tContentRect, \ 
@@ -301,8 +328,23 @@ on inspectorLayoutGroups pGroupList, pForceHeight
             the bottom of this card of me - tMargin
    end if
    unlock messages
+   
+   # adapt right size of controls to vScrollbar on and off
+   if tvScrollChanged then resizeInspector
+   
    unlock screen
 end inspectorLayoutGroups
+
+before resizeStack pNewWidth, pNewHeight, pOldWidth, pOldHeight
+   put pNewHeight into sNewHeight
+   put pOldHeight into sOldHeight
+   pass resizeStack
+end resizeStack
+
+function getManualHeight
+   return sManualHeightOfStack
+end getManualHeight
+
 
 local sSelectedSection, sSelectedSectionIndex
 private on inspectorSectionSet pSection

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -1,5 +1,6 @@
 ﻿script "com.livecode.pi.customprops.behavior"
 local sPropSet, sHilitePath
+constant kWidgetHeight = 150
 
 on editorInitialize
    put empty into sPropSet
@@ -113,7 +114,7 @@ on editorResize
    
    # Use all space not taken by other elements for main array display
       local tWidgetHeight, tValueHeight
-   put 150 into tWidgetHeight -- or other value
+   put kWidgetHeight into tWidgetHeight
    put max (the height of this card - ( 12 * kControlGap + kLabelFieldHeight  \
          + kKeyFieldHeight + kValueFieldHeight + kSetButtonsHeight  \
          + tWidgetHeight), kValueFieldHeight) into tValueHeight

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -112,8 +112,12 @@ on editorResize
    send "groupResize kLabelSize, kControlGap" to group "Set buttons" of me
    
    # Use all space not taken by other elements for main array display
-   local tWidgetHeight
-   put the height of me - (4 * kControlGap + kLabelFieldHeight + kKeyFieldHeight + kValueFieldHeight + kSetButtonsHeight) into tWidgetHeight
+      local tWidgetHeight, tValueHeight
+   put 150 into tWidgetHeight -- or other value
+   put max (the height of this card - ( 12 * kControlGap + kLabelFieldHeight  \
+         + kKeyFieldHeight + kValueFieldHeight + kSetButtonsHeight  \
+         + tWidgetHeight), kValueFieldHeight) into tValueHeight
+
    set the height of widget 1 of me to tWidgetHeight
    set the width of widget 1 of me to the width of me
    set the left of widget 1 of me to the left of me
@@ -135,7 +139,7 @@ on editorResize
    set the left of field "value label" of me to the left of me
    
    set the width of field "value" of me to the width of me - kLabelSize - kControlGap
-   set the height of field "value" of me to kValueFieldHeight
+   set the height of field "value" of me to kValueFieldHeight + tValueHeight
    set the top of field "value" of me to the bottom of field "key" of me + kControlGap
    set the left of field "value" of me to the right of field "value label" of me + kControlGap
    

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.stackfiles.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.stackfiles.behavior.livecodescript
@@ -43,7 +43,7 @@ on editorResize
    
    local tManualHeight, tManualGroupHeight
    put getManualHeight() into tManualHeight
-   if tManualHeight <> empty then
+   if tManualHeight is not empty then
       put tManualHeight - the height of group "background" - kControlGap - 2 into tManualGroupHeight
       set the height of me to tManualGroupHeight
       set the height of the owner of me to tManualGroupHeight

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.stackfiles.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.stackfiles.behavior.livecodescript
@@ -41,6 +41,14 @@ on editorResize
    local tRect, tFieldRect
    put the rect of me into tRect
    
+   local tManualHeight, tManualGroupHeight
+   put getManualHeight() into tManualHeight
+   if tManualHeight <> empty then
+      put tManualHeight - the height of group "background" - kControlGap - 2 into tManualGroupHeight
+      set the height of me to tManualGroupHeight
+      set the height of the owner of me to tManualGroupHeight
+   end if
+   
    put tRect into tFieldRect
    put item 2 of tFieldRect + kButtonHeight + kColumnHeaderHeight + kControlGap into item 2 of tFieldRect
    set the effective rect of field "stackFilesField" of me to tFieldRect

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.textcontents.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.textcontents.behavior.livecodescript
@@ -47,7 +47,7 @@ on editorResize
    lock messages
    local tManualHeight, tManualGroupHeight
    put getManualHeight() into tManualHeight
-   if tManualHeight <> empty then
+   if tManualHeight is not empty then
       put tManualHeight - the height of group "controls" of me - kControlGap - 1 - the height of group "background" into tManualGroupHeight
       set the height of me to tManualGroupHeight
       set the height of the owner of me to tManualGroupHeight
@@ -60,7 +60,7 @@ on editorResize
    put item 2 of tRect + the height of group "controls" of me + kControlGap into item 2 of tRect
    
    local tHeight
-   if tManualHeight <> empty then
+   if tManualHeight is not empty then
       put tManualGroupHeight - kControlGap  into tHeight
    else
       put the formattedHeight of field "htmltext" of me into tHeight

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.textcontents.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.textcontents.behavior.livecodescript
@@ -45,6 +45,14 @@ constant kMaxHeight = 800
 on editorResize
    lock screen
    lock messages
+   local tManualHeight, tManualGroupHeight
+   put getManualHeight() into tManualHeight
+   if tManualHeight <> empty then
+      put tManualHeight - the height of group "controls" of me - kControlGap - 1 - the height of group "background" into tManualGroupHeight
+      set the height of me to tManualGroupHeight
+      set the height of the owner of me to tManualGroupHeight
+   end if
+
    set the topleft of field "rowlabel" of me to the topleft of me
    set the topright of group "controls" of me to the topright of me
    local tRect
@@ -52,8 +60,13 @@ on editorResize
    put item 2 of tRect + the height of group "controls" of me + kControlGap into item 2 of tRect
    
    local tHeight
-   put the formattedHeight of field "htmltext" of me into tHeight
-   put max(tHeight, item 4 of tRect - item 2 of tRect) into tHeight
+   if tManualHeight <> empty then
+      put tManualGroupHeight - kControlGap  into tHeight
+   else
+      put the formattedHeight of field "htmltext" of me into tHeight
+      put max(tHeight, item 4 of tRect - item 2 of tRect) into tHeight
+   end if
+   
    put min(tHeight, kMaxHeight) into tHeight
    put item 2 of tRect + tHeight into item 4 of tRect
    set the rect of field "htmltext" of me to tRect

--- a/notes/bugfix-20701.md
+++ b/notes/bugfix-20701.md
@@ -1,0 +1,1 @@
+# Make manual height of PI consitent, increase value field in Custom Props


### PR DESCRIPTION
Makes setting the height in PI consistent. PI will either use manual height or max height of tab if smaller than manual height.

custom properties now have a field "value" that is larger and increases with increaing the height of PI.

Furthermore it fixes the delay when vScrollbar is on or off for accomodating for vScrollbar regarding right side of controls.