### PR TITLE
[[ Bug 22124 ]] Replace the content of a file property editor with dr…

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.file.behavior.livecodescript
@@ -61,3 +61,18 @@ on mouseUp pButton
       end if
    end if
 end mouseUp
+
+on dragEnter
+   if the dragData["files"] is empty then
+      pass dragEnter
+   end if
+   set the dragAction to "link"
+end dragEnter
+
+on dragDrop
+   if the dragData["files"] is empty then
+      pass dragDrop
+   end if
+   set the text of field 1 of me to line 1 of the dragData["files"]
+   valueChanged
+end dragDrop

--- a/notes/bugfix-22124.md
+++ b/notes/bugfix-22124.md
@@ -1,0 +1,1 @@
+# Replace content of file property editors when a file is dropped onto the field


### PR DESCRIPTION
…opped files

This patch fixes an issue where the file property editor was inserting drag and dropped file
paths rather than replacing the entire content of the field.