### PR TITLE
[[ Bug 15638 ]] Remove cantModify from basic stack properties

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Stack.tsv
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.Stack.tsv
@@ -19,7 +19,6 @@ startupIconic							false
 destroyStack							false					
 destroyWindow							false					
 cantDelete							false					
-cantModify							false					
 cantAbort							false					
 stackFiles												
 externals												

--- a/notes/bugfix-15638.md
+++ b/notes/bugfix-15638.md
@@ -1,0 +1,1 @@
+# Remove `cantModify` from stack basic properties palette


### PR DESCRIPTION
This patch removes the cantModify checkbox from the basic stack properties
palette as it is too easy for a user to check the box and be unable to recover.