### PR TITLE
Add support for new device sizes in new stack templates

### DIFF
--- a/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -1364,16 +1364,39 @@ private function revMenubarFileMenu pContext
       put true into tCanSaveStack
    end if
    
+   local sDeviceList
+   put  \
+         "Generic Android 6-inch Phone (412,775)" & return & \
+         "Generic Android 7-inch Phablet (600, 1024)" & return & \
+         "Generic Android 10-inch Tablet Portrait (720,1280)" & return & \
+         "Generic Android 10-inch Tablet Landscape 1280,720)" & return & \
+         "iPhone SE (320x568)" & return & \
+         "iPhone 6s//7//8 (375x667)" & return & \
+         "iPhone 6s+//7+//8+ (414x736)" & return & \
+         "iPhone X//XS//11 Pro (375x812)" & return & \
+         "iPhone XR//11 (414x896)" & return & \
+         "iPhone XS Max//11 Pro Max (414x896)" & return & \
+         "iPad 9.7-inch//Tablet Portrait (768x1024)" & return & \
+         "iPad 9.7-inch//Tablet Landscape (1024x768)" & return & \
+         "iPad 10.2-inch//Tablet Portrait (810x1080)" & return & \
+         "iPad 10.2-inch//Tablet Landscape (1080x810)" & return & \
+         "iPad 10.5-inch//Tablet Portrait (834x1112)" & return & \
+         "iPad 10.5-inch//Tablet Landscape (1112x834)" & return & \
+         "iPad 11-inch//Tablet Portrait (834x1194)" & return & \
+         "iPad 11-inch//Tablet Landscape (1194x834)" & return & \
+         "iPad 12.9-inch//Tablet Portrait (1024x1366)" & return & \
+         "iPad 12.9-inch//Tablet Landscape (1366x1024)" \
+         into sDeviceList
+   
    local tFile
    put "&New Stack" & return after tFile
    put tab & "Default Size" & return after tFile
    put tab & "-" & return after tFile
-   put tab & "iPhone 4 (320x480)" & return after tFile
-   put tab & "iPhone 5 (320x568)" & return after tFile
-   put tab & "iPhone 6 (375x667)" & return after tFile
-   put tab & "iPhone 6 Plus (414x736)" & return after tFile
-   put tab & "iPad//Tablet Portrait (768x1024)" & return after tFile
-   put tab & "iPad//Tablet Landscape (1024x768)" & return after tFile
+   
+   repeat for each line tDevice in sDeviceList
+      put tab & tDevice & return after tFile
+   end repeat
+   
    put tab & "-" & return after tFile
    put tab & "Script only Stack" & return after tFile
    

--- a/Toolset/palettes/start center/revStartCenterBehavior.livecodescript
+++ b/Toolset/palettes/start center/revStartCenterBehavior.livecodescript
@@ -341,21 +341,120 @@ function tilesArray pState
          put "lc-ipad-landscape" into tArray[4]["icon"]
          put "lc-ipad-landscape-filled" into tArray[4]["hoverIcon"]
          
-         put "iPhone 6" into tArray[5]["label"]
-         put "newIphone6" into tArray[5]["tag"]
+         put "Phone" into tArray[5]["label"]
+         put "newphone" into tArray[5]["tag"]
+         put "lc-iphone" into tArray[5]["icon"]
+         put "lc-iphone-filled" into tArray[5]["hoverIcon"]
+         break
+         
+      case "newPhone"
+         put "SE" into tArray[1]["label"]
+         put "newIphoneSE" into tArray[1]["tag"]
+         put "lc-iphone" into tArray[1]["icon"]
+         put "lc-iphone-filled" into tArray[1]["hoverIcon"]
+         
+         put "6s/7/8" into tArray[2]["label"]
+         put "newIphone6s78" into tArray[2]["tag"]
+         put "lc-iphone" into tArray[2]["icon"]
+         put "lc-iphone-filled" into tArray[2]["hoverIcon"]
+         
+         put "6s+/7+/8+" into tArray[3]["label"]
+         put "newIphone6sPlus7Plus8Plus" into tArray[3]["tag"]
+         put "lc-iphone" into tArray[3]["icon"]
+         put "lc-iphone-filled" into tArray[3]["hoverIcon"]
+         
+         put "X/XS/11 Pro" into tArray[4]["label"]
+         put "newIphoneXXS11Pro" into tArray[4]["tag"]
+         put "lc-iphone" into tArray[4]["icon"]
+         put "lc-iphone-filled" into tArray[4]["hoverIcon"]
+         
+         put "XR/11" into tArray[5]["label"]
+         put "newIphoneXR11" into tArray[5]["tag"]
          put "lc-iphone" into tArray[5]["icon"]
          put "lc-iphone-filled" into tArray[5]["hoverIcon"]
          
