### PR TITLE
[22477] Fix broken links in Resource Center

### DIFF
--- a/notes/bugfix-22477.md
+++ b/notes/bugfix-22477.md
@@ -1,0 +1,1 @@
+# Fix broken links in Resource Center


### PR DESCRIPTION
Binary changes:

In the script of stack "revResourceCenter", changed:

```
if pType is "stack" then
   put "http://revonline.runrev.com/resources/tutorials/" & tLeaf into tRemotePath
else
   put "http://revonline.runrev.com/resources/video/" & tLeaf into tRemotePath
end if
```

with
```
if pType is "stack" then
   put "http://livecodeshare.runrev.com/resources/tutorials/" & tLeaf into tRemotePath
else
   put "http://livecodeshare.runrev.com/resources/video/" & tLeaf into tRemotePath
end if
```