### PR TITLE
failsafe for revdebuggerlibrary __ResolveId

### DIFF
--- a/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -1948,6 +1948,8 @@ end __ActivateBreakpoints
 #   being resolved is in the stack script.
 private function __ResolveId pId, pStack
    local tID
+# [[2020.08.31 MDW fix_resolveID_crash_in_debugger]]
+    try
    if pId is 0 then
       put the long id of pStack into tID
    else
@@ -1958,6 +1960,8 @@ private function __ResolveId pId, pStack
          put the long id of control id pId of pStack into tID
       end if
    end if
+    catch e
+    end try
    return tID
 end __ResolveId
 


### PR DESCRIPTION
__ResolveId barfs if it finds a relic watchedvariables entry that has a no-longer-existent object reference.
This can have disastrous consequences, the least of which would be a non-firing preOpenStack handler.
The patch puts __ResolveId in revdebuggerlibrary in a try-catch clause so that processing can continue.

Reference:
https://forums.livecode.com/viewtopic.php?f=77&t=34574&sid=4d298f59e29b82c43dddc7e894564ec3