### PR TITLE
[21555] Ensure mobileControlTarget returns the long ID of the target if the target is a DataGrid

### DIFF
--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -324,8 +324,8 @@ private command _CreateMobileScroller
          (_ControlType() is "table" and \
          the dgProps["show hscrollbar"] of me is not false) then
       if sScrollerId is empty or sScrollerId is not among the lines of mobileControls() then
-         mobileControlCreate "scroller"
-         put the result into sScrollerId
+         put the short name of me into sScrollerId
+         mobileControlCreate "scroller", sScrollerId
       end if
       mobileControlSet sScrollerId, "canBounce", "true"
       mobileControlSet sScrollerId, "pagingEnabled", "false"

--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -324,7 +324,7 @@ private command _CreateMobileScroller
          (_ControlType() is "table" and \
          the dgProps["show hscrollbar"] of me is not false) then
       if sScrollerId is empty or sScrollerId is not among the lines of mobileControls() then
-         put the short name of me into sScrollerId
+         put the long id of me into sScrollerId
          mobileControlCreate "scroller", sScrollerId
       end if
       mobileControlSet sScrollerId, "canBounce", "true"

--- a/notes/bugfix-21555.md
+++ b/notes/bugfix-21555.md
@@ -1,0 +1,1 @@
+# Ensure mobileControlTarget() returns the name of the target, if the target is a DataGrid

--- a/notes/bugfix-21555.md
+++ b/notes/bugfix-21555.md
@@ -1,1 +1,1 @@
-# Ensure mobileControlTarget() returns the name of the target, if the target is a DataGrid
+# Ensure mobileControlTarget() returns the long id of the target, if the target is a DataGrid


### PR DESCRIPTION
On mobile, the DG2 has native scrollers automatically. However, in this case `mobileControlTarget` returned the ID of the native scroller. This was problematic because when leaving and then revisiting the card that has the DG2, the ID was changing.

This patch ensures that `mobileControlTarget` will always return the *long ID* of the target, if the target is a DG2. This ensures `mobileControlTarget` returns a unique ID that does not change.