### PR TITLE
[[ Bug 23221 ]] Show names in SVG Icon Picker in Properties Inspector

### DIFF
--- a/Toolset/palettes/inspector/editors/com.livecode.pi.svgiconfilter.behavior.livecodescript
+++ b/Toolset/palettes/inspector/editors/com.livecode.pi.svgiconfilter.behavior.livecodescript
@@ -3,7 +3,8 @@ on preOpenStack
    set the text of field "FilterText" to "Search"
    set the filterString of widget "iconList" of me to empty
    set the showSelectedElement of widget "iconList" of me to false
-   set the iconSize of widget "iconList" of me to 45
+   set the iconSize of widget "iconList" of me to 55
+   set the showNames of widget "iconList" of me to true
    set the selectedIcon of widget "iconList" of me to the dialogData
    
    set the behavior of me to the long id of stack "com.livecode.pi.svgiconfilter.behavior"

--- a/notes/bugfix-23221.md
+++ b/notes/bugfix-23221.md
@@ -1,0 +1,1 @@
+# Enable show names in svgIconPicker when used in Properties Inspector


### PR DESCRIPTION
Additionally Icon size is increased to 55 which results in 4 icons in a row.
Previously at size 45 there were 5 iconds in a row but text is well readable at that size