### PR TITLE
Adding new item to revMenuBarStandardContextMenu

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2182,9 +2182,23 @@ function revMenuBarStandardContextMenu pObject, pIndent, pSelectable
    put tIndent & "Property Inspector" & return after tText
    put tIndent & "-" & return after tText
    put tIndent & enableMenuItem("Cut", pSelectable) & return after tText
-   put tIndent & enableMenuItem("Copy", pSelectable) after tText
+   put tIndent & enableMenuItem("Copy", pSelectable) & return after tText
+   put tIndent & "-" & return after tText
+   put tIndent & buildArrangeSubmenu() after tText
    return tText
 end revMenuBarStandardContextMenu
+
+private function buildArrangeSubmenu
+   local tArrange
+   put "Arrange" & return after tArrange 
+   put tab & "Send to Back" & return after tArrange
+   put tab & "Move Backward" & return after tArrange
+   put tab & "Move Forward" & return after tArrange
+   put tab & "Bring to Front" after tArrange
+   return tArrange
+end buildArrangeSubmenu
+
+
 
 function revBuildContextSensitiveMenu pExtraText, pTarget, pType, pSelectable
    local tText
@@ -2549,7 +2563,7 @@ on revMenubarContextMenuPickTarget pWhich, pTarget
    
    set the itemdelimiter to "|"
    switch item 1 of pWhich
-      ######## OBJECTS #########
+            ######## OBJECTS #########
       case "Edit Script"
          revIDEEditScriptOfObjects pTarget
          break
@@ -2695,6 +2709,21 @@ on revMenubarContextMenuPickTarget pWhich, pTarget
          break
       case "Stack"
          revMenubarContextMenuPickTarget item 2 to 3 of pWhich, tTargetStack
+         break
+   end switch
+   ######## ARRANGESUBMENU #########
+   switch item 2 of pWhich
+      case "Send to Back"
+         revIDEActionSendToBack
+         break
+      case "Move Backward"
+         revIDEActionMoveBackward
+         break
+      case "Move forward"
+         revIDEActionMoveForward
+         break
+      case "Bring to Front"
+         revIDEActionBringToFront
          break
       default
          break


### PR DESCRIPTION
Every time I prototype a UI in LiveCode I always look for an arrange object layer menu item when I right-click. Mainly because this is present in other tools I use such as Adobe XD and Moqups. Looking for a coding challenge I decided to figure out how to do it myself. 

I have added the ability to Send to Back, Move Backward, Move Forward and Bring to front from an arrange menu item when you right-click on an object. I understand that you can code this or you can do it from the object menu item from the top menu bar, but I personally think this is a good place for those options to be, I always look for it here when I am prototyping something.

<img width="697" alt="Screenshot 2020-04-06 at 21 08 40" src="https://user-images.githubusercontent.com/14182262/78600403-d4b89100-784a-11ea-9ae5-26198fee0cd4.png">