### PR TITLE
[21969] Reset the templategroup before creating the tools palette

### DIFF
--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -1,4 +1,4 @@
-﻿script "revTools"
+﻿script "revTools" with behavior "revPaletteBehavior"
 constant BLOCK_SIZE = 20
 
 constant kToolsColumnCountDefault = 3
@@ -170,6 +170,7 @@ on generatePalette
    repeat while there is a group "contents"
       delete group "contents"
    end repeat
+   reset the templateGroup
    create group "contents"
    
    # Clear the error group

--- a/Toolset/palettes/tools/revtools.livecodescript
+++ b/Toolset/palettes/tools/revtools.livecodescript
@@ -1,4 +1,4 @@
-﻿script "revTools" with behavior "revPaletteBehavior"
+﻿script "revTools"
 constant BLOCK_SIZE = 20
 
 constant kToolsColumnCountDefault = 3

--- a/notes/bugfix-21969.md
+++ b/notes/bugfix-21969.md
@@ -1,0 +1,1 @@
+# Ensure the templategroup is reset before creating the tools palette


### PR DESCRIPTION
submitted on behalf of @BerndN 

Problem: If a stack does stuff to the `templateGroup` on `preopenstack` and you open this stack by dragging the .livecode file onto the LC dock icon while LC is not open, then the Tools palette is affected by the changes of the templateGroup.

Resolution: Reset the templateGroup before creating groups in the Tools palette