### PR TITLE
Allow the se contextual menu to find handlers in quotes

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2342,6 +2342,8 @@ function getClickText
    --   if tTo < tFrom then
    getCaretToken true
    put the result into tText
+# MDW 2019.10.06 [[ fix_find_definition ]] allow quoted handler names, as in "dispatch" and "send"
+   replace quote with empty in tText
    --else
    --   put char tFrom to tTo of textGetScript() into tText
    --end if

--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -1024,6 +1024,8 @@ local sDefinitionMatches
 private command prepareContextMenu
    local tSelectedText
    put getClickText() into tSelectedText
+# MDW 2019.10.06 [[ fix_find_definition ]] allow quoted handler names, as in "dispatch" and "send"
+   replace quote with empty in tSelectedText
    
    local tLine, tSelectedHandler
    put word 2 of the selectedLine into tLine


### PR DESCRIPTION
The script editor contextual menu can't find handlers in quotes as in "dispatch" and "send" commands. This keeps the "go to definition" link disabled even though it should be a valid link.
This patch removes the quotes to allow "go to definition" to work properly.