### PR TITLE
[[ Bug 22300 ]] Ensure right-clicking on the PB selects the correct row

### DIFF
--- a/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
+++ b/Toolset/palettes/project browser/revprojectbrowserbehavior.livecodescript
@@ -1065,6 +1065,7 @@ end getAbsoluteRow
 function getVisibleRow pLongID
    local tRow
    put getRow(pLongID) into tRow
+   set the wholeMatches to true
    return itemOffset(tRow, sDisplayArray["visible object keys"])
 end getVisibleRow
 

--- a/notes/bugfix-22300.md
+++ b/notes/bugfix-22300.md
@@ -1,0 +1,1 @@
+# Ensure right-clicking on the Project Browser object list selects the correct row


### PR DESCRIPTION
This patch fixes an issue where under some circumstances an incorrect object row was selected when right-clicking on the Project Browser. This happened because `itemOffset` was called without `wholeMatches=true`, returning an incorrect value, e.g. `itemOffset("1","5,3,2,13,6,1")` returned `4` instead of `6`, thus an incorrect row was selected.