### PR TITLE
don't make invisible windows visible on linux

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9939,10 +9939,12 @@ on revIDESendCurrentWindowToBack
    then put tWindows2 & return & tWindows into tWindows
    
    repeat for each line l in tWindows
-      -- delete char 1 to 2 of l
-      if the mode of stack l is 1 or the mode of stack l is 2 then toplevel l
-      else if the mode of stack l is 3 then modeless l
-      show stack l
+    -- [[ 2019.09.06 mdw ]] don't make invisible windows visible on linux
+      if the visible of stack l then
+        if the mode of stack l is 1 or the mode of stack l is 2 then toplevel l
+        else if the mode of stack l is 3 then modeless l
+        show stack l
+      end if
    end repeat
    unlock messages
 end revIDESendCurrentWindowToBack


### PR DESCRIPTION
I find I often hit command-quote instead of shift-quote on the keyboard, which has the effect from the menubar of sending the current stack to the back. On linux this also makes any invisible stacks (I have three invisible plugin stacks hiding in the background) visible and forces me to close each one to restore my desktop. Don't know what happens on Windows, but on OSX this isn't a problem. At any rate, this patch fixes the problem by simply ignoring stacks with their visible set to false.