-         put "iPhone 5" into tArray[6]["label"]
-         put "newIphone5" into tArray[6]["tag"]
+         put "XS Max/11 Pro Max" into tArray[6]["label"]
+         put "newIphoneXSMax11ProMax" into tArray[6]["tag"]
          put "lc-iphone" into tArray[6]["icon"]
          put "lc-iphone-filled" into tArray[6]["hoverIcon"]
          
-         put "iPhone 4" into tArray[7]["label"]
-         put "newIphone4" into tArray[7]["tag"]
+         put "Android 6-inch generic" into tArray[7]["label"]
+         put "android6inchgeneric" into tArray[7]["tag"]
          put "lc-iphone" into tArray[7]["icon"]
          put "lc-iphone-filled" into tArray[7]["hoverIcon"]
          
+         break
+      case "newTabletPortrait"
+         put "9.7-inch" into tArray[1]["label"]
+         put "newTablet9.7portrait" into tArray[1]["tag"]
+         put "lc-ipad-portrait" into tArray[1]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[1]["hoverIcon"]
+         
+         put "10.2-inch" into tArray[2]["label"]
+         put "newTablet10.2portrait" into tArray[2]["tag"]
+         put "lc-ipad-portrait" into tArray[2]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[2]["hoverIcon"]
+         
+         put "10.5-inch" into tArray[3]["label"]
+         put "newTablet10.5portrait" into tArray[3]["tag"]
+         put "lc-ipad-portrait" into tArray[3]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[3]["hoverIcon"]
+         
+         put "11-inch" into tArray[4]["label"]
+         put "newTablet11portrait" into tArray[4]["tag"]
+         put "lc-ipad-portrait" into tArray[4]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[4]["hoverIcon"]
+         
+         put "12.9-inch" into tArray[5]["label"]
+         put "newTablet12.9portrait" into tArray[5]["tag"]
+         put "lc-ipad-portrait" into tArray[5]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[5]["hoverIcon"]
+         
+         put "10-inch" into tArray[6]["label"]
+         put "newTablet10portrait" into tArray[6]["tag"]
+         put "lc-ipad-portrait" into tArray[6]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[6]["hoverIcon"]
+         
+         put "7-inch" into tArray[7]["label"]
+         put "newTablet7portrait" into tArray[7]["tag"]
+         put "lc-ipad-portrait" into tArray[7]["icon"]
+         put "lc-ipad-portrait-filled" into tArray[7]["hoverIcon"]
+         break
+      case "newTabletLandscape"
+         put "9.7-inch" into tArray[1]["label"]
+         put "newTablet9.7landscape" into tArray[1]["tag"]
+         put "lc-ipad-landscape" into tArray[1]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[1]["hoverIcon"]
+         
+         put "10.2-inch" into tArray[2]["label"]
+         put "newTablet10.2landscape" into tArray[2]["tag"]
+         put "lc-ipad-landscape" into tArray[2]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[2]["hoverIcon"]
+         
+         put "10.5-inch" into tArray[3]["label"]
+         put "newTablet10.5landscape" into tArray[3]["tag"]
+         put "lc-ipad-landscape" into tArray[3]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[3]["hoverIcon"]
+         
+         put "11-inch" into tArray[4]["label"]
+         put "newTablet11landscape" into tArray[4]["tag"]
+         put "lc-ipad-landscape" into tArray[4]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[4]["hoverIcon"]
+         
+         put "12.9-inch" into tArray[5]["label"]
+         put "newTablet12.9landscape" into tArray[5]["tag"]
+         put "lc-ipad-landscape" into tArray[5]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[5]["hoverIcon"]
+         
+         put "10-inch" into tArray[6]["label"]
+         put "newTablet10landscape" into tArray[6]["tag"]
+         put "lc-ipad-landscape" into tArray[6]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[6]["hoverIcon"]
+         
+         put "7-inch" into tArray[7]["label"]
+         put "newTablet7landscape" into tArray[7]["tag"]
+         put "lc-ipad-landscape" into tArray[7]["icon"]
+         put "lc-ipad-landscape-filled" into tArray[7]["hoverIcon"]
          break
    end switch
    return tArray
@@ -496,6 +595,20 @@ on startCenterAction pAction
          put tilesArray(pAction) into tArray
          tilesUpdate tArray
          break
+      case "newphone"
+         put "Home / New / Phone" into field "breadcrumb"
+         set the textStyle of word 1 of field "breadcrumb" to "link"
+         put tilesArray(pAction) into tArray
+         tilesUpdate tArray
+         break
+      case "newTabletPortrait"
+      case "newTabletLandscape"
+         put "Home / New / Tablet" into field "breadcrumb"
+         set the textStyle of word 1 of field "breadcrumb" to "link"
+         put tilesArray(pAction) into tArray
+         tilesUpdate tArray
+         break
+         
       case "samples"
          revIDELaunchResource "sample stacks"
          break
@@ -550,20 +663,68 @@ on startCenterAction pAction
       case "newScriptOnlyStack"
          revIDEActionNewScriptOnlyStack
          break
