### PR TITLE
[21679] Fix for manual input into tableField

### DIFF
--- a/Toolset/libraries/revtablelibrary.livecodescript
+++ b/Toolset/libraries/revtablelibrary.livecodescript
@@ -504,6 +504,12 @@ on revWriteCellField pObject
   then set the htmltext of field tFieldName to tCurrentView
   else set the text of field tFieldName to tCurrentView
   set the itemDelimiter to tab
+  
+   # Patch for bug 18983
+   if the number of items of line tycell of field tFieldName < txcell then
+      put empty into item txcell of line tycell of field tFieldName
+   end if
+
   put the htmltext of item txcell of line tycell of field tFieldName into tCurrentHtmlText
   if tCurrentHtmltext contains "#9;" then
     put "<p></p>" into tCurrentHtmlText

--- a/notes/bugfix-21679.md
+++ b/notes/bugfix-21679.md
@@ -1,0 +1,1 @@
+# Fix manual input into tableField via edit field


### PR DESCRIPTION
manual input into a tableField via "cellEdit" fails due to a chunking error as described in bug 18983