### PR TITLE
refine revinspectorbehavior re manualHeight

### DIFF
--- a/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
+++ b/Toolset/palettes/behaviors/revinspectorbehavior.livecodescript
@@ -4,6 +4,9 @@ constant kMaxLabelSize = 200
 # The inspector data
 local sDataA
 
+# used by manualHeight
+local sStackIsInFront
+
 on setAsBehavior pTarget
    dispatch "setAsBehavior" to revIDEFrameBehavior() with the long id of this me
    set the behavior of pTarget to the long id of this me
@@ -36,6 +39,7 @@ before openStack
    end repeat
    set the stackfiles of me to tStackFiles
    revIDEPopDefaultFolder
+   put true into sStackIsInFront
 end openStack
 
 on resizeInspector
@@ -180,7 +184,8 @@ local sManualHeightOfStack, sNewHeight, sOldHeight
 on inspectorLayoutGroups pGroupList, pForceHeight
    
    # store height of stack when manually resizing
-   if pForceHeight is not true and the mouse is "down" and sNewHeight is not sOldHeight then
+   if pForceHeight is not true and the mouse is "down"  \
+         and sNewHeight is not sOldHeight and the mouseStack is empty and sStackIsInFront then
       put the height of this stack into sManualHeightOfStack
    end if
    
@@ -277,7 +282,11 @@ on inspectorLayoutGroups pGroupList, pForceHeight
    
    local tStackHeight
    if tInspectorHeight is empty then
-      put kInspectorMinHeight into tStackHeight
+      if sManualHeightOfStack is not empty then
+         put sManualHeightOfStack into tStackHeight
+      else
+         put kInspectorMinHeight into tStackHeight
+      end if
    else
       put tInspectorHeight + tMargin into tStackHeight
    end if
@@ -286,11 +295,6 @@ on inspectorLayoutGroups pGroupList, pForceHeight
       set the maxheight of me to 65535
    else
       set the maxheight of me to tStackHeight
-   end if
-   
-   # reset manualHeight if user expands a non-expandable tab to full height
-   if not pForceHeight and not tCanExpand and sManualHeightOfStack is tStackHeight then
-      put empty into sManualHeightOfStack
    end if
    
    -- Make stack smaller rather than go offscreen
@@ -342,6 +346,16 @@ before resizeStack pNewWidth, pNewHeight, pOldWidth, pOldHeight
    put pOldHeight into sOldHeight
    pass resizeStack
 end resizeStack
+
+on resumeStack
+   put true into sStackIsInFront
+   pass resumeStack
+end resumeStack
+
+on suspendStack
+   put false into sStackIsInFront
+   pass suspendStack
+end suspendStack
 
 function getManualHeight
    return sManualHeightOfStack

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -1,6 +1,5 @@
 ﻿script "com.livecode.pi.customprops.behavior"
 local sPropSet, sHilitePath
-constant kWidgetHeight = 150
 
 on editorInitialize
    put empty into sPropSet
@@ -91,9 +90,10 @@ end editorUpdate
 constant kControlGap = 5
 constant kKeyFieldHeight = 21
 constant kLabelFieldHeight = 21
-constant kValueFieldHeight = 63
+constant kValueFieldHeight = 126
 constant kLabelSize = 50
 constant kSetButtonsHeight = 30
+constant kWidgetHeight = 150
 
 on editorResize
    lock screen
@@ -112,12 +112,15 @@ on editorResize
    set the lockLoc of group "Set buttons" of me to true
    send "groupResize kLabelSize, kControlGap" to group "Set buttons" of me
    
+   local tTopGroupHeight
+   put the bottom of group "background" into tTopGroupHeight
+   
    # Use all space not taken by other elements for main array display
-      local tWidgetHeight, tValueHeight
+   local tWidgetHeight, tValueHeight
    put kWidgetHeight into tWidgetHeight
-   put max (the height of this card - ( 12 * kControlGap + kLabelFieldHeight  \
+   put max(the height of this card - ( 7 * kControlGap + kLabelFieldHeight  \
          + kKeyFieldHeight + kValueFieldHeight + kSetButtonsHeight  \
-         + tWidgetHeight), kValueFieldHeight) into tValueHeight
+         + tWidgetHeight + tTopGroupHeight), 0) into tValueHeight
 
    set the height of widget 1 of me to tWidgetHeight
    set the width of widget 1 of me to the width of me

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -118,7 +118,7 @@ on editorResize
    # Use all space not taken by other elements for main array display
    local tWidgetHeight, tValueHeight
    put kWidgetHeight into tWidgetHeight
-   put max(the height of this card - ( 7 * kControlGap + kLabelFieldHeight  \
+   put max(the height of this card - ( 6 * kControlGap + kLabelFieldHeight  \
          + kKeyFieldHeight + kValueFieldHeight + kSetButtonsHeight  \
          + tWidgetHeight + tTopGroupHeight), 0) into tValueHeight
 


### PR DESCRIPTION
Make sure manual height is not accidentally set when clicking in a stacks title bar by making sure PI is activated (resumed) when changing manual height.
Remove option to cancel manualHeight by changing height of e.g. "text" to smaler and then full height.