### PR TITLE
Place newly created stacks at center of screen

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2762,6 +2762,10 @@ on revMenubarFileMenuPick pWhich
                else
                   revIDEActionNewMainstack tStackType
                end if
+                # [[ 2019.09.27 mdw center new stacks on linux ]]
+               local tStack
+               put the result into tStack
+               set the location of tStack to the screenloc
                break
             case "Open Recent File"
                local tRecentStack


### PR DESCRIPTION
Currently new stack creation places the stack in the upper left corner of the screen.

This patch places it at the center of the screen instead.