### PR TITLE
[[ Bug 22211 ]] Remove unnecessary 'unlock cursor' in ideMouseMove

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -3335,8 +3335,6 @@ on ideMouseMove pX, pY, pTarget
       else
          unlock cursor
       end if
-   else
-      unlock cursor
    end if
 end ideMouseMove
 

--- a/notes/bugfix-22211.md
+++ b/notes/bugfix-22211.md
@@ -1,0 +1,1 @@
+# Ensure lock cursor does not break when the pointer tool is selected


### PR DESCRIPTION
This patch removes a seemingly unnecessary `unlock cursor` in the IDE's
mouseMove event handler (`ideMouseMove`).

The IDE intercepts mouseMove so that it can update the resize cursor
used when the mouse is over the relevant selection handlers. It does this
by locking the cursor in this case and then changing the cursor
appropriately; unlocking the cursor when there is a selected object and
the mouse is not over a selection handle.

Previously it would also unlock the cursor if pointer tool was in effect and
there was no selected object which (because the handler is executed in
time after any user handlers) would undo any user use of `lock cursor`.

Closes https://quality.livecode.com/show_bug.cgi?id=22211