### PR TITLE
[Bug 14079] Ensure one can set subscripts/superscripts more than once

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -8520,7 +8520,9 @@ on ideStyleText pSelectedChunk, pSelectedObject, pIsField, pWhich, pValue
 
          if pWhich is "superscript" then put -4 into tTextShiftAmount
          else put 4 into tTextShiftAmount
-         if the textShift of tTarget is a number then put 0 into tTextShiftAmount
+         if the textShift of tTarget is a number AND the textShift of tTarget is not 0 then 
+            put 0 into tTextShiftAmount
+         end if
 
          set the textShift of tTarget to tTextShiftAmount
          break

--- a/notes/bugfix-14079.md
+++ b/notes/bugfix-14079.md
@@ -1,0 +1,1 @@
+# Ensure subscripts and superscripts can be set more than once 


### PR DESCRIPTION
Previously a non-zero `textShift` was applied to the selectedChunk only if the existing `textShift` was `not a number`. This worked fine in the first attempt where the the existing textShift was empty, but did not work afterwards if the `textShift` had been set to 0 (since 0 _is_ a number).

So we also need to check if the existing textShift is zero.