### PR TITLE
[[ Bug 22847 ]] Improve display of enum values in dictionary

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -1263,7 +1263,7 @@
 					   tHTML += '<li><span class="lcdoc_parameterValue">';
 					   tHTML += value.value + '</span>';
 					   if (nonEmptyElement(value, "description"))
-						   tHTML += ' -' + value.description;
+						   tHTML += ' -  ' + value.description;
 					   tHTML += '</li>';
 				   });
 				   tHTML += "</ul>";

--- a/notes/bugfix-22847.md
+++ b/notes/bugfix-22847.md
@@ -1,0 +1,1 @@
+# Improve display of enum values in dictionary


### PR DESCRIPTION
This patch improves the display of enum values in the dictionary by adding
an additional space after the `-` separating name and description.