-      case "newTabletPortrait"
+      case "newIphoneSE"
+         revIDEActionNewMainstack "iPhone SE (320x568)"
+         break
+      case "newIphone6s78"
+         revIDEActionNewMainstack "iPhone 6s/7/8 (375x667)"
+         break
+      case "newIphone6sPlus7Plus8Plus"
+         revIDEActionNewMainstack "iPhone 6s+/7+/8+ (414x736)"
+         break
+      case "newIphoneXXS11Pro"
+         revIDEActionNewMainstack "iPhone X/XS/11 Pro (375x812)"
+         break
+      case "newIphoneXR11"
+         revIDEActionNewMainstack "iPhone XR/11 (414x896)"
+         break
+      case "newIphoneXSMax11ProMax"
+         revIDEActionNewMainstack "iPhone XS Max / 11 Pro Max (414x896)"
+         break
+      case "android6inchgeneric"
+         revIDEActionNewMainstack "Generic Android 6-inch Phone (412,775)"
+         break
+      case "newTablet9.7portrait"
          revIDEActionNewMainstack "iPad/Tablet Portrait (768x1024)"
          break
-      case "newTabletLandscape"
-         revIDEActionNewMainstack "iPad/Tablet Lanscape (1024x768)"
+      case "newTablet10.2portrait"
+         revIDEActionNewMainstack "iPad/Tablet Portrait (810x1080)"
          break
-      case "newIphone6"
-         revIDEActionNewMainstack "iPhone 6 (375x667)"
+      case "newTablet10.5portrait"
+         revIDEActionNewMainstack "iPad/Tablet Portrait (834x1112)"
          break
-      case "newIphone5"
-         revIDEActionNewMainstack "iPhone 5 (320x568)"
+      case "newTablet11portrait"
+         revIDEActionNewMainstack "iPad/Tablet Portrait (834x1194)"
          break
-      case "newIphone4"
-         revIDEActionNewMainstack "iPhone 4 (320x480)"
+      case "newTablet12.9portrait"
+         revIDEActionNewMainstack "iPad 12.9-inch/Tablet Portrait (1024x1366)"
+         break
+      case "newTablet10portrait"
+         revIDEActionNewMainstack "Generic Android 10-inch Tablet Portrait (720x1280)"
+         break
+      case "newTablet7portrait"
+         revIDEActionNewMainstack "Generic Android 7-inch Tablet Portrait (600x1024)"
+         break
+      case "newTablet9.7landscape"
+         revIDEActionNewMainstack "iPad/Tablet Landscape (1024x768)"
+         break
+      case "newTablet10.2landscape"
+         revIDEActionNewMainstack "iPad/Tablet Landscape (1080x810)"
+         break
+      case "newTablet10.5landscape"
+         revIDEActionNewMainstack "iPad/Tablet Landscape (1112x834)"
+         break
+      case "newTablet11landscape"
+         revIDEActionNewMainstack "iPad/Tablet Landscape (1194x834)"
+         break
+      case "newTablet12.9landscape"
+         revIDEActionNewMainstack "iPad 12.9-inch/Tablet Landscape (1366x1024)"
+         break
+      case "newTablet10landscape"
+         revIDEActionNewMainstack "Generic Android 10-inch Tablet Landscape (1280x720)"
+         break
+      case "newTablet7landscape"
+         revIDEActionNewMainstack "Generic Android 7-inch Tablet Landscape (1024x600)"
          break
    end switch
 end startCenterAction


### PR DESCRIPTION
This patch adds support for new device sizes in new stack templates, both in the 'New File' menu and the in the start center.

<img width="814" alt="Screenshot 2020-07-14 at 21 33 14" src="https://user-images.githubusercontent.com/5111835/87463492-27f46980-c61a-11ea-9a45-37c7d10f849d.png">


Start Center:

<img width="912" alt="Screenshot 2020-07-13 at 16 54 48" src="https://user-images.githubusercontent.com/5111835/87313024-061bb980-c52a-11ea-85cb-ed76f6b3d2d1.png">

After pressing "New" in Start Center:

<img width="912" alt="Screenshot 2020-07-14 at 21 42 49" src="https://user-images.githubusercontent.com/5111835/87464088-342cf680-c61b-11ea-8d93-520eb223f956.png">


After pressing "Tablet Portrait":

<img width="912" alt="Screenshot 2020-07-14 at 21 43 00" src="https://user-images.githubusercontent.com/5111835/87464110-3f802200-c61b-11ea-804c-9ab1db231b78.png">


After pressing "Tablet Landscape":

<img width="912" alt="Screenshot 2020-07-14 at 21 44 02" src="https://user-images.githubusercontent.com/5111835/87464133-4a3ab700-c61b-11ea-9aa2-e427309dff3e.png">

After pressing "Phone":

<img width="912" alt="Screenshot 2020-07-14 at 21 33 43" src="https://user-images.githubusercontent.com/5111835/87463521-33479500-c61a-11ea-81ed-d59f91fa45c1.png">



