### PR TITLE
[[ Bug 22137 ]] Fix conditional breakpoint evaluation

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -2455,6 +2455,7 @@ on traceBreak pHandler, pLine
       set the traceStack to the short name of __TargetStack(the long id of the target)
       __UpdateScriptEditor tTarget, pHandler, pLine, "debug"
    else
+      delete variable sLastBreakInfo
       set the traceReturn to true
    end if
 end traceBreak

--- a/notes/bugfix-22137.md
+++ b/notes/bugfix-22137.md
@@ -1,0 +1,1 @@
+# Fix issue causing conditional breakpoints in repeat loops to only be evaluated once


### PR DESCRIPTION
This patch ensures that conditional breakpoints that evaluate to false are reevaluated
if the same breakpoint is encountered again. For example, if a conditional breakpoint
is in a repeat loop it should be evaluated each iteration. A previous patch indended to
ensure that errors encountered while debugging a previous event were not re-entered
caused conditional breakpoints to not re-evaluate each iteration if no other breakpoint
was encountered.