### PR TITLE
[Bug 19145] SE can cut chars from end handler struct

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -474,7 +474,13 @@ private function textFormatIndentLineRemoves pPreviousLine, pLine
       # OK-2009-02-16 : Bug 7707 - We can't assume the previous line was correctly formatted or script may be deleted.
       # Instead we simplify this by simply chopping off whatever indentation it did have.
       --return min(-(the number of chars of textFormatGetLineIndent(pPreviousLine)), item 1 of sTextFormatKeywordMap[tToken])
-      return item 1 of sTextFormatKeywordMap["end"]
+      --return item 1 of sTextFormatKeywordMap["end"]
+      
+      if token 1 of pPreviousLine is among the items of (handlerTypes() & ",private") then 
+         return item 1 of sTextFormatKeywordMap["end"]
+      else
+         return max(-(the number of chars of textFormatGetLineIndent(pPreviousLine)), item 1 of sTextFormatKeywordMap[tToken])
+      end if
    else
       # We can't assume that the previous line was correctly indented
       # because the script might have been edited from outside this script editor. Therefore

--- a/notes/bugfix-19145.md
+++ b/notes/bugfix-19145.md
@@ -1,0 +1,1 @@
+# fix cutting chars from "end handler" struct in certain circumstances  


### PR DESCRIPTION
If cursor is at end of "end handler" struct and indentation of previous non-empty line is less than indentation preference hitting return will cut off characters of "end handler" struct