### PR TITLE
[[ Bug 21484 ]] Allow scroll wheel to work in PI text fields

### DIFF
--- a/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
@@ -303,10 +303,6 @@ getProp editorExpandVertical
    return sExpandVertical
 end editorExpandVertical
 
-after openField
-   select the text of the target
-end openField
-
 on rawKeyDown pKeyNum
    -- allow scroll wheel, pgup, & pgdn to scroll the text field
    -- bubble up to the parent if at either limit

--- a/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
+++ b/Toolset/palettes/inspector/behaviors/revinspectoreditorbehavior.livecodescript
@@ -302,3 +302,44 @@ end editorExpandVertical
 getProp editorExpandVertical
    return sExpandVertical
 end editorExpandVertical
+
+after openField
+   select the text of the target
+end openField
+
+on rawKeyDown pKeyNum
+   -- allow scroll wheel, pgup, & pgdn to scroll the text field
+   -- bubble up to the parent if at either limit
+   if the target contains "field" then
+      local tScrollPosition, tScrollAmount, tScrollMax
+      put the vScroll of the target into tScrollPosition
+      put 0 into tScrollAmount
+      switch pKeyNum
+         case "65365"
+            put 45 into tScrollAmount
+            -- fall through
+         case "65309"
+            if tScrollPosition is 0 then pass rawKeyDown
+            add 5 to tScrollAmount
+            put max(0, tScrollPosition - tScrollAmount) into tScrollPosition
+            break
+         case "65366"
+            put 45 into tScrollAmount
+            -- fall through
+         case "65308"
+            add 5 to tScrollAmount
+            put the formattedHeight of the target - \
+                  the height of the target into tScrollMax
+            if tScrollPosition is tScrollMax then pass rawKeyDown
+            put min(tScrollMax, tScrollPosition + tScrollAmount) \
+                  into tScrollPosition
+            break
+         default
+            pass rawKeyDown
+      end switch
+      set the vScroll of the target to tScrollPosition
+   else
+      pass rawKeyDown
+   end if
+end rawKeyDown
+

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -69,6 +69,7 @@ on editorUpdate
       if the result is empty then
          put tKey into field "value" of me
          put item -1 of tPath into field "key" of me
+         select the text of field "key" of me
       else
          put empty into field "key" of me
          put empty into field "value" of me

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -69,7 +69,6 @@ on editorUpdate
       if the result is empty then
          put tKey into field "value" of me
          put item -1 of tPath into field "key" of me
-         select the text of field "key" of me
       else
          put empty into field "key" of me
          put empty into field "value" of me

--- a/notes/bugfix-21484.md
+++ b/notes/bugfix-21484.md
@@ -1,3 +1,1 @@
 # Allow scroll wheel to work in PI text fields
-
-# Automatically select text of fields in PI

--- a/notes/bugfix-21484.md
+++ b/notes/bugfix-21484.md
@@ -1,0 +1,3 @@
+# Allow scroll wheel to work in PI text fields
+
+# Automatically select text of fields in PI


### PR DESCRIPTION
Include a `rawKeyDown` handler in the `revinspectoreditorbehavior` to
intercept pgup/pgdn/scroll wheel messages when inside a text field.  If
the field is not at either limit, then the messages will scroll the text
field.  If at a limit, then the messages will bubble up to the parent card.

Add `openField` handler to select the text of fields.  For the custom
properties behavior, when a key is selected in the tree view widget, then
the corresponding key text will also be selected.