### PR TITLE
[Bug 22555] Keep compile errors in SE w/o LiveError on

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -742,6 +742,15 @@ command scriptCompile pObject
          setCompilationErrors line 1 of tResult, pObject
          put "error" into tState
       end if
+   else
+      send "clearErrors" to group "Errors" of the owner of me
+      if tResult is empty then
+         setCompilationErrors empty, pObject
+      else
+         send "addError compilation, line 1 of tResult, pObject" to group "Errors" of the owner of me
+         setCompilationErrors line 1 of tResult, pObject
+         put "error" into tState
+      end if
    end if
    
    seSetObjectState pObject, tState

--- a/notes/bugfix-22555.md
+++ b/notes/bugfix-22555.md
@@ -1,0 +1,1 @@
+# Flag compile errors consistently when LiveError is turned off


### PR DESCRIPTION
If LiveError is off compile errors are not flagged if one clicks in field "script" or any other action in SE.
Bug 22555