### PR TITLE
[[ Bug 22285 ]] Restrict selection of key field in customprops editor

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -1,8 +1,9 @@
 ﻿script "com.livecode.pi.customprops.behavior"
-local sPropSet, sHilitePath
+local sPropSet, sHilitePath, sReselect
 
 on editorInitialize
    put empty into sPropSet
+   put false into sReselect
    put the editorLabel of me into field "rowlabel" of me
    set the rowShowLabel of me to false
    set the label of button "customPropertySet" of group "Set buttons" of me to "customKeys"
@@ -69,7 +70,10 @@ on editorUpdate
       if the result is empty then
          put tKey into field "value" of me
          put item -1 of tPath into field "key" of me
-         select the text of field "key" of me
+         if sReselect then
+            select the text of field "key" of me
+            put false into sReselect
+         end if
       else
          put empty into field "key" of me
          put empty into field "value" of me
@@ -371,6 +375,7 @@ function revValidSetName pWhich
 end revValidSetName
 
 on hiliteChanged
+   put true into sReselect
    checkRehilite
    editorUpdate
    put empty into sHilitePath

--- a/notes/bugfix-22285.md
+++ b/notes/bugfix-22285.md
@@ -1,0 +1,1 @@
+# Only reselect key field in customprops editor in response to a change in hilite


### PR DESCRIPTION
This patch ensures that the key field of the custom properties
editor in the property inspector is only selected in response to
a change in the tree view hilite.

This is essentially just a tweak of #2077 but using the fact that `hiliteChanged` only happens when the hilite really changes.