### PR TITLE
[22205] Ensure the check for IDE stacks is accurate

### DIFF
--- a/Toolset/libraries/revcommonlibrary.livecodescript
+++ b/Toolset/libraries/revcommonlibrary.livecodescript
@@ -464,8 +464,6 @@ function revStackNameIsIDEStack pStackName
       return true
    else if pStackName begins with "com.livecode." then
       return true
-   else if pStackName is among the lines of revInternal__ListLoadedLibraries() then
-      return true
    else
       return pStackName begins with "rev"
    end if   

--- a/Toolset/libraries/revinitialisationlibrary.livecodescript
+++ b/Toolset/libraries/revinitialisationlibrary.livecodescript
@@ -68,6 +68,7 @@ command revInternal__LoadIfLibrary pLibrary
       else
          throw "not a library"
       end if
+      set the _ideoverride of stack pLibrary to true
       send tMsg to stack pLibrary
       local tStackName
       put the name of stack pLibrary into tStackName

--- a/notes/bugfix-22205.md
+++ b/notes/bugfix-22205.md
@@ -1,0 +1,1 @@
+# Ensure user stacks that have library names, e.g. "drawing", "diff" etc are not treated as IDE stacks


### PR DESCRIPTION
Closes [bug 22205](https://quality.livecode.com/show_bug.cgi?id=22205)

This patch ensures that user stacks with names similar to the leaf name of IDE library stacks (e.g. "drawing", "diff" etc) are no longer treated as IDE stacks. The check if the stack name is among the lines of `revInternal__ListLoadedLibraries()` was removed, as all the stacks included in this list either already have their `_ideoverride` set to true, or begin with "rev". The only exception to this is `tsNetLibURL`, so for this reason its `_ideoverride` property is set when this stack is loaded (i.e. in `revInternal__LoadIfLibrary`)