### PR TITLE
fixes bug 16880 by setting the minHeight of the menubar

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -251,6 +251,8 @@ on setMenuProperties
    local tScreenRect
    put revIDEStackScreenRect(the short name of this stack, true) into tScreenRect
    
+   // 2020.02.29 mdw [[ bugfix_16880 ]]
+   set the minHeight of me to 19
    if the platform is not "MacOS" then
       if item 3 of the screenRect is 800 then
          set the topLeft of me to item 1 to 2 of tScreenRect

--- a/notes/bugfix-16880.md
+++ b/notes/bugfix-16880.md
@@ -1,0 +1,1 @@
+# set the minHeight of the menubar to prevent system hangs on linux


### PR DESCRIPTION
On linux disabling viewing both text and icons on the menubar will cause a loop short enough to hang not only LiveCode but the entire linux desktop. This is because the height of the menubar drops below the minimum specified height of 23, causing a recursive resize. The details are at https://quality.livecode.com/show_bug.cgi?id=16880#c9 . This patch sets the minimum height for the menubar to 19, which is below the menubar height with both text and icon views disabled.