### PR TITLE
show the full content line in the tooltip

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsetoolbarbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsetoolbarbehavior.livecodescript
@@ -264,6 +264,8 @@ private command debugControlsUpdate pMode
    end if
    
    set the cContexts of button "Debug Context" of me to tFilteredContexts
+# 2019-11-12 MDW [[ fix_debug_context_tooltip ]]
+   set the tooltip of button "Debug Context" to the label of button "Debug Context"
    unlock screen
 end debugControlsUpdate
 


### PR DESCRIPTION
There isn't enough space in the debug context pulldown menu to show the full text of the context. This patch changes the tooltip for the button from a generic "debug context" message to the actual context being displayed, so hovering over the button will display the entire text.