### PR TITLE
fix for bug report 22297

### DIFF
--- a/Toolset/palettes/inspector/revinspectortemplate.livecodescript
+++ b/Toolset/palettes/inspector/revinspectortemplate.livecodescript
@@ -29,8 +29,8 @@ end openStack
 
 on closeStack
    ## Unsubscribe from all messages
-   revIDEUnsubscribe "idePreferenceChanged:idePropertyInspector_labels"
-   
+   revIDEUnsubscribeAll
+
    set the cSelectedObjects of me to empty
    
    # Unlock

--- a/Toolset/palettes/inspector/revinspectortemplate.livecodescript
+++ b/Toolset/palettes/inspector/revinspectortemplate.livecodescript
@@ -29,7 +29,7 @@ end openStack
 
 on closeStack
    ## Unsubscribe from all messages
-   revIDEUnsubscribeAll
+   revIDEUnsubscribeAll the long id of me
 
    set the cSelectedObjects of me to empty
    

--- a/Toolset/palettes/inspector/revinspectortemplate.livecodescript
+++ b/Toolset/palettes/inspector/revinspectortemplate.livecodescript
@@ -29,6 +29,7 @@ end openStack
 
 on closeStack
    ## Unsubscribe from all messages
+   revIDEUnsubscribeAll
    revIDEUnsubscribeAll the long id of me
 
    set the cSelectedObjects of me to empty


### PR DESCRIPTION
This patches the property inspector to do a revUnsubscribeAll on closing.

The problem reported in bug report 22297 being that the property inspector subscribes to the idePropertyChanged message but doesn't unsubscribe from that message if the selected object hasn't changed, as for example if you try to edit the script of an object after having looked at its properties. This will trigger a recurring error display and require closing the IDE.