### PR TITLE
[Bug 22440] Fix card indentation in PB if stack name contains "of"

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -1476,7 +1476,7 @@ function levelConnectors pObjectArray, pParentRow, pPosition
          put "branch"  into tLevelConnectors[1] 
       end if
    else if pObjectArray["type"] is "card" then
-      if word 1 of pObjectArray["owner"] is "stack" AND pObjectArray["owner"] contains "of" then
+      if word 1 of pObjectArray["owner"] is "stack" AND pObjectArray["owner"] contains "of stack " & quote then
          put sDisplayArray["objects"][pParentRow]["levels"] into tParentLevelConnectors
          if pPosition is "only" then 
             if tParentLevelConnectors[1] is "branch" then  put "vertical" into tLevelConnectors[1]

--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -1476,7 +1476,7 @@ function levelConnectors pObjectArray, pParentRow, pPosition
          put "branch"  into tLevelConnectors[1] 
       end if
    else if pObjectArray["type"] is "card" then
-      if word 1 of pObjectArray["owner"] is "stack" AND pObjectArray["owner"] contains "of stack " & quote then
+      if word 1 of pObjectArray["owner"] is "stack" AND the owner of pObjectArray["owner"] is not empty then
          put sDisplayArray["objects"][pParentRow]["levels"] into tParentLevelConnectors
          if pPosition is "only" then 
             if tParentLevelConnectors[1] is "branch" then  put "vertical" into tLevelConnectors[1]

--- a/notes/bugfix-22440.md
+++ b/notes/bugfix-22440.md
@@ -1,0 +1,1 @@
+# Fix card indentation in PB if stack name contains "of"


### PR DESCRIPTION
PB checks for cards whether the owner of the card is a substack by testing for "stack" and "of" in owner name.
This fails if the stack name contains "of" and returns wrong indentation level.