### PR TITLE
[Bug 22636] Assure textFormatSelection preserves returns at end of text

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -677,6 +677,9 @@ private function textFormatSelection pText
    put pText into tTextLines
    split tTextLines by return
    
+   local tLastCharIsReturn
+   put (char -1 of pText is return) into tLastCharIsReturn
+   
    get textFormatLine(1, tTextLines, tPreviousLine)
    put firstWordToEnd(tTextLines[1]) into tTextLines[1]
    put tTextLines[1] into tResult
@@ -699,6 +702,10 @@ private function textFormatSelection pText
       
       put return & tTextLines[tIndex] after tResult
    end repeat
+   
+   if char -1 of tResult is not return and tLastCharIsReturn then
+      put return after tResult
+   end if
    
    if line -1 of pText = "" then put cr after tResult
    

--- a/notes/bugfix-22636.md
+++ b/notes/bugfix-22636.md
@@ -1,0 +1,1 @@
+# Assure textFormatSelection preserves returns at end of text


### PR DESCRIPTION
Keep textFormatSelection from removing a return If last char of a text is return