### PR TITLE
[Bug 22211] Remove unnecessary 'unlock cursor' in ideMouseMove

### DIFF
--- a/Toolset/libraries/revbackscriptlibrary.livecodescript
+++ b/Toolset/libraries/revbackscriptlibrary.livecodescript
@@ -3284,7 +3284,12 @@ constant kHandleSize = 5
 on ideMouseMove pX, pY, pTarget
    if the tool is not "pointer tool" then exit ideMouseMove
    
-   if pTarget is among the lines of the selectedObjects then
+   local tOldCursor
+   if the lockcursor then
+      put the cursor into tOldCursor
+   end if
+   
+   if pTarget is among the lines of the selectedObjects and not (the lockLoc of pTarget)  then
       local tRect
       put the rect of pTarget into tRect
       local tLeft = false
@@ -3336,7 +3341,11 @@ on ideMouseMove pX, pY, pTarget
          unlock cursor
       end if
    else
-      unlock cursor
+      if tOldCursor is not empty and tOldCursor is not among the items of "83,84,31,30" then
+         set the cursor to tOldCursor
+      else
+         unlock cursor
+      end if
    end if
 end ideMouseMove
 

--- a/notes/bugfix-22211.md
+++ b/notes/bugfix-22211.md
@@ -1,0 +1,1 @@
+# Remove unnecessary 'unlock cursor' in ideMouseMove


### PR DESCRIPTION
This patch removes a seemingly unnecessary `unlock cursor` in the IDE's
mouseMove event handler (`ideMouseMove`).

The IDE intercepts mouseMove so that it can update the resize cursor
used when the mouse is over the relevant selection handlers. It does this
by locking the cursor in this case and then changing the cursor
appropriately; unlocking the cursor when there is a selected object and
the mouse is not over a selection handle.

Previously it would also unlock the cursor if pointer tool was in effect and
there was no selected object which (because the handler is executed in
time after any user handlers) would undo any user use of `lock cursor`.

This fixes bug 22211 and bug 18428 and avoids the problems of a fix for these in 
https://github.com/livecode/livecode-ide/pull/2092