### PR TITLE
[[ Bug ]] Add missing layerMode to inspector

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.CurveGraphic.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.CurveGraphic.tsv
@@ -17,7 +17,7 @@ dashes
 startArrow							false					
 endArrow							false					
 points												
-layerMode							Static	Static,Dynamic,Scrolling				
+layerMode												
 behavior							empty	long id				
 foregroundColor						Border fill						
 foregroundPattern						Border fill						

--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Group.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Group.tsv
@@ -25,7 +25,7 @@ cantDelete							false
 sharedBehavior							false					
 backgroundBehavior							false					
 boundingRect												
-layerMode												
+layerMode								Static,Dynamic,Scrolling,Container				
 behavior												
 foregroundColor												
 foregroundPattern												

--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.tsv
@@ -95,7 +95,7 @@ innerShadow	Inner shadow	Effects	com.livecode.pi.graphicEffect	true	false			popu
 kind	Kind	Basic	com.livecode.pi.string	true	true		no_default
 label	Label	Basic	com.livecode.pi.text	true	false			
 layer	Layer	Position	com.livecode.pi.integer	true	false		no_default			1		1
-layerMode	Layer mode	Advanced	com.livecode.pi.enum	true	false		Static	Static,Dynamic,Scrolling				
+layerMode	Layer mode	Advanced	com.livecode.pi.enum	true	false		Static	Static,Dynamic				
 left::revIDESetRectProperty	Left	Position	com.livecode.pi.integer	true	false		no_default					1
 lineInc	Scroll distance on arrow click	Basic	com.livecode.pi.number	true	false		512	
 lineSize	Line thickness	Basic	com.livecode.pi.number	true	false		1	


### PR DESCRIPTION
This patch adds the missing container layerMode to the inspector in the IDE. It also
ensures that the options for layerMode only show the values that are appropriate for
the object being inspected. All controls show `Static` and `Dynamic` while groups
also show `Scrolling` and `Container`.