### PR TITLE
Allow "passed" dispatch commands in menu revHooks

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
@@ -611,7 +611,8 @@ private function modifyMenu pMenuName, pMenu
    
    local tModifiedMenu
    dispatch "revHookBuildScriptEditorMenu" to me with pMenuName, pMenu, tModifiedMenu
-   if it is not "handled" then
+# [[ 2019.09.16 mdw allow both handled and passed responses ]]
+   if it is "unhandled" then
       put pMenu into tModifiedMenu
    end if
    return tModifiedMenu
@@ -619,5 +620,6 @@ end modifyMenu
 
 private function dispatchMenuPick pMenuName, pWhich
    dispatch "revHookScriptEditorMenuPick" to me with pMenuName, pWhich
-   return it is "handled"
+# [[ 2019.09.16 mdw allow both handled and passed responses ]]
+   return it is not "unhandled"
 end dispatchMenuPick


### PR DESCRIPTION
Dispatch commands can return one of three states in the "it" variable: handled, unhandled, and passed.
This patch allows a return state of "passed" as well as "handled" to allow for chained revHook... handlers to coexist in menuItems of the menubar. Currently my Refactor plugin is, to my knowledge, the only thing using the menu revHooks, but this patch will make it easier for others to modify or add to the existing menus without having to do extra coding to accomodate others.