### PR TITLE
Fix delete watched variable

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -1139,12 +1139,12 @@ end revDebuggerAddWatch
 #   pVariable : the name of the variable being watched
 # Description
 #   Removes the specified watch, deactivating it first.
-command revDebuggerRemoveWatch pObject, pHandler, pVariable
+command revDebuggerRemoveWatch pObject, pHandler, pVariable, pCondition
    # Deactivate the watch then remove it from the object
-   revDebuggerDeactivateWatch pObject, pHandler, pVariable
+   revDebuggerDeactivateWatch pObject, pHandler, pVariable, pCondition
    
    local tWatch
-   put __BuildWatchLineFromDetails(pObject, pHandler, pVariable) into tWatch
+   put __BuildWatchLineFromDetails(pObject, pHandler, pVariable, pCondition) into tWatch
    
    local tStoredWatches
    put __GetWatchInformation(pObject, "watches") into tStoredWatches
@@ -1240,7 +1240,7 @@ end __GetWatchInformation
 #   pVariable : the name of the varaiable being watched
 # Description
 #   Deactivates the specified watch, by removing it from the watchedVariables.
-command revDebuggerDeactivateWatch pObject, pHandler, pVariable
+command revDebuggerDeactivateWatch pObject, pHandler, pVariable, pCondition
    --   local tWatch, tDataStore, tMetadataType
    --   if pObject is empty then
    --      put empty & comma & empty & comma & pVariable into tWatch
@@ -1255,7 +1255,7 @@ command revDebuggerDeactivateWatch pObject, pHandler, pVariable
    put __GetWatchInformation(pObject, "watches") into tStackWatches
    
    local tWatch
-   put __BuildWatchLineFromDetails(pObject, pHandler, pVariable) into tWatch
+   put __BuildWatchLineFromDetails(pObject, pHandler, pVariable, pCondition) into tWatch
    
    local tStackLineNumber
    put __WatchOffset(tWatch, tStackWatches) into tStackLineNumber
@@ -1542,11 +1542,11 @@ end __BreakpointOffset
 #   pWatches : the list of watches to search in
 private function __Watchoffset pWatch, pWatches
    local tMatchString
-   if the last char of pWatch is not comma then
-      put pWatch & comma into tMatchString
-   else
+   --if the last char of pWatch is not comma then
+      --put pWatch & comma into tMatchString
+   --else
       put pWatch into tMatchString
-   end if
+   --end if
    return lineOffset(tMatchString, pWatches)
 end __Watchoffset
 

--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -1139,6 +1139,7 @@ end revDebuggerAddWatch
 #   pVariable : the name of the variable being watched
 # Description
 #   Removes the specified watch, deactivating it first.
+# 2019-10-27 MDW [[ fix_delete_watched_variable ]] added pCondition
 command revDebuggerRemoveWatch pObject, pHandler, pVariable, pCondition
    # Deactivate the watch then remove it from the object
    revDebuggerDeactivateWatch pObject, pHandler, pVariable, pCondition
@@ -1240,6 +1241,7 @@ end __GetWatchInformation
 #   pVariable : the name of the varaiable being watched
 # Description
 #   Deactivates the specified watch, by removing it from the watchedVariables.
+# 2019-10-27 MDW [[ fix_delete_watched_variable ]] added pCondition
 command revDebuggerDeactivateWatch pObject, pHandler, pVariable, pCondition
    --   local tWatch, tDataStore, tMetadataType
    --   if pObject is empty then
@@ -1542,11 +1544,9 @@ end __BreakpointOffset
 #   pWatches : the list of watches to search in
 private function __Watchoffset pWatch, pWatches
    local tMatchString
-   --if the last char of pWatch is not comma then
-      --put pWatch & comma into tMatchString
-   --else
-      put pWatch into tMatchString
-   --end if
+
+# 2019-10-27 MDW [[ fix_delete_watched_variable ]] no trailing comma is for watched variables
+   put pWatch into tMatchString
    return lineOffset(tMatchString, pWatches)
 end __Watchoffset
 

--- a/Toolset/palettes/script editor/behaviors/revsebreakpointpanebehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsebreakpointpanebehavior.livecodescript
@@ -461,7 +461,7 @@ on menuPick pItemName
             if the cType of sSelectedItem is "breakpoint" then
                revDebuggerRemoveBreakpoint the cObject of sSelectedItem, the cLine of sSelectedItem
             else
-               revDebuggerRemoveWatch the cObject of sSelectedItem, the cHandler of sSelectedItem, the cVariable of sSelectedItem
+               revDebuggerRemoveWatch the cObject of sSelectedItem, the cHandler of sSelectedItem, the cVariable of sSelectedItem, the cCondition of sSelectedItem
             end if
          end if
       break

--- a/Toolset/palettes/script editor/behaviors/revsebreakpointpanebehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsebreakpointpanebehavior.livecodescript
@@ -439,6 +439,7 @@ on mouseDown pButtonNumber
    pass mouseDown
 end mouseDown
 
+# 2019-10-27 MDW [[ fix_delete_watched_variable ]] added pCondition
 on menuPick pItemName
    if the short name of the target is not "Breakpoint Context Menu" then
       pass menuPick


### PR DESCRIPTION
Attempting to delete watched variables from the script editor isn't currently working. The code seems to be cut-and-pasted from the breakpoints code, and a few tweaks (adding the watched condition...) are necessary to allow editing and deleting watched variables properly from the SE.