### PR TITLE
[[ Bug 17476 ]] Use numeric sort for keys in SE variables list

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsevariablespanebehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsevariablespanebehavior.livecodescript
@@ -528,5 +528,6 @@ private command setDefaultsAndCallbacks
    set the cCallbackTarget of tFilter to the long id of me
    set the cPlaceholderText of tFilter to "Search variables..."
    
-   set the pathdelimiter of widget "tree" of me to numToCodepoint(0)
+   set the pathDelimiter of widget "tree" of me to numToCodepoint(0)
+   set the sortType of widget "tree" of me to "numeric"
 end setDefaultsAndCallbacks

--- a/notes/bugfix-17476.md
+++ b/notes/bugfix-17476.md
@@ -1,0 +1,1 @@
+# Use numeric sort for variables/keys in SE variables lists


### PR DESCRIPTION
Made an update to `revsevariablespanebehavior.livecodescript`

In the `setDefaultsAndCallbacks` handler, set the `sortType` for the
tree widget to `numeric`.  With the updated sort logic in the widget
that will have the numeric keys sort at the top of lists but also sort
non-numeric keys alphabetically.