### PR TITLE
[Bug 22199] Prevent hiliting field "value" when clicking

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -401,3 +401,9 @@ function arrayKeysAreNumeric pArrayA
    end repeat
    return true
 end arrayKeysAreNumeric
+
+## bug 22199 prevent hiliting field "Value" when clicking to enter text
+after openField
+   ## block "after openfield" message in stack "revInspectorEditorBehavior"
+end openField
+

--- a/notes/bugfix-22199.md
+++ b/notes/bugfix-22199.md
@@ -1,0 +1,1 @@
+# Prevent hiliting field "value" of PI "custom" when clicking


### PR DESCRIPTION
Blocking "after openField" to reach stack "revInspectorEditorBehavior" avoids hiliting of field "value" when clicking. Thus preventing an unwanted scroll.