### PR TITLE
Bugfix 22798

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.customprops.behavior.livecodescript
@@ -1,8 +1,9 @@
 ﻿script "com.livecode.pi.customprops.behavior"
-local sPropSet, sHilitePath
+local sPropSet, sHilitePath, sReselect
 
 on editorInitialize
    put empty into sPropSet
+   put false into sReselect
    put the editorLabel of me into field "rowlabel" of me
    set the rowShowLabel of me to false
    set the label of button "customPropertySet" of group "Set buttons" of me to "customKeys"
@@ -69,7 +70,10 @@ on editorUpdate
       if the result is empty then
          put tKey into field "value" of me
          put item -1 of tPath into field "key" of me
-         select the text of field "key" of me
+         if sReselect then
+            select the text of field "key" of me
+            put false into sReselect
+         end if
       else
          put empty into field "key" of me
          put empty into field "value" of me
@@ -371,6 +375,7 @@ function revValidSetName pWhich
 end revValidSetName
 
 on hiliteChanged
+   put true into sReselect
    checkRehilite
    editorUpdate
    put empty into sHilitePath

--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -368,7 +368,7 @@ private command _CreateMobileScroller
       mobileControlSet sScrollerId, "canBounce", "true"
       mobileControlSet sScrollerId, "pagingEnabled", "false"
       mobileControlSet sScrollerId, "canScrollToTop", "true"
-      mobileControlSet sScrollerId, "delayTouches", "false"
+      mobileControlSet sScrollerId, "delayTouches", "true"
       mobileControlSet sScrollerId, "canCancelTouches", "true"
       __PollVisibility
    end if

--- a/notes/bugfix-22285.md
+++ b/notes/bugfix-22285.md
@@ -1,0 +1,1 @@
+# Only reselect key field in customprops editor in response to a change in hilite


### PR DESCRIPTION
mobile datagrid scrollers are initialized with
delayTouches = true
this will prevent a datagrid from scrolling because the moment the datagrid is touched, a row will be selected.