### PR TITLE
removed extra lock messages command

### DIFF
--- a/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/Toolset/libraries/revidelibrary.8.livecodescript
@@ -9774,7 +9774,7 @@ command revIDERestoreDevelopmentTools
          
          # OK-2008-05-23 : If tMode is empty, it means that the stack's mode matched its style at the time of closing
          # and this means that no mode change is required.
-         lock messages
+         # 2019-12-23 MDW [[ fix_restore_dev_tools ]] removed extra lock messages command
          switch tMode
             case "toplevel"
                go stack tStackName as toplevel


### PR DESCRIPTION
Removed an extra lock messages command that was
a) already wrapped in a lock/unlock pair
b) not paired with a corresponding unlock messages command