### PR TITLE
[[ Deployment Docs ]] Make sections easier to find continued.

### DIFF
--- a/Documentation/guides/Deploying Your Application.md
+++ b/Documentation/guides/Deploying Your Application.md
@@ -422,7 +422,7 @@ Related lessons:
 * [LiveCode and Android Studio](http://lessons.livecode.com/m/4069/l/985962-livecode-and-android-studio)
 * [The Basics: How do I Create Hello World on Android?](http://lessons.livecode.com/m/4069/l/27733-the-basics-how-do-i-create-hello-world-on-android)
 
-#### HTML5 Deployment
+## HTML5 Deployment
 
 ![](images/standalone-settings-html5.png)
 

--- a/Documentation/guides/Deploying Your Application.md
+++ b/Documentation/guides/Deploying Your Application.md
@@ -51,7 +51,7 @@ Deploying an app to standalone is straightforward:
 
 Your application will be packaged up and placed in the selected output folder.
 
-### Standalone Applications Settings
+## Standalone Applications Settings
 
 The Standalone Applications Setting dialog allows you to create settings for your 
 standalone application. This dialog can be found in the File menu. The settings you enter 
@@ -63,7 +63,7 @@ Related lessons:
 
 * [The Standalone Application Settings](http://lessons.livecode.com/m/4603/l/685074-the-standalone-application-settings)
 
-#### General Settings
+## General Settings
 
 ![](images/standalone-settings-general.png)
 
@@ -196,7 +196,7 @@ The following database drivers are available by default:
 - SQLite
 - PostgreSQL
 
-#### Mac Deployment
+## Mac Deployment
 
 ![](images/standalone-settings-mac.png)
 
@@ -220,7 +220,7 @@ Related lessons:
 
 * [Signing and Uploading apps to the Mac App Store](http://lessons.livecode.com/m/4071/l/876834-signing-and-uploading-apps-to-the-mac-app-store)
 
-#### Windows Deployment
+## Windows Deployment
 
 ![](images/standalone-settings-windows.png)
 
@@ -235,7 +235,7 @@ Figure 6 – Standalone Settings – Windows
 | **Version information**        | The version information to be stored as part of your application and displayed in the Windows property inspector and dialogs.                                                                                                                                                    |
 | **UAC Execution Level**        | Select the user account control level that applies to your application. For more information, consult [MSDN](https://msdn.microsoft.com/en-us/library/bb384608.aspx)                                                                                                             |
 
-#### Linux Deployment
+## Linux Deployment
 
 ![](images/standalone-settings-linux.png)
 
@@ -247,7 +247,7 @@ Figure 7 – Standalone Settings – Linux
 | **Build for Linux x64**         | Build a standalone for 64-bit Linux                                                                                                                                                                                                                          |
 | **Include**                     | Select built-in LiveCode dialogs to include. These dialogs are useful if your application may be run on a system that does not include these dialogs as part of the OS. You do not need to include these dialogs if you are running a recent version of GTK. |
 
-#### iOS Deployment
+## iOS Deployment
 
 ![](images/standalone-settings-ios-basic.png)
 
@@ -363,7 +363,7 @@ Related lessons:
 * [How do I Become an iOS Developer?](http://lessons.livecode.com/m/4069/l/565715-how-do-i-become-an-ios-developer)
 * [How do I build an iOS application?](http://lessons.livecode.com/m/4069/l/565713-how-do-i-build-an-ios-application)
 
-#### Android Deployment
+## Android Deployment
 
 ![](images/standalone-settings-android.png)
 


### PR DESCRIPTION
…
-Forgot to change the HTML5 heading to ## in the previous pull request. Made it in this one.-

Proposed changes to the heading structure to make sections easier to find

On LiveCode.com it's not been straight forward to find the iOS deployment guide or the Android deployment guide etc. All the information is in here but because we are using #### instead of ## for the settings sections they are not displaying in the right-hand menu on https://livecode.com/docs/9-5-0/deployment/deploying-your-application/

I am proposing changing some important section headers from #### to ## to make them easier to discover.