### PR TITLE
treat all plugins as system stacks

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -6630,6 +6630,7 @@ on revIDEOpenPlugin pName
    else 
       do "go stack" && quote &  tStackPath & quote && "as" && tMode
    end if
+   set the _ideoverride of stack tStackPath to true
 end revIDEOpenPlugin
 
 function revIDELocalise pString, pSubstitutions


### PR DESCRIPTION
There are several (at least two) ways of identifying system stacks: the name starts with "rev" and the _ideoverride of the stack is true. This patch sets the _ideoverride of a plugin stack to true when the plugin is loaded. The property is set for the duration of the current session - it's not persistent unless the plugin is saved to disk.