### PR TITLE
[[ Bug 13085 ]] Add new paragraph props to field inspector

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Field.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Field.tsv
@@ -27,6 +27,10 @@ multipleHilites							false
 nonContiguousHilites							false					
 toggleHilites							false					
 firstIndent							0					
+leftIndent							0					
+rightIndent							0					
+spaceAbove							0					
+spaceBelow							0					
 dontSearch							false					
 layerMode												
 behavior												

--- a/Toolset/resources/supporting_files/property_definitions/propertyInfo.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/propertyInfo.tsv
@@ -97,6 +97,7 @@ label	Label	Basic	com.livecode.pi.text	true	false
 layer	Layer	Position	com.livecode.pi.integer	true	false		no_default			1		1
 layerMode	Layer mode	Advanced	com.livecode.pi.enum	true	false		Static	Static,Dynamic				
 left::revIDESetRectProperty	Left	Position	com.livecode.pi.integer	true	false		no_default					1
+leftIndent	Left indent	Basic	com.livecode.pi.integer	true	false		0					1
 lineInc	Scroll distance on arrow click	Basic	com.livecode.pi.number	true	false		512	
 lineSize	Line thickness	Basic	com.livecode.pi.number	true	false		1	
 linkColor	Link color	Colors	com.livecode.pi.color	true	false			
@@ -146,6 +147,7 @@ repeatCount	Repeat	Basic	com.livecode.pi.integer	true	false					0		1
 resizable	Resizable	Position	com.livecode.pi.boolean	true	false		true	
 resizeQuality	Resize quality	Basic	com.livecode.pi.enum	true	false		normal	best,good,normal	
 right::revIDESetRectProperty	Right	Position	com.livecode.pi.integer	true	false		no_default					1
+rightIndent	Right indent	Basic	com.livecode.pi.integer	true	false		0					1
 roundRadius	Corner radius	Basic	com.livecode.pi.number	true	false							
 scaleFactor	Scale factor	Basic	com.livecode.pi.number	true	false							
 scrollbarWidth	Scrollbar width	Basic	com.livecode.pi.enum	true	false		16	12,16,20				
@@ -166,6 +168,8 @@ showName	Show name	Basic	com.livecode.pi.boolean	true	false
 showSelection	Hilite selection	Basic	com.livecode.pi.boolean	true	false			
 showValue	Show value	Basic	com.livecode.pi.boolean	true	false		false			
 size	Size in bytes	Basic	com.livecode.pi.integer	true	true
+spaceAbove	Space above	Basic	com.livecode.pi.integer	true	false		0					1
+spaceBelow	Space below	Basic	com.livecode.pi.integer	true	false		0					1
 stackFiles::revIDESetStackFilesProperty	Stack files	Stack Files	com.livecode.pi.stackfiles	true	false			
 startAngle	Start	Basic	com.livecode.pi.number	true	false		0			0	360	1
 startArrow	Start arrow	Basic	com.livecode.pi.boolean	true	false			


### PR DESCRIPTION
This patch adds `leftIndent`, `rightIndent`, `spaceAbove` and `spaceBelow` to
the field inspector.

Depends on https://github.com/livecode/livecode/pull/7195