### PR TITLE
Add a refresh button footer to refresh the view

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -140,7 +140,7 @@ private command doRefreshProjectView
    repeat for each line tStack in tStacks
       put the cardIDs of stack tStack into tCards
       repeat for each line tCardID in tCards
-         refreshChildren the long name of card id tCardID of stack tStack
+         refreshChildren the long id of card id tCardID of stack tStack
       end repeat
    end repeat
    

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -133,7 +133,7 @@ on preOpenStack
 end preOpenStack
 
 on doRefreshProjectView
-    local tStacks, tCards
+    local tStacks, tCards, tControls
 
     lock screen
     put the openstacks into tStacks
@@ -142,6 +142,13 @@ on doRefreshProjectView
         repeat for each line tCardID in tCards
             refreshChildren the long name of card id tCardID of stack tStack
         end repeat
+    end repeat
+
+    put the controlIDs of card "list" of stack "revIDEprojectbrowser" into tControls
+    repeat for each line tGroup in tControls
+        if the short name of control id tGroup is "containerRow" then
+            set the visible of control id tGroup of card "list" of stack "revIDEprojectbrowser" to true
+        end if
     end repeat
     refreshProjectView
     unlock screen

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -76,7 +76,7 @@ on preOpenStack
    addFrameItem "groupControl","footer", "action", "Group controls", "folder open alt", "","groupControls", the long id of me
    addFrameItem "cloneControl","footer", "action", "Clone control", "files alt", "","cloneControls", the long id of me
    addFrameItem "deleteControl","footer", "action", "Delete control", "trash", "","deleteControls", the long id of me
-   addFrameItem "refreshControl","footer", "action", "Refresh display", "cog", "","refreshProjectView", the long id of me
+   addFrameItem "refreshControl","footer", "action", "Refresh display", "refresh", "","refreshProjectView", the long id of me
 
    
    # Preferences

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -76,7 +76,7 @@ on preOpenStack
    addFrameItem "groupControl","footer", "action", "Group controls", "folder open alt", "","groupControls", the long id of me
    addFrameItem "cloneControl","footer", "action", "Clone control", "files alt", "","cloneControls", the long id of me
    addFrameItem "deleteControl","footer", "action", "Delete control", "trash", "","deleteControls", the long id of me
-   addFrameItem "refreshControl","footer", "action", "Refresh display", "refresh", "","doRefreshProjectView", the long id of me
+   addFrameItem "refreshControl","footer", "action", "Refresh display", "refresh", "","panic", the long id of me
 
    
    # Preferences
@@ -132,27 +132,26 @@ on preOpenStack
    ideSelectedObjectChanged
 end preOpenStack
 
-on doRefreshProjectView
-    local tStacks, tCards, tControls
-
-    lock screen
-    put the openstacks into tStacks
-    repeat for each line tStack in tStacks
-        put the cardIDs of stack tStack into tCards
-        repeat for each line tCardID in tCards
-            refreshChildren the long name of card id tCardID of stack tStack
-        end repeat
-    end repeat
-
-    put the controlIDs of card "list" of stack "revIDEprojectbrowser" into tControls
-    repeat for each line tGroup in tControls
-        if the short name of control id tGroup is "containerRow" then
-            set the visible of control id tGroup of card "list" of stack "revIDEprojectbrowser" to true
-        end if
-    end repeat
-    refreshProjectView
-    unlock screen
+private command doRefreshProjectView
+   local tStacks, tCards
+   
+   lock screen
+   put the openstacks into tStacks
+   repeat for each line tStack in tStacks
+      put the cardIDs of stack tStack into tCards
+      repeat for each line tCardID in tCards
+         refreshChildren the long name of card id tCardID of stack tStack
+      end repeat
+   end repeat
+   
+   refreshProjectView
+   unlock screen
 end doRefreshProjectView
+ 
+on panic
+   dispatch "ResetView" to control "dvList" of card "list" of this stack
+   doRefreshProjectView
+end panic
 
 on resizeStack
    lock screen

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -142,7 +142,6 @@ private command doRefreshProjectView
 end doRefreshProjectView
  
 on panic
-   dispatch "ResetView" to control "dvList" of card "list" of this stack
    doRefreshProjectView
 end panic
 

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -136,15 +136,8 @@ private command doRefreshProjectView
    local tStacks, tCards
    
    lock screen
-   put the openstacks into tStacks
-   repeat for each line tStack in tStacks
-      put the cardIDs of stack tStack into tCards
-      repeat for each line tCardID in tCards
-         refreshChildren the long id of card id tCardID of stack tStack
-      end repeat
-   end repeat
-   
-   refreshProjectView
+   setUpProjectView # bn's implementation
+   buildProjectView true
    unlock screen
 end doRefreshProjectView
  

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -76,7 +76,8 @@ on preOpenStack
    addFrameItem "groupControl","footer", "action", "Group controls", "folder open alt", "","groupControls", the long id of me
    addFrameItem "cloneControl","footer", "action", "Clone control", "files alt", "","cloneControls", the long id of me
    addFrameItem "deleteControl","footer", "action", "Delete control", "trash", "","deleteControls", the long id of me
-   
+   addFrameItem "refreshControl","footer", "action", "Refresh display", "cog", "","refreshProjectView", the long id of me
+
    
    # Preferences
    addFrameItem "pb_indicator", "header", "preference", "Object type indicator", "enum","Text,Icon", "preferenceChanged", the long id of me   

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -76,7 +76,7 @@ on preOpenStack
    addFrameItem "groupControl","footer", "action", "Group controls", "folder open alt", "","groupControls", the long id of me
    addFrameItem "cloneControl","footer", "action", "Clone control", "files alt", "","cloneControls", the long id of me
    addFrameItem "deleteControl","footer", "action", "Delete control", "trash", "","deleteControls", the long id of me
-   addFrameItem "refreshControl","footer", "action", "Refresh display", "refresh", "","refreshProjectView", the long id of me
+   addFrameItem "refreshControl","footer", "action", "Refresh display", "refresh", "","doRefreshProjectView", the long id of me
 
    
    # Preferences
@@ -131,6 +131,21 @@ on preOpenStack
    set the rect of group "content" of card 1 of me to the contentRect of me
    ideSelectedObjectChanged
 end preOpenStack
+
+on doRefreshProjectView
+    local tStacks, tCards
+
+    lock screen
+    put the openstacks into tStacks
+    repeat for each line tStack in tStacks
+        put the cardIDs of stack tStack into tCards
+        repeat for each line tCardID in tCards
+            refreshChildren the long name of card id tCardID of stack tStack
+        end repeat
+    end repeat
+    refreshProjectView
+    unlock screen
+end doRefreshProjectView
 
 on resizeStack
    lock screen

--- a/notes/bugfix-17916.md
+++ b/notes/bugfix-17916.md
@@ -1,0 +1,2 @@
+# Add a refresh display button to the Project Browser
+


### PR DESCRIPTION
The Project Browser annoyingly loses its content regularly. This patch adds a button to the toolbar to refresh the content when it gets messed up. I reused the cog icon because I couldn't figure out how to add a new one or where the current ones come from. Unlikely to be confusing though.