### PR TITLE
default to no backdrop on new installation

### DIFF
--- a/Toolset/home.livecodescript
+++ b/Toolset/home.livecodescript
@@ -759,7 +759,8 @@ command revInternal__ResetPreferences
    put "22" into tPropsArray["cMenuHeight"]
    put "1067,251,1882,827" into tPropsArray["cRevDocsRect"]
    put "Gray88" into tPropsArray["cBackDropColor"]
-   put "Gray88" into tPropsArray["cBackdrop"]
+   # 2019-11-30 MDW [[ bugfix_22050 ]] make "off" be the backdrop default on new installation
+   put "none" into tPropsArray["cBackdrop"]
    put "false" into tPropsArray["cREVMsgShowUIFrontScripts"]
    put "false" into tPropsArray["revstack"]
    put "100" into tPropsArray["cMacOSProgressScrollbarWidth"]

--- a/notes/bugfix-22050.md
+++ b/notes/bugfix-22050.md
@@ -1,0 +1,2 @@
+# Default to backdrop off on new installation
+


### PR DESCRIPTION
I thought this was already done. Default to no backdrop since it interferes with some linux desktop managers.