### PR TITLE
Sort behavior script list

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11696,7 +11696,7 @@ private function shouldShow pType, pFilter
 end shouldShow
 
 # 2019-12-12 MDW [[ sort_behavior_script_list ]] allow separately sorted lists
-function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter, pShouldSort
+function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter, pSortItem
    local tStack, tDefaultStack
    local tStacks,tCards,tControls,tStackList
    local tNumControls, tNumCards
@@ -11742,9 +11742,9 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter, pShouldSort
             put tab & l & "s" & cr & tControlsArray[l] & cr after tControlsList
          end repeat
       end if
-        if pShouldSort then
+        if pSortItem is not empty then
             sort tControlsList by word 1 of each
-            sort tControlsList by word 2 of each
+            sort tControlsList by word pSortItem of each
         end if
    end if
    
@@ -11762,10 +11762,10 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter, pShouldSort
       sort lines of tCards by item 2 of each
       
       put tab & "Card" & cr before tCards
-        if pShouldSort then
-            sort tCards by word 1 of each
-            sort tCards by word 2 of each
-        end if
+      if pSortItem is not empty then
+          sort tCards by word 1 of each
+          sort tCards by word pSortItem of each
+      end if
    end if
    set the defaultStack to tDefaultStack
    
@@ -11799,16 +11799,16 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter, pShouldSort
       sort lines of tStacks by item 2 of each
       if tStacks is empty then put "(" & tab & "Stack" into tStacks
       else put tab & "Stack" & cr before tStacks
-        if pShouldSort then
-            sort tStacks by word 1 of each
-            sort tStacks by word 2 of each
-        end if
+      if pSortItem is not empty then
+          sort tStacks by word 1 of each
+          sort tStacks by word pSortItem of each
+      end if
    end if
    
    local tMenu
-   if pShouldSort then
+   if pSortItem is not empty then
        sort tControls by item 1 of each
-       sort tControls by item 2 of each
+       sort tControls by item pSortItem of each
    end if
    if the number of lines in tControls > 20 then 
       replace cr with cr & tab & tab in tCards

--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -11695,7 +11695,8 @@ private function shouldShow pType, pFilter
    return pType is among the items of pFilter
 end shouldShow
 
-function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter
+# 2019-12-12 MDW [[ sort_behavior_script_list ]] allow separately sorted lists
+function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter, pShouldSort
    local tStack, tDefaultStack
    local tStacks,tCards,tControls,tStackList
    local tNumControls, tNumCards
@@ -11741,6 +11742,10 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter
             put tab & l & "s" & cr & tControlsArray[l] & cr after tControlsList
          end repeat
       end if
+        if pShouldSort then
+            sort tControlsList by word 1 of each
+            sort tControlsList by word 2 of each
+        end if
    end if
    
    if shouldShow("card", pTypeFilter) then
@@ -11757,6 +11762,10 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter
       sort lines of tCards by item 2 of each
       
       put tab & "Card" & cr before tCards
+        if pShouldSort then
+            sort tCards by word 1 of each
+            sort tCards by word 2 of each
+        end if
    end if
    set the defaultStack to tDefaultStack
    
@@ -11790,9 +11799,17 @@ function revIDEObjectSelectionMenu pTargetObjects, pTypeFilter
       sort lines of tStacks by item 2 of each
       if tStacks is empty then put "(" & tab & "Stack" into tStacks
       else put tab & "Stack" & cr before tStacks
+        if pShouldSort then
+            sort tStacks by word 1 of each
+            sort tStacks by word 2 of each
+        end if
    end if
    
    local tMenu
+   if pShouldSort then
+       sort tControls by item 1 of each
+       sort tControls by item 2 of each
+   end if
    if the number of lines in tControls > 20 then 
       replace cr with cr & tab & tab in tCards
       replace cr with cr & tab & tab in tStacks

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.script.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.script.behavior.livecodescript
@@ -131,7 +131,8 @@ on popupMenu
    
    put the cSelectedObjects of this stack into tObject
    
-   put "Select Behavior" & return & revIDEObjectSelectionMenu("", "button,stack") into tMenu
+   # 2019-12-12 MDW [[ sort_behavior_script_list ]] sort the targets alphabetically
+   put "Select Behavior" & return & revIDEObjectSelectionMenu("", "button,stack", true) into tMenu
    put return & "Create behavior from script only stack/|create behavior" after tMenu   
    put return & tab & "Create stack with empty script/|create empty behavior" & return after tMenu
    if word 1 to -1 of the script of tObject is empty then

--- a/Toolset/palettes/inspector/editors/com.livecode.pi.script.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.script.behavior.livecodescript
@@ -132,7 +132,7 @@ on popupMenu
    put the cSelectedObjects of this stack into tObject
    
    # 2019-12-12 MDW [[ sort_behavior_script_list ]] sort the targets alphabetically
-   put "Select Behavior" & return & revIDEObjectSelectionMenu("", "button,stack", true) into tMenu
+   put "Select Behavior" & return & revIDEObjectSelectionMenu("", "button,stack", 2) into tMenu
    put return & "Create behavior from script only stack/|create behavior" after tMenu   
    put return & tab & "Create stack with empty script/|create empty behavior" & return after tMenu
    if word 1 to -1 of the script of tObject is empty then


### PR DESCRIPTION
When assigning a behavior object in the property inspector, the list of objects is not alphabetically sorted, making it hard to select the proper object, especially when looking at a very long list of stacks. This patch sorts the lists alphabetically, and also allows for the flexibility to sort by a different item if the functions are needed in some other place.