### PR TITLE
Feature pb hide scriptonly stacks

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -2113,7 +2113,8 @@ private function __ideFilterObjectIDListWithPreference pObjectList
    return __ideRemoveIDEObjectIDsFromList(pObjectList)
 end __ideFilterObjectIDListWithPreference
 
-function revIDEStacksForDataView pIndex
+# [[ 2019.09.06 mdw Allow hiding script-only stacks ]]
+function revIDEStacksForDataView pIndex, pHideScriptOnlyStacks
    local tSortType, tSortOrder
    revIDEGetPBSortPreferences "pb_stackSort", tSortType, tSortOrder
    
@@ -2121,6 +2122,16 @@ function revIDEStacksForDataView pIndex
    local tMainStacks, tInvertedMainStacks
    
    put ideMainStacks() into tMainStacks
+   if pHideScriptOnlyStacks is true then
+      local tStacks
+      repeat for each line tStack in tMainStacks
+         if "livecodescript" is in the long id of stack tStack then
+         else
+           put tStack & cr after tStacks
+         end if
+      end repeat
+      put tStacks into tMainStacks
+   end if
    if tSortType is "name" then
       if tSortOrder is "ascending" then
          sort lines of tMainStacks ascending

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -80,7 +80,8 @@ on preOpenStack
    
    # Preferences
    addFrameItem "pb_indicator", "header", "preference", "Object type indicator", "enum","Text,Icon", "preferenceChanged", the long id of me   
-   addFrameItem "pb_sections", "header", "preference", "Show Sections", "set","Front Scripts,Stacks,Back Scripts,Stacks in use", "preferenceChanged", the long id of me
+# [[ 2019.09.06 mdw Allow hiding script-only stacks ]]
+   addFrameItem "pb_sections", "header", "preference", "Show Sections", "set","Front Scripts,Stacks,Back Scripts,Stacks in use,Script-Only Stacks", "preferenceChanged", the long id of me
    addFrameItem "pb_stackSort","header","preference","Order stacks by","enum","Name - ascending,Name - descending,Layer - ascending,Layer - descending","preferenceChanged",the long id of me
    addFrameItem "pb_cardSort","header","preference","Order cards by","enum","Name - ascending,Name - descending,Layer - ascending,Layer - descending","preferenceChanged",the long id of me
    addFrameItem "pb_controlSort","header","preference","Order controls by","enum","Name - ascending,Name - descending,Layer - ascending,Layer - descending","preferenceChanged",the long id of me
@@ -446,7 +447,7 @@ command buildProjectView pRememberExpansion
    sort lines of tOldExpandedControls by item 2 of each
    
    repeat with x  = 1 to the number of items in tSections
-      if item x of tSections is not among the items of "Front Scripts,Stacks,Back Scripts,Stacks in use" then
+      if item x of tSections is not among the items of "Front Scripts,Stacks,Back Scripts,Stacks in use,Script-Only Stacks" then
          delete item x of tSections
       end if
    end repeat
@@ -466,8 +467,9 @@ command buildProjectView pRememberExpansion
       end if
    end if
    
+# [[ 2019.09.06 mdw Allow hiding script-only stacks ]]
    if "Stacks" is among the items of tSections then
-      put revIDEStacksForDataView(tIndex) into tStacks
+      put revIDEStacksForDataView(tIndex, "Script-Only Stacks" is not among the items of tSections) into tStacks
    end if
    
    if "Back Scripts" is among the items of tSections then


### PR DESCRIPTION
This provides a new section in the Project Browser to show or hide script-only stacks. Viewing IDE stacks presents an ever-growing list of library stacks, which often makes it a chore to locate the stack you're interested in. Hiding some of the stacks helps this process. It's not ideal, as there may be other stacks to show or hide, but it's a start and certainly makes my life easier not having to wade through all the Navigator behavior scripts.