### PR TITLE
Fix DataGrid cached control error

### DIFF
--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -3233,6 +3233,10 @@ private command _list.DrawCachedControlList pForceRefresh, pCallback, pCallbackC
    local theSequence
    local theTopLeft
    -----
+
+   # If controls haven't been cached yet then exit
+   if sControlOfIndexA is not an array then return empty
+
    put false into noRedrawNeeded
    put empty into theFirstControlHeight
    

--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -5431,7 +5431,7 @@ end uProps
 getprop uProps[pProp]
     if the target is not me then pass uProps
     return the dgProps[pProp] of me
-end uProps[pProp]
+end uProps
 ## end temporary aliases
 
 
@@ -6927,7 +6927,7 @@ getprop dgDataControlOfIndex [pIndex]
         end if
     end if
     return empty
-end dgDataControlOfIndex[pIndex]
+end dgDataControlOfIndex
 
 
 function ColumnControlOfIndex pColumn, pIndex

--- a/notes/bugfix-11295.md
+++ b/notes/bugfix-11295.md
@@ -1,0 +1,1 @@
+# Fix error in DataGrid when form controls are cached, fixed line height is true, and showing the vertical scrollbar is set to auto.


### PR DESCRIPTION
If form controls were cached, fixed line height was true, and showing the vertical scrollbar was set to auto then the DataGrid would attempt to draw itself prior to generating the list of cached controls. This would result in an empty line in the list of controls to draw from. This empty line would then be used in handlers that loop through the controls. Instead of a valid control reference an empty value would be used and an error would be triggered.
