### PR TITLE
avoid an autocomplete endless loop

### DIFF
--- a/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2062,6 +2062,10 @@ function autoCompleteIFsAreBalanced pLineNumber, pScript
       put offset(tBeginAsterix, pScript) into tCharBegin
       if tCharBegin is 0 then exit repeat
       put offset(tEndAsterix, pScript) into tCharEnd
+      -- MDW 2020.07.10 [[ bugfix_22826 ]]
+      if tCharEnd is 0 then
+        exit repeat -- avoid an endless loop
+      end if
       delete char tCharBegin to tCharEnd of pScript
    end repeat
 


### PR DESCRIPTION
This patch fixes bug #22826, which caused an endless loop when I tried to insert a newline in a script.