### PR TITLE
[[ Bug 22903 ]] Send RowLeftSwipeControlClicked with target param

### DIFF
--- a/Toolset/palettes/revdatagridlibrary/bahaviorsswipecontrolholderbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/bahaviorsswipecontrolholderbehavior.livecodescript
@@ -198,10 +198,10 @@ on mouseUp
    if the long id of the target contains the long id of sSwipeControl then
       switch sSwipeControlSide
          case "left"
-            dispatch DG2_GetMessageNameForTag("RowLeftSwipeControlClicked") to tRowControl
+            dispatch DG2_GetMessageNameForTag("RowLeftSwipeControlClicked") to tRowControl with the target
             break
          case "right"
-            dispatch DG2_GetMessageNameForTag("RowRightSwipeControlClicked") to tRowControl
+            dispatch DG2_GetMessageNameForTag("RowRightSwipeControlClicked") to tRowControl with the target
             break
       end switch
    else

--- a/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
+++ b/Toolset/palettes/revdatagridlibrary/behaviorsdatagridbuttonbehavior.livecodescript
@@ -9987,11 +9987,11 @@ end EditModeHideActionControl
 -- These messages are handled at this point of the message path to allow
 -- users to potentially handle them at group level.
 
-on RowLeftSwipeControlClicked
+on RowLeftSwipeControlClicked pTarget
    DeleteIndex the dgIndex of the target
 end RowLeftSwipeControlClicked
 
-on RowRightSwipeControlClicked
+on RowRightSwipeControlClicked pTarget
    DeleteIndex the dgIndex of the target
 end RowRightSwipeControlClicked
 

--- a/notes/bugfix-22903.md
+++ b/notes/bugfix-22903.md
@@ -1,0 +1,1 @@
+# Ensure RowLeftSwipeControlClicked message is sent with a target parameter


### PR DESCRIPTION
This patch ensures that both `RowLeftSwipeControlClicked` and `RowRightSwipeControlClicked` messages are sent with a target parameter, as mentioned in the dictionary.

Closes https://quality.livecode.com/show_bug.cgi?id=